### PR TITLE
feat(app): add provider and model selection workflow

### DIFF
--- a/configs/model_profiles_test.go
+++ b/configs/model_profiles_test.go
@@ -27,7 +27,7 @@ func TestLoadWithEnv_AutoTokenLimitsByModelSeries(t *testing.T) {
 		{name: "claude-4.6-sonnet", model: "claude-sonnet-4.6", wantWindow: 1000000},
 		{name: "claude-4.5-haiku", model: "claude-haiku-4.5", wantWindow: 200000},
 		{name: "kimi-k2", model: "kimi-k2", wantWindow: 128000},
-		{name: "namespaced-kimi-k2.5", model: "moonshotai/kimi-k2.5", wantWindow: 256000},
+		{name: "namespaced-kimi-k2.5", model: "provider/kimi-k2.5", wantWindow: 256000},
 		{name: "deepseek-reasoner", model: "deepseek-reasoner", wantWindow: 128000},
 		{name: "qwen3", model: "qwen3-max", wantWindow: 262144},
 		{name: "qwen3.5", model: "qwen3.5-plus", wantWindow: 1000000},

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -77,6 +77,35 @@ runTask:
 No orchestrator, no planner, no adapter layer. The app calls the engine
 directly. The LLM plans inline within the agent loop.
 
+### Provider And Model Selection
+
+`mscli` now separates provider connection from model selection:
+
+```text
+/connect
+  -> merged provider catalog:
+       builtin MindSpore CLI Free
+       + models.dev cache/remote catalog
+       + ~/.mscli/config.json extra_providers
+  -> persist connected provider auth in ~/.mscli/auth.json
+
+/model
+  -> load usable providers:
+       MindSpore CLI Free when logged in
+       + providers connected in ~/.mscli/auth.json
+  -> persist active/recent/favorite model refs in ~/.mscli/model.json
+  -> translate logical provider selection into current configs.ModelConfig
+  -> Application.SetProvider(...)
+```
+
+Local state files:
+
+- `~/.mscli/credentials.json`: MindSpore CLI login only
+- `~/.mscli/auth.json`: connected provider auth only
+- `~/.mscli/model.json`: active/recent/favorite model refs
+- `~/.mscli/cached/models-dev-api.json`: models.dev cache fallback
+- `~/.mscli/config.json`: deprecated model compatibility plus `extra_providers`
+
 ### Skill activation
 
 Skills are embedded in the binary at build time from the `mindspore-skills` repo.

--- a/internal/app/appconfig.go
+++ b/internal/app/appconfig.go
@@ -4,21 +4,37 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
 	modelModeMSCLIProvided = "mscli-provided"
-	modelModeOwn            = "own"
-	modelModeOwnEnv         = "own-env"
-	modelSetupToken         = "__model_setup"
+	modelModeOwn           = "own"
+	modelModeOwnEnv        = "own-env"
+	modelSetupToken        = "__model_setup"
+	connectProviderToken   = "__connect_provider__"
 )
 
 // appConfig holds persistent local settings stored in ~/.mscli/config.json.
 // Separate from credentials.json (issue server auth) and configs/ (YAML + env).
 type appConfig struct {
-	ModelMode     string `json:"model_mode,omitempty"`      // "mscli-provided" or "own" or ""
-	ModelPresetID string `json:"model_preset_id,omitempty"` // e.g. "kimi-k2.5-free"
-	ModelToken    string `json:"model_token,omitempty"`     // API token for mscli-provided models
+	ModelMode      string                `json:"model_mode,omitempty"`      // "mscli-provided" or "own" or ""
+	ModelPresetID  string                `json:"model_preset_id,omitempty"` // e.g. "kimi-k2.5-free"
+	ModelToken     string                `json:"model_token,omitempty"`     // API token for mscli-provided models
+	ExtraProviders []extraProviderConfig `json:"extra_providers,omitempty"`
+}
+
+type extraProviderConfig struct {
+	ID       string                     `json:"id"`
+	Label    string                     `json:"label,omitempty"`
+	BaseURL  string                     `json:"base_url"`
+	Protocol string                     `json:"protocol"`
+	Models   []extraProviderModelConfig `json:"models,omitempty"`
+}
+
+type extraProviderModelConfig struct {
+	ID    string `json:"id"`
+	Label string `json:"label,omitempty"`
 }
 
 // appConfigPathOverride allows tests to redirect the config path.
@@ -44,11 +60,13 @@ func loadAppConfig() (*appConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	cfg.normalize()
 	return &cfg, nil
 }
 
 func saveAppConfig(cfg *appConfig) error {
 	path := appConfigPath()
+	cfg.normalize()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
@@ -57,4 +75,38 @@ func saveAppConfig(cfg *appConfig) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+func (c *appConfig) normalize() {
+	if c == nil {
+		return
+	}
+	if len(c.ExtraProviders) == 0 {
+		c.ExtraProviders = nil
+		return
+	}
+
+	out := make([]extraProviderConfig, 0, len(c.ExtraProviders))
+	for _, provider := range c.ExtraProviders {
+		provider.ID = strings.TrimSpace(provider.ID)
+		provider.Label = strings.TrimSpace(provider.Label)
+		provider.BaseURL = strings.TrimSpace(provider.BaseURL)
+		provider.Protocol = strings.TrimSpace(provider.Protocol)
+		if provider.ID == "" {
+			continue
+		}
+
+		models := make([]extraProviderModelConfig, 0, len(provider.Models))
+		for _, model := range provider.Models {
+			model.ID = strings.TrimSpace(model.ID)
+			model.Label = strings.TrimSpace(model.Label)
+			if model.ID == "" {
+				continue
+			}
+			models = append(models, model)
+		}
+		provider.Models = models
+		out = append(out, provider)
+	}
+	c.ExtraProviders = out
 }

--- a/internal/app/appconfig_test.go
+++ b/internal/app/appconfig_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -49,5 +51,88 @@ func TestLoadAppConfigMissing(t *testing.T) {
 	}
 	if cfg.ModelMode != "" {
 		t.Errorf("expected empty ModelMode, got %q", cfg.ModelMode)
+	}
+}
+
+func TestAppConfigRoundTripPreservesExtraProviders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	origPath := appConfigPathOverride
+	appConfigPathOverride = path
+	t.Cleanup(func() { appConfigPathOverride = origPath })
+
+	cfg := &appConfig{
+		ModelMode:     "mscli-provided",
+		ModelPresetID: "kimi-k2.5-free",
+		ModelToken:    "deprecated-token",
+		ExtraProviders: []extraProviderConfig{
+			{
+				ID:       "openrouter",
+				Label:    "OpenRouter",
+				BaseURL:  "https://openrouter.ai/api/v1",
+				Protocol: "openai-chat",
+				Models: []extraProviderModelConfig{
+					{ID: "openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+			},
+		},
+	}
+	if err := saveAppConfig(cfg); err != nil {
+		t.Fatalf("saveAppConfig: %v", err)
+	}
+
+	loaded, err := loadAppConfig()
+	if err != nil {
+		t.Fatalf("loadAppConfig: %v", err)
+	}
+	if got, want := len(loaded.ExtraProviders), 1; got != want {
+		t.Fatalf("len(loaded.ExtraProviders) = %d, want %d", got, want)
+	}
+	if got, want := loaded.ExtraProviders[0].ID, "openrouter"; got != want {
+		t.Fatalf("loaded.ExtraProviders[0].ID = %q, want %q", got, want)
+	}
+	if got, want := loaded.ExtraProviders[0].Models[0].ID, "openai/gpt-4o-mini"; got != want {
+		t.Fatalf("loaded.ExtraProviders[0].Models[0].ID = %q, want %q", got, want)
+	}
+	if got, want := loaded.ModelToken, "deprecated-token"; got != want {
+		t.Fatalf("loaded.ModelToken = %q, want %q", got, want)
+	}
+}
+
+func TestLoadAppConfigExtraProvidersLabelOptional(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	origPath := appConfigPathOverride
+	appConfigPathOverride = path
+	t.Cleanup(func() { appConfigPathOverride = origPath })
+
+	data, err := json.MarshalIndent(map[string]any{
+		"extra_providers": []map[string]any{
+			{
+				"id":       "my-gateway",
+				"base_url": "https://llm.example.com/v1",
+				"protocol": "openai-chat",
+			},
+		},
+	}, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := loadAppConfig()
+	if err != nil {
+		t.Fatalf("loadAppConfig() error = %v", err)
+	}
+	if got, want := len(loaded.ExtraProviders), 1; got != want {
+		t.Fatalf("len(loaded.ExtraProviders) = %d, want %d", got, want)
+	}
+	if got, want := loaded.ExtraProviders[0].ID, "my-gateway"; got != want {
+		t.Fatalf("loaded.ExtraProviders[0].ID = %q, want %q", got, want)
+	}
+	if got := loaded.ExtraProviders[0].Label; got != "" {
+		t.Fatalf("loaded.ExtraProviders[0].Label = %q, want empty", got)
 	}
 }

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -117,6 +117,16 @@ func (a *Application) cmdLogin(args []string) {
 	a.issueRole = me.Role
 
 	a.EventCh <- model.Event{Type: model.IssueUserUpdate, Message: me.User}
+	if !a.llmReady {
+		if result, err := a.activateLogicalModelSelection(mindsporeCLIFreeProviderID, "kimi-k2.5"); err == nil {
+			a.EventCh <- model.Event{
+				Type:     model.ModelUpdate,
+				Message:  a.Config.Model.Model,
+				Provider: result.ProviderLabel,
+				CtxMax:   a.Config.Context.Window,
+			}
+		}
+	}
 	a.EventCh <- model.Event{
 		Type:    model.AgentReply,
 		Message: fmt.Sprintf("logged in as %s (%s)", me.User, me.Role),

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -26,6 +26,8 @@ func (a *Application) handleCommand(input string) {
 	args := strings.Fields(cmd.Remainder)
 
 	switch cmd.Name {
+	case "/connect":
+		a.cmdConnect(args)
 	case "/model":
 		a.cmdModel(args)
 	case "/exit":
@@ -170,34 +172,82 @@ func (a *Application) handleSkillAliasCommand(commandName, rawRemainder string) 
 
 func (a *Application) cmdModel(args []string) {
 	if len(args) == 0 {
-		a.emitModelSetupPopup(true)
+		a.emitModelPicker()
 		return
 	}
 
 	modelArg := strings.TrimSpace(strings.Join(args, " "))
+	if strings.Contains(modelArg, ":") {
+		parts := strings.SplitN(modelArg, ":", 2)
+		providerName := llm.NormalizeProvider(parts[0])
+		modelName := strings.TrimSpace(parts[1])
+		if llm.IsSupportedProvider(providerName) {
+			a.restoreModelConfigFromPreset()
+			a.switchModel(providerName, modelName)
+			return
+		}
+		if result, err := a.activateLogicalModelSelection(parts[0], parts[1]); err == nil {
+			a.EventCh <- model.Event{
+				Type:     model.ModelUpdate,
+				Message:  a.Config.Model.Model,
+				Provider: result.ProviderLabel,
+				CtxMax:   a.Config.Context.Window,
+			}
+			a.EventCh <- model.Event{
+				Type:    model.AgentReply,
+				Message: fmt.Sprintf("Model switched to: %s", a.Config.Model.Model),
+			}
+			return
+		} else {
+			if strings.Contains(err.Error(), fmt.Sprintf("unknown provider %q", strings.TrimSpace(parts[0]))) {
+				a.EventCh <- model.Event{
+					Type:    model.AgentReply,
+					Message: fmt.Sprintf("Unsupported provider prefix: %s (supported: openai-completion, openai-responses, anthropic)", providerName),
+				}
+				return
+			}
+			a.EventCh <- model.Event{
+				Type:    model.AgentReply,
+				Message: fmt.Sprintf("Failed to switch model: %v", err),
+			}
+			return
+		}
+	}
+
 	if preset, ok := resolveBuiltinModelPreset(modelArg); ok {
 		a.switchToBuiltinModelPreset(preset)
 		return
 	}
 
 	a.restoreModelConfigFromPreset()
-	modelArg = args[0]
-	if strings.Contains(modelArg, ":") {
-		parts := strings.SplitN(modelArg, ":", 2)
-		providerName := llm.NormalizeProvider(parts[0])
-		modelName := strings.TrimSpace(parts[1])
-		if !llm.IsSupportedProvider(providerName) {
-			a.EventCh <- model.Event{
-				Type:    model.AgentReply,
-				Message: fmt.Sprintf("Unsupported provider prefix: %s (supported: openai-completion, openai-responses, anthropic)", providerName),
-			}
-			return
-		}
-		a.switchModel(providerName, modelName)
+	a.switchModel("", modelArg)
+}
+
+func (a *Application) cmdConnect(args []string) {
+	if len(args) == 0 {
+		a.emitConnectPopup(true)
 		return
 	}
 
-	a.switchModel("", modelArg)
+	providerID := strings.TrimSpace(args[0])
+	apiKey := ""
+	if len(args) > 1 {
+		apiKey = strings.TrimSpace(strings.Join(args[1:], " "))
+	}
+
+	a.EventCh <- model.Event{Type: model.AgentThinking}
+	if err := a.connectProvider(providerID, apiKey); err != nil {
+		a.EventCh <- model.Event{
+			Type:     model.ToolError,
+			ToolName: "connect",
+			Message:  fmt.Sprintf("Failed to connect provider: %v", err),
+		}
+		return
+	}
+	a.EventCh <- model.Event{
+		Type:    model.AgentReply,
+		Message: fmt.Sprintf("Provider connected: %s", providerID),
+	}
 }
 
 // applyPreset applies a preset with the given API key. It saves the current
@@ -243,9 +293,10 @@ func (a *Application) switchToBuiltinModelPreset(preset builtinModelPreset) {
 	}
 
 	a.EventCh <- model.Event{
-		Type:    model.ModelUpdate,
-		Message: a.Config.Model.Model,
-		CtxMax:  a.Config.Context.Window,
+		Type:     model.ModelUpdate,
+		Message:  a.Config.Model.Model,
+		Provider: runtimeProviderDisplayLabel(a.Config.Model.Provider),
+		CtxMax:   a.Config.Context.Window,
 	}
 
 	a.EventCh <- model.Event{
@@ -277,9 +328,10 @@ func (a *Application) switchModel(providerName, modelName string) {
 	}
 
 	a.EventCh <- model.Event{
-		Type:    model.ModelUpdate,
-		Message: a.Config.Model.Model,
-		CtxMax:  a.Config.Context.Window,
+		Type:     model.ModelUpdate,
+		Message:  a.Config.Model.Model,
+		Provider: runtimeProviderDisplayLabel(a.Config.Model.Provider),
+		CtxMax:   a.Config.Context.Window,
 	}
 
 	a.EventCh <- model.Event{
@@ -386,9 +438,10 @@ func (a *Application) cmdModelSetup(args []string) {
 	// Step 6: Emit UI updates.
 	a.EventCh <- model.Event{Type: model.IssueUserUpdate, Message: userName}
 	a.EventCh <- model.Event{
-		Type:    model.ModelUpdate,
-		Message: a.Config.Model.Model,
-		CtxMax:  a.Config.Context.Window,
+		Type:     model.ModelUpdate,
+		Message:  a.Config.Model.Model,
+		Provider: runtimeProviderDisplayLabel(a.Config.Model.Provider),
+		CtxMax:   a.Config.Context.Window,
 	}
 	a.EventCh <- model.Event{Type: model.ModelSetupClose}
 	a.EventCh <- model.Event{
@@ -880,4 +933,3 @@ func defaultSkillRequest(skillName string) string {
 		skillName,
 	)
 }
-

--- a/internal/app/commands_model_test.go
+++ b/internal/app/commands_model_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -85,20 +86,29 @@ func TestCmdModel_InvalidPrefixNoMutation(t *testing.T) {
 	}
 }
 
-func TestCmdModel_NoArgsShowsSetupPopup(t *testing.T) {
+func TestCmdModel_NoArgsShowsModelPicker(t *testing.T) {
 	app := newModelCommandTestApp()
+	t.Setenv("HOME", t.TempDir())
+	if err := saveCredentials(&credentials{
+		ServerURL: "https://mscli.dev",
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
 
 	app.cmdModel(nil)
 
-	ev := drainUntilEventType(t, app, model.ModelSetupOpen)
-	if ev.SetupPopup == nil {
-		t.Fatal("ModelSetupOpen popup = nil, want SetupPopup")
+	ev := drainUntilEventType(t, app, model.ModelPickerOpen)
+	if ev.Popup == nil {
+		t.Fatal("ModelPickerOpen popup = nil, want SelectionPopup")
 	}
-	if !ev.SetupPopup.CanEscape {
-		t.Fatal("expected CanEscape=true from /model command")
+	if len(ev.Popup.Options) == 0 {
+		t.Fatal("expected model picker options")
 	}
-	if len(ev.SetupPopup.PresetOptions) == 0 || ev.SetupPopup.PresetOptions[0].ID != "kimi-k2.5-free" {
-		t.Fatalf("preset options = %#v, want kimi preset option", ev.SetupPopup.PresetOptions)
+	if got, want := ev.Popup.ActionID, "model_picker"; got != want {
+		t.Fatalf("popup.ActionID = %q, want %q", got, want)
 	}
 }
 
@@ -190,6 +200,389 @@ func TestCmdModel_BuiltinPresetUsesServerCredentialAndRestoresOnSwitchBack(t *te
 	}
 	if got, want := app.Config.Model.Model, "gpt-4o"; got != want {
 		t.Fatalf("model after switch = %q, want %q", got, want)
+	}
+}
+
+func TestCmdModel_LogicalProviderSelectionWorksWithoutCache(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	if err := saveProviderAuthState(&providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+		},
+	}); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
+	}
+
+	app.cmdModel([]string{"openrouter:openai/gpt-4o-mini"})
+
+	drainUntilEventType(t, app, model.ModelUpdate)
+	drainUntilEventType(t, app, model.AgentReply)
+
+	if got, want := app.Config.Model.Provider, "openai-completion"; got != want {
+		t.Fatalf("provider = %q, want %q", got, want)
+	}
+	if got, want := app.Config.Model.Model, "openai/gpt-4o-mini"; got != want {
+		t.Fatalf("model = %q, want %q", got, want)
+	}
+}
+
+func TestCmdModel_LogicalProviderSelectionPreservesUnderlyingError(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	app.cmdModel([]string{"openrouter:openai/gpt-4o-mini"})
+
+	ev := drainUntilEventType(t, app, model.AgentReply)
+	if !strings.Contains(ev.Message, "not connected") {
+		t.Fatalf("message = %q, want underlying connection error", ev.Message)
+	}
+}
+
+func TestCmdConnect_NoArgsUsesCachedCatalogWithoutBlocking(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"openrouter": {
+				"id": "openrouter",
+				"name": "OpenRouter",
+				"npm": "@openrouter/ai-sdk-provider",
+				"models": {}
+			}
+		}`))
+	}))
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	cached := `{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {}
+		}
+	}`
+	if err := writeModelsDevCache([]byte(cached)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	start := time.Now()
+	app.cmdConnect(nil)
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("cmdConnect(nil) took %v, want under 500ms", elapsed)
+	}
+
+	ev := drainUntilEventType(t, app, model.ModelSetupOpen)
+	if ev.SetupPopup == nil {
+		t.Fatal("ModelSetupOpen popup = nil")
+	}
+}
+
+func TestCmdConnect_NoArgsShowsProviderPickerWithFreeLoginHint(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"anthropic": {"id": "anthropic", "name": "Anthropic", "npm": "@ai-sdk/anthropic", "models": {}},
+		"openai": {"id": "openai", "name": "OpenAI", "npm": "@ai-sdk/openai", "models": {}},
+		"kimi-for-coding": {"id": "kimi-for-coding", "name": "Kimi for Coding", "npm": "@ai-sdk/openai-compatible", "models": {}},
+		"deepseek": {"id": "deepseek", "name": "DeepSeek", "npm": "@ai-sdk/openai-compatible", "models": {}},
+		"openrouter": {"id": "openrouter", "name": "OpenRouter", "npm": "@openrouter/ai-sdk-provider", "models": {}}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+	if err := writeModelsDevCache([]byte(`{
+		"anthropic": {"id": "anthropic", "name": "Anthropic", "npm": "@ai-sdk/anthropic", "models": {}},
+		"openai": {"id": "openai", "name": "OpenAI", "npm": "@ai-sdk/openai", "models": {}},
+		"kimi-for-coding": {"id": "kimi-for-coding", "name": "Kimi for Coding", "npm": "@ai-sdk/openai-compatible", "models": {}},
+		"deepseek": {"id": "deepseek", "name": "DeepSeek", "npm": "@ai-sdk/openai-compatible", "models": {}},
+		"openrouter": {"id": "openrouter", "name": "OpenRouter", "npm": "@openrouter/ai-sdk-provider", "models": {}}
+	}`)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	app.cmdConnect(nil)
+
+	ev := drainUntilEventType(t, app, model.ModelSetupOpen)
+	if ev.SetupPopup == nil {
+		t.Fatal("ModelSetupOpen popup = nil, want SetupPopup")
+	}
+	if got, want := ev.SetupPopup.Title, "Connect Provider"; got != want {
+		t.Fatalf("popup.Title = %q, want %q", got, want)
+	}
+	if len(ev.SetupPopup.PresetOptions) == 0 {
+		t.Fatal("expected provider options")
+	}
+	if got, want := ev.SetupPopup.PresetOptions[0].Label, "Popular"; got != want {
+		t.Fatalf("first option label = %q, want %q", got, want)
+	}
+	if got, want := ev.SetupPopup.PresetOptions[1].ID, "anthropic"; got != want {
+		t.Fatalf("second option ID = %q, want %q", got, want)
+	}
+	if got, want := ev.SetupPopup.PresetOptions[5].Separator, true; got != want {
+		t.Fatalf("separator before other = %v, want %v", got, want)
+	}
+	if got, want := ev.SetupPopup.PresetOptions[6].Label, "Other"; got != want {
+		t.Fatalf("other header label = %q, want %q", got, want)
+	}
+	firstOther := ev.SetupPopup.PresetOptions[7]
+	if got, want := firstOther.ID, mindsporeCLIFreeProviderID; got != want {
+		t.Fatalf("first other provider ID = %q, want %q", got, want)
+	}
+	if !firstOther.Disabled {
+		t.Fatal("expected free provider to be disabled before login")
+	}
+	if !strings.Contains(firstOther.Desc, "require login") {
+		t.Fatalf("firstOther.Desc = %q, want require login hint", firstOther.Desc)
+	}
+}
+
+func TestCmdConnect_LoggedInShowsFreeAsRecommendedFirstPopularItem(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := saveCredentials(&credentials{
+		ServerURL: "https://mscli.dev",
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"anthropic": {"id": "anthropic", "name": "Anthropic", "npm": "@ai-sdk/anthropic", "models": {}},
+		"openai": {"id": "openai", "name": "OpenAI", "npm": "@ai-sdk/openai", "models": {}}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+	if err := writeModelsDevCache([]byte(`{
+		"anthropic": {"id": "anthropic", "name": "Anthropic", "npm": "@ai-sdk/anthropic", "models": {}},
+		"openai": {"id": "openai", "name": "OpenAI", "npm": "@ai-sdk/openai", "models": {}}
+	}`)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	app.cmdConnect(nil)
+
+	ev := drainUntilEventType(t, app, model.ModelSetupOpen)
+	if ev.SetupPopup == nil {
+		t.Fatal("ModelSetupOpen popup = nil, want SetupPopup")
+	}
+	if got, want := ev.SetupPopup.PresetOptions[0].Label, "Popular"; got != want {
+		t.Fatalf("popular header label = %q, want %q", got, want)
+	}
+	firstPopular := ev.SetupPopup.PresetOptions[1]
+	if got, want := firstPopular.ID, mindsporeCLIFreeProviderID; got != want {
+		t.Fatalf("first popular ID = %q, want %q", got, want)
+	}
+	if firstPopular.Disabled {
+		t.Fatal("expected free provider enabled after login")
+	}
+	if !strings.Contains(firstPopular.Desc, "Recommended") {
+		t.Fatalf("firstPopular.Desc = %q, want Recommended", firstPopular.Desc)
+	}
+}
+
+func TestCmdConnect_ConfiguredProviderStillRequiresAPIKeyInput(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+	if err := writeModelsDevCache([]byte(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+	if err := saveProviderAuthState(&providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-old"},
+		},
+	}); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
+	}
+
+	app.cmdConnect(nil)
+
+	ev := drainUntilEventType(t, app, model.ModelSetupOpen)
+	if ev.SetupPopup == nil {
+		t.Fatal("ModelSetupOpen popup = nil")
+	}
+	var openrouter model.SelectionOption
+	found := false
+	for _, opt := range ev.SetupPopup.PresetOptions {
+		if opt.ID == "openrouter" {
+			openrouter = opt
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected openrouter option")
+	}
+	if strings.Contains(openrouter.Desc, "connected") {
+		t.Fatalf("openrouter.Desc = %q, want no connected hint", openrouter.Desc)
+	}
+	if !openrouter.RequiresInput {
+		t.Fatal("expected openrouter to require API key input even when already configured")
+	}
+}
+
+func TestCmdConnect_WithAPIKeyPersistsAuthAndOpensProviderScopedModelPicker(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	app.cmdConnect([]string{"openrouter", "sk-openrouter"})
+
+	drainUntilEventType(t, app, model.AgentThinking)
+	ev := drainUntilEventType(t, app, model.ModelSetupClose)
+	if got, want := ev.Type, model.ModelSetupClose; got != want {
+		t.Fatalf("event type = %s, want %s", got, want)
+	}
+	picker := drainUntilEventType(t, app, model.ModelPickerOpen)
+	if picker.Popup == nil {
+		t.Fatal("ModelPickerOpen popup = nil")
+	}
+	if got, want := picker.Popup.ActionID, "connect_provider_model_picker:openrouter"; got != want {
+		t.Fatalf("picker.Popup.ActionID = %q, want %q", got, want)
+	}
+	if len(picker.Popup.Options) != 1 {
+		t.Fatalf("len(picker.Popup.Options) = %d, want 1 provider-scoped model option", len(picker.Popup.Options))
+	}
+	if got, want := picker.Popup.Options[0].ID, "openrouter:openai/gpt-4o-mini"; got != want {
+		t.Fatalf("picker.Popup.Options[0].ID = %q, want %q", got, want)
+	}
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	entry, ok := authState.Providers["openrouter"]
+	if !ok {
+		t.Fatalf("authState.Providers = %#v, want openrouter entry", authState.Providers)
+	}
+	if got, want := entry.APIKey, "sk-openrouter"; got != want {
+		t.Fatalf("entry.APIKey = %q, want %q", got, want)
 	}
 }
 

--- a/internal/app/model_presets.go
+++ b/internal/app/model_presets.go
@@ -15,7 +15,7 @@ import (
 type modelCredentialStrategy string
 
 const (
-	credentialStrategyStatic       modelCredentialStrategy = "static"
+	credentialStrategyStatic      modelCredentialStrategy = "static"
 	credentialStrategyMSCLIServer modelCredentialStrategy = "mscli-server"
 )
 
@@ -114,33 +114,7 @@ func fetchPresetAPIKey(preset builtinModelPreset) (string, error) {
 		if err != nil || strings.TrimSpace(cred.Token) == "" || strings.TrimSpace(cred.ServerURL) == "" {
 			return "", fmt.Errorf("not logged in")
 		}
-		path := strings.TrimSpace(preset.Credential.Path)
-		if path == "" {
-			path = "/model-presets/" + preset.ID + "/credential"
-		}
-		url := strings.TrimRight(strings.TrimSpace(cred.ServerURL), "/") + path
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
-		if err != nil {
-			return "", err
-		}
-		req.Header.Set("Authorization", "Bearer "+cred.Token)
-		client := &http.Client{Timeout: 5 * time.Second}
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("status %d", resp.StatusCode)
-		}
-		var payload struct {
-			APIKey string `json:"api_key"`
-		}
-		if err := json.Unmarshal(data, &payload); err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(payload.APIKey), nil
+		return requestPresetCredential(context.Background(), preset, cred)
 	default:
 		return "", fmt.Errorf("unsupported strategy %q", preset.Credential.Strategy)
 	}
@@ -165,6 +139,17 @@ func (a *Application) fetchPresetAPIKeyFromServer(ctx context.Context, preset bu
 	if err != nil || strings.TrimSpace(cred.Token) == "" || strings.TrimSpace(cred.ServerURL) == "" {
 		return "", fmt.Errorf("not logged in. run /login <token> first")
 	}
+	apiKey, err := requestPresetCredential(ctx, preset, cred)
+	if err != nil {
+		return "", fmt.Errorf("request preset credential: %w", err)
+	}
+	return apiKey, nil
+}
+
+func requestPresetCredential(ctx context.Context, preset builtinModelPreset, cred *credentials) (string, error) {
+	if cred == nil {
+		return "", fmt.Errorf("credentials unavailable")
+	}
 	path := strings.TrimSpace(preset.Credential.Path)
 	if path == "" {
 		path = "/model-presets/" + preset.ID + "/credential"
@@ -180,13 +165,13 @@ func (a *Application) fetchPresetAPIKeyFromServer(ctx context.Context, preset bu
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("request preset credential: %w", err)
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("request preset credential failed: status %d", resp.StatusCode)
+		return "", fmt.Errorf("status %d", resp.StatusCode)
 	}
 	var payload struct {
 		APIKey string `json:"api_key"`

--- a/internal/app/model_setup_integration_test.go
+++ b/internal/app/model_setup_integration_test.go
@@ -8,8 +8,25 @@ import (
 	"github.com/mindspore-lab/mindspore-cli/ui/model"
 )
 
-func TestModelCommand_OpensSetupPopupWithState(t *testing.T) {
+func TestModelCommand_OpensModelPickerWithState(t *testing.T) {
 	eventCh := make(chan model.Event, 64)
+	t.Setenv("HOME", t.TempDir())
+	if err := saveCredentials(&credentials{
+		ServerURL: "https://mscli.dev",
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
+	if err := saveModelSelectionState(&modelSelectionState{
+		Active: &modelRef{
+			ProviderID: mindsporeCLIFreeProviderID,
+			ModelID:    "kimi-k2.5",
+		},
+	}); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
 	app := &Application{
 		EventCh:             eventCh,
 		Config:              configs.DefaultConfig(),
@@ -19,36 +36,30 @@ func TestModelCommand_OpensSetupPopupWithState(t *testing.T) {
 
 	app.cmdModel(nil)
 
-	var popup *model.SetupPopup
+	var popup *model.SelectionPopup
 	for len(eventCh) > 0 {
 		ev := <-eventCh
-		if ev.Type == model.ModelSetupOpen {
-			popup = ev.SetupPopup
+		if ev.Type == model.ModelPickerOpen {
+			popup = ev.Popup
 		}
 	}
 	if popup == nil {
-		t.Fatal("expected setup popup to open")
+		t.Fatal("expected model picker to open")
 	}
-	if !popup.CanEscape {
-		t.Error("expected CanEscape=true from /model")
+	if got, want := popup.ActionID, "model_picker"; got != want {
+		t.Errorf("popup.ActionID = %q, want %q", got, want)
 	}
-	if popup.CurrentMode != modelModeMSCLIProvided {
-		t.Errorf("expected current mode %q, got %q", modelModeMSCLIProvided, popup.CurrentMode)
+	if len(popup.Options) == 0 {
+		t.Fatal("expected model options")
 	}
-	if popup.CurrentPreset != "kimi-k2.5-free" {
-		t.Errorf("expected current preset 'kimi-k2.5-free', got %q", popup.CurrentPreset)
-	}
-
-	disabledCount := 0
-	for _, opt := range popup.PresetOptions {
-		if opt.Disabled {
-			disabledCount++
-			if !strings.Contains(opt.Label, "coming soon") {
-				t.Errorf("disabled option %q should contain 'coming soon'", opt.Label)
-			}
+	foundFree := false
+	for _, opt := range popup.Options {
+		if strings.Contains(opt.ID, "mindspore-cli-free:kimi-k2.5") {
+			foundFree = true
+			break
 		}
 	}
-	if disabledCount != 2 {
-		t.Errorf("expected 2 disabled (coming soon) presets, got %d", disabledCount)
+	if !foundFree {
+		t.Errorf("expected free model option, got %#v", popup.Options)
 	}
 }

--- a/internal/app/project_test.go
+++ b/internal/app/project_test.go
@@ -450,20 +450,20 @@ func TestRenderMilestoneLines_TagsColumn(t *testing.T) {
 	}
 }
 
-func TestRenderTaskLines_LongTitleTruncated(t *testing.T) {
+func TestRenderTaskLines_LongSingleTokenPreservedWithoutEllipsis(t *testing.T) {
 	longTitle := strings.Repeat("a", 120)
 	tasks := []projectTask{
 		{ID: "1", Title: longTitle, Status: "doing", Progress: 50, Owner: "alice", Tags: "long"},
 	}
 	lines := renderTaskLines(tasks)
 	if len(lines) != 1 {
-		t.Fatalf("expected 1 line, got %d", len(lines))
+		t.Fatalf("expected 1 line for single-token title, got %d", len(lines))
 	}
-	if strings.Contains(lines[0], longTitle) {
-		t.Errorf("expected title to be truncated, got full title in:\n%s", lines[0])
+	if strings.Contains(lines[0], "...") {
+		t.Errorf("expected long single-token title to be preserved without ellipsis, got:\n%s", lines[0])
 	}
-	if !strings.Contains(lines[0], "...") {
-		t.Errorf("expected truncation marker '...', got:\n%s", lines[0])
+	if !strings.Contains(lines[0], longTitle) {
+		t.Errorf("expected full single-token title to be preserved, got:\n%s", lines[0])
 	}
 }
 

--- a/internal/app/provider_catalog.go
+++ b/internal/app/provider_catalog.go
@@ -1,0 +1,462 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	mindsporeCLIFreeProviderID = "mindspore-cli-free"
+	defaultModelsDevAPIURL     = "https://models.dev/api.json"
+)
+
+var (
+	connectPopularProviderIDs = []string{
+		"anthropic",
+		"openai",
+		"kimi-for-coding",
+		"deepseek",
+	}
+	defaultPopularProviderIDs = append(
+		[]string{mindsporeCLIFreeProviderID},
+		append(append([]string(nil), connectPopularProviderIDs...), "openrouter", "google", "groq")...,
+	)
+
+	modelsDevAPIURL            = defaultModelsDevAPIURL
+	modelsDevCachePathOverride string
+
+	modelsDevProvidersCacheMu      sync.Mutex
+	modelsDevProvidersCache        []providerCatalogEntry
+	modelsDevProvidersCacheLoaded  bool
+	modelsDevProvidersRefreshAt    time.Time
+	modelsDevProvidersRefreshAlive bool
+)
+
+const modelsDevRefreshTTL = 5 * time.Minute
+
+type providerCatalog struct {
+	Providers []providerCatalogEntry
+}
+
+type providerCatalogEntry struct {
+	ID          string
+	Label       string
+	BaseURL     string
+	Protocol    string
+	Description string
+	Builtin     bool
+	Popular     bool
+	Models      []modelCatalogEntry
+}
+
+type modelCatalogEntry struct {
+	ProviderID      string
+	ID              string
+	Label           string
+	Description     string
+	ContextWindow   int
+	MaxOutputTokens int
+	Tags            []string
+}
+
+type modelsDevProvider struct {
+	ID     string                    `json:"id"`
+	API    string                    `json:"api"`
+	Name   string                    `json:"name"`
+	Doc    string                    `json:"doc"`
+	NPM    string                    `json:"npm"`
+	Models map[string]modelsDevModel `json:"models"`
+}
+
+type modelsDevModel struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Limit struct {
+		Context int `json:"context"`
+		Output  int `json:"output"`
+	} `json:"limit"`
+}
+
+func loadProviderCatalog(httpClient *http.Client, extras []extraProviderConfig) (*providerCatalog, error) {
+	providers := make(map[string]providerCatalogEntry)
+
+	for _, provider := range builtinProviderCatalog() {
+		providers[provider.ID] = provider
+	}
+
+	var remote []providerCatalogEntry
+	var ok bool
+	if httpClient == nil {
+		remote, ok = loadModelsDevProvidersNonBlocking()
+	} else {
+		remote, ok = loadModelsDevProviders(httpClient)
+	}
+	if ok {
+		for _, provider := range remote {
+			providers[provider.ID] = provider
+		}
+	}
+
+	for _, provider := range extraProvidersToCatalog(extras) {
+		providers[provider.ID] = provider
+	}
+
+	out := make([]providerCatalogEntry, 0, len(providers))
+	for _, provider := range providers {
+		out = append(out, provider)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left, right := out[i], out[j]
+		if left.Popular != right.Popular {
+			return left.Popular
+		}
+		if left.Builtin != right.Builtin {
+			return left.Builtin
+		}
+		return left.Label < right.Label
+	})
+
+	return &providerCatalog{Providers: out}, nil
+}
+
+func loadProviderCatalogBlocking(extras []extraProviderConfig) (*providerCatalog, error) {
+	return loadProviderCatalog(&http.Client{Timeout: 5 * time.Second}, extras)
+}
+
+func loadModelsDevProvidersNonBlocking() ([]providerCatalogEntry, bool) {
+	if cached, ok := cachedModelsDevProviders(); ok {
+		maybeRefreshModelsDevProvidersAsync()
+		return cached, true
+	}
+	if disk, ok := loadModelsDevProvidersFromDisk(); ok {
+		setCachedModelsDevProvidersFromDisk(disk)
+		maybeRefreshModelsDevProvidersAsync()
+		return disk, true
+	}
+	maybeRefreshModelsDevProvidersAsync()
+	return nil, false
+}
+
+func (c *providerCatalog) Provider(id string) (providerCatalogEntry, bool) {
+	if c == nil {
+		return providerCatalogEntry{}, false
+	}
+	needle := normalizedProviderID(id)
+	for _, provider := range c.Providers {
+		if provider.ID == needle {
+			return provider, true
+		}
+	}
+	return providerCatalogEntry{}, false
+}
+
+func builtinProviderCatalog() []providerCatalogEntry {
+	return []providerCatalogEntry{
+		{
+			ID:       mindsporeCLIFreeProviderID,
+			Label:    "MindSpore CLI Free",
+			Protocol: "mindspore-cli-free",
+			Builtin:  true,
+			Popular:  true,
+			Models: []modelCatalogEntry{
+				{
+					ProviderID:      mindsporeCLIFreeProviderID,
+					ID:              "kimi-k2.5",
+					Label:           "Kimi K2.5",
+					ContextWindow:   262144,
+					MaxOutputTokens: 262144,
+				},
+				{
+					ProviderID:      mindsporeCLIFreeProviderID,
+					ID:              "deepseek-chat",
+					Label:           "DeepSeek V3",
+					ContextWindow:   128000,
+					MaxOutputTokens: 8000,
+				},
+			},
+		},
+	}
+}
+
+func loadModelsDevProviders(httpClient *http.Client) ([]providerCatalogEntry, bool) {
+	body, ok := fetchModelsDevCatalog(httpClient)
+	if ok {
+		_ = writeModelsDevCache(body)
+	} else {
+		cached, err := readModelsDevCache()
+		if err != nil {
+			return nil, false
+		}
+		body = cached
+	}
+
+	parsed, err := parseModelsDevCatalog(body)
+	if err != nil {
+		return nil, false
+	}
+	setCachedModelsDevProviders(parsed)
+	return parsed, true
+}
+
+func loadModelsDevProvidersFromDisk() ([]providerCatalogEntry, bool) {
+	cached, err := readModelsDevCache()
+	if err != nil {
+		return nil, false
+	}
+	parsed, err := parseModelsDevCatalog(cached)
+	if err != nil {
+		return nil, false
+	}
+	return parsed, true
+}
+
+func cachedModelsDevProviders() ([]providerCatalogEntry, bool) {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	if !modelsDevProvidersCacheLoaded || len(modelsDevProvidersCache) == 0 {
+		return nil, false
+	}
+	return cloneProviderCatalogEntries(modelsDevProvidersCache), true
+}
+
+func setCachedModelsDevProviders(providers []providerCatalogEntry) {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	modelsDevProvidersCache = cloneProviderCatalogEntries(providers)
+	modelsDevProvidersCacheLoaded = true
+	modelsDevProvidersRefreshAt = time.Now()
+}
+
+func setCachedModelsDevProvidersFromDisk(providers []providerCatalogEntry) {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	modelsDevProvidersCache = cloneProviderCatalogEntries(providers)
+	modelsDevProvidersCacheLoaded = true
+}
+
+func maybeRefreshModelsDevProvidersAsync() {
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+
+	modelsDevProvidersCacheMu.Lock()
+	if modelsDevProvidersRefreshAlive {
+		modelsDevProvidersCacheMu.Unlock()
+		return
+	}
+	if !modelsDevProvidersRefreshAt.IsZero() && time.Since(modelsDevProvidersRefreshAt) < modelsDevRefreshTTL {
+		modelsDevProvidersCacheMu.Unlock()
+		return
+	}
+	modelsDevProvidersRefreshAlive = true
+	modelsDevProvidersRefreshAt = time.Now()
+	modelsDevProvidersCacheMu.Unlock()
+
+	go func() {
+		defer func() {
+			modelsDevProvidersCacheMu.Lock()
+			modelsDevProvidersRefreshAlive = false
+			modelsDevProvidersCacheMu.Unlock()
+		}()
+
+		body, ok := fetchModelsDevCatalog(httpClient)
+		if !ok {
+			return
+		}
+		parsed, err := parseModelsDevCatalog(body)
+		if err != nil {
+			return
+		}
+		_ = writeModelsDevCache(body)
+		setCachedModelsDevProviders(parsed)
+	}()
+}
+
+func cloneProviderCatalogEntries(in []providerCatalogEntry) []providerCatalogEntry {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]providerCatalogEntry, len(in))
+	for i, provider := range in {
+		cloned := provider
+		if len(provider.Models) > 0 {
+			cloned.Models = append([]modelCatalogEntry(nil), provider.Models...)
+		}
+		out[i] = cloned
+	}
+	return out
+}
+
+func resetModelsDevProviderCacheForTest() {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	modelsDevProvidersCache = nil
+	modelsDevProvidersCacheLoaded = false
+	modelsDevProvidersRefreshAt = time.Time{}
+	modelsDevProvidersRefreshAlive = false
+}
+
+func fetchModelsDevCatalog(httpClient *http.Client) ([]byte, bool) {
+	req, err := http.NewRequest(http.MethodGet, modelsDevAPIURL, nil)
+	if err != nil {
+		return nil, false
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, false
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024*1024))
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+func parseModelsDevCatalog(body []byte) ([]providerCatalogEntry, error) {
+	var payload map[string]modelsDevProvider
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	out := make([]providerCatalogEntry, 0, len(payload))
+	for _, provider := range payload {
+		id := normalizedProviderID(provider.ID)
+		if id == "" {
+			continue
+		}
+		models := make([]modelCatalogEntry, 0, len(provider.Models))
+		for modelID, model := range provider.Models {
+			normalizedModelID := strings.TrimSpace(model.ID)
+			if normalizedModelID == "" {
+				normalizedModelID = strings.TrimSpace(modelID)
+			}
+			if normalizedModelID == "" {
+				continue
+			}
+			label := strings.TrimSpace(model.Name)
+			if label == "" {
+				label = normalizedModelID
+			}
+			models = append(models, modelCatalogEntry{
+				ProviderID:      id,
+				ID:              normalizedModelID,
+				Label:           label,
+				ContextWindow:   model.Limit.Context,
+				MaxOutputTokens: model.Limit.Output,
+			})
+		}
+		sort.Slice(models, func(i, j int) bool { return models[i].Label < models[j].Label })
+
+		label := strings.TrimSpace(provider.Name)
+		if label == "" {
+			label = id
+		}
+		label = canonicalProviderLabel(id, label)
+		out = append(out, providerCatalogEntry{
+			ID:          id,
+			Label:       label,
+			BaseURL:     strings.TrimSpace(provider.API),
+			Protocol:    inferProtocolFromModelsDev(provider),
+			Description: strings.TrimSpace(provider.Doc),
+			Popular:     isPopularProviderID(id),
+			Models:      models,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Label < out[j].Label })
+	return out, nil
+}
+
+func extraProvidersToCatalog(extras []extraProviderConfig) []providerCatalogEntry {
+	out := make([]providerCatalogEntry, 0, len(extras))
+	for _, provider := range extras {
+		id := normalizedProviderID(provider.ID)
+		if id == "" {
+			continue
+		}
+		label := strings.TrimSpace(provider.Label)
+		if label == "" {
+			label = provider.ID
+		}
+		label = canonicalProviderLabel(id, label)
+		models := make([]modelCatalogEntry, 0, len(provider.Models))
+		for _, model := range provider.Models {
+			modelID := strings.TrimSpace(model.ID)
+			if modelID == "" {
+				continue
+			}
+			modelLabel := strings.TrimSpace(model.Label)
+			if modelLabel == "" {
+				modelLabel = modelID
+			}
+			models = append(models, modelCatalogEntry{
+				ProviderID: id,
+				ID:         modelID,
+				Label:      modelLabel,
+			})
+		}
+		out = append(out, providerCatalogEntry{
+			ID:       id,
+			Label:    label,
+			BaseURL:  strings.TrimSpace(provider.BaseURL),
+			Protocol: strings.TrimSpace(provider.Protocol),
+			Popular:  isPopularProviderID(id),
+			Models:   models,
+		})
+	}
+	return out
+}
+
+func inferProtocolFromModelsDev(provider modelsDevProvider) string {
+	npm := strings.ToLower(strings.TrimSpace(provider.NPM))
+	switch {
+	case strings.Contains(npm, "anthropic"):
+		return "anthropic-messages"
+	case strings.Contains(npm, "responses"):
+		return "openai-responses"
+	default:
+		return "openai-chat"
+	}
+}
+
+func isPopularProviderID(id string) bool {
+	needle := normalizedProviderID(id)
+	for _, candidate := range defaultPopularProviderIDs {
+		if needle == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalProviderLabel(id, fallback string) string {
+	return strings.TrimSpace(fallback)
+}
+
+func modelsDevCachePath() string {
+	if modelsDevCachePathOverride != "" {
+		return modelsDevCachePathOverride
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+}
+
+func writeModelsDevCache(body []byte) error {
+	path := modelsDevCachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o600)
+}
+
+func readModelsDevCache() ([]byte, error) {
+	return os.ReadFile(modelsDevCachePath())
+}

--- a/internal/app/provider_catalog_test.go
+++ b/internal/app/provider_catalog_test.go
@@ -1,0 +1,344 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestProviderCatalogIncludesBuiltinFreeProvider(t *testing.T) {
+	server := newModelsDevTestServer(`{}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	provider, ok := catalog.Provider(mindsporeCLIFreeProviderID)
+	if !ok {
+		t.Fatalf("catalog.Provider(%q) ok = false", mindsporeCLIFreeProviderID)
+	}
+	if got, want := provider.Label, "MindSpore CLI Free"; got != want {
+		t.Fatalf("provider.Label = %q, want %q", got, want)
+	}
+	if got, want := provider.Models[0].ID, "kimi-k2.5"; got != want {
+		t.Fatalf("provider.Models[0].ID = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogMergesModelsDevAndExtraProviders(t *testing.T) {
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {
+				"openai/gpt-4o-mini": {
+					"id": "openai/gpt-4o-mini",
+					"name": "GPT-4o mini",
+					"limit": {"context": 128000, "output": 16384}
+				}
+			}
+		}
+	}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, []extraProviderConfig{
+		{
+			ID:       "my-gateway",
+			Label:    "My Gateway",
+			BaseURL:  "https://llm.example.com/v1",
+			Protocol: "openai-chat",
+			Models: []extraProviderModelConfig{
+				{ID: "my-model", Label: "My Model"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	if _, ok := catalog.Provider("openrouter"); !ok {
+		t.Fatal("expected openrouter in merged catalog")
+	}
+	custom, ok := catalog.Provider("my-gateway")
+	if !ok {
+		t.Fatal("expected my-gateway in merged catalog")
+	}
+	if got, want := custom.Models[0].ID, "my-model"; got != want {
+		t.Fatalf("custom.Models[0].ID = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogLocalOverridesTakePrecedence(t *testing.T) {
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {
+				"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}
+			}
+		}
+	}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, []extraProviderConfig{
+		{
+			ID:       "openrouter",
+			Label:    "OpenRouter Custom",
+			BaseURL:  "https://custom.example/v1",
+			Protocol: "openai-chat",
+			Models: []extraProviderModelConfig{
+				{ID: "custom-model", Label: "Custom Model"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	provider, ok := catalog.Provider("openrouter")
+	if !ok {
+		t.Fatal("expected openrouter in catalog")
+	}
+	if got, want := provider.Label, "OpenRouter Custom"; got != want {
+		t.Fatalf("provider.Label = %q, want %q", got, want)
+	}
+	if got, want := provider.BaseURL, "https://custom.example/v1"; got != want {
+		t.Fatalf("provider.BaseURL = %q, want %q", got, want)
+	}
+	if got, want := provider.Models[0].ID, "custom-model"; got != want {
+		t.Fatalf("provider.Models[0].ID = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogFallsBackToCacheOnFetchFailure(t *testing.T) {
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	cached := `{
+		"anthropic": {
+			"id": "anthropic",
+			"name": "Anthropic",
+			"npm": "@ai-sdk/anthropic",
+			"models": {
+				"claude-sonnet-4-5": {"id": "claude-sonnet-4-5", "name": "Claude Sonnet 4.5"}
+			}
+		}
+	}`
+	if err := writeModelsDevCache([]byte(cached)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = "http://127.0.0.1:1"
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	if _, ok := catalog.Provider("anthropic"); !ok {
+		t.Fatal("expected cached anthropic provider")
+	}
+}
+
+func TestProviderCatalogFallsBackToBuiltinAndExtraWithoutCache(t *testing.T) {
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "missing", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = "http://127.0.0.1:1"
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, []extraProviderConfig{
+		{
+			ID:       "my-gateway",
+			BaseURL:  "https://llm.example.com/v1",
+			Protocol: "openai-chat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	if _, ok := catalog.Provider(mindsporeCLIFreeProviderID); !ok {
+		t.Fatal("expected builtin free provider")
+	}
+	if _, ok := catalog.Provider("my-gateway"); !ok {
+		t.Fatal("expected extra provider fallback")
+	}
+}
+
+func TestProviderCatalogPreservesProviderIDAndName(t *testing.T) {
+	server := newModelsDevTestServer(`{
+		"acmeai": {
+			"id": "acmeai",
+			"name": "Acme AI",
+			"api": "https://api.acme.ai/v1",
+			"npm": "@ai-sdk/openai-compatible",
+			"models": {}
+		}
+	}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	provider, ok := catalog.Provider("acmeai")
+	if !ok {
+		t.Fatal("expected acmeai in catalog")
+	}
+	if got, want := provider.ID, "acmeai"; got != want {
+		t.Fatalf("provider.ID = %q, want %q", got, want)
+	}
+	if got, want := provider.Label, "Acme AI"; got != want {
+		t.Fatalf("provider.Label = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogUsesCacheWithoutBlockingWhenNilClient(t *testing.T) {
+	resetModelsDevProviderCacheForTest()
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	cached := `{
+		"anthropic": {
+			"id": "anthropic",
+			"name": "Anthropic",
+			"npm": "@ai-sdk/anthropic",
+			"models": {}
+		}
+	}`
+	if err := writeModelsDevCache([]byte(cached)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	start := time.Now()
+	catalog, err := loadProviderCatalog(nil, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("loadProviderCatalog() took %v, want under 500ms", elapsed)
+	}
+	if _, ok := catalog.Provider("anthropic"); !ok {
+		t.Fatal("expected cached anthropic provider")
+	}
+}
+
+func TestProviderCatalogNilClientReturnsBuiltinAndExtraWithoutBlockingWhenCacheMissing(t *testing.T) {
+	resetModelsDevProviderCacheForTest()
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "missing", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"openrouter": {
+				"id": "openrouter",
+				"name": "OpenRouter",
+				"npm": "@openrouter/ai-sdk-provider",
+				"models": {}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	start := time.Now()
+	catalog, err := loadProviderCatalog(nil, []extraProviderConfig{
+		{
+			ID:       "my-gateway",
+			BaseURL:  "https://llm.example.com/v1",
+			Protocol: "openai-chat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("loadProviderCatalog() took %v, want under 500ms", elapsed)
+	}
+	if _, ok := catalog.Provider(mindsporeCLIFreeProviderID); !ok {
+		t.Fatal("expected builtin free provider")
+	}
+	if _, ok := catalog.Provider("my-gateway"); !ok {
+		t.Fatal("expected extra provider")
+	}
+}
+
+func newModelsDevTestServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}

--- a/internal/app/provider_restore_test.go
+++ b/internal/app/provider_restore_test.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/configs"
+)
+
+func TestRestoreProviderSelectionUsesPersistentState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origConfigPath := appConfigPathOverride
+	appConfigPathOverride = filepath.Join(home, ".mscli", "config.json")
+	t.Cleanup(func() { appConfigPathOverride = origConfigPath })
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+	origCachePath := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCachePath })
+
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	if err := saveProviderAuthState(&providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+		},
+	}); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
+	}
+	if err := saveModelSelectionState(&modelSelectionState{
+		Active: &modelRef{ProviderID: "openrouter", ModelID: "openai/gpt-4o-mini"},
+	}); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
+
+	cfg := configs.DefaultConfig()
+	result, err := restoreProviderSelection(cfg)
+	if err != nil {
+		t.Fatalf("restoreProviderSelection() error = %v", err)
+	}
+	if !result.Restored {
+		t.Fatal("result.Restored = false, want true")
+	}
+	if got, want := cfg.Model.Provider, "openai-completion"; got != want {
+		t.Fatalf("cfg.Model.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.Model, "openai/gpt-4o-mini"; got != want {
+		t.Fatalf("cfg.Model.Model = %q, want %q", got, want)
+	}
+}
+
+func TestRestoreProviderSelectionDefaultsToFreeWhenLoggedIn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origConfigPath := appConfigPathOverride
+	appConfigPathOverride = filepath.Join(home, ".mscli", "config.json")
+	t.Cleanup(func() { appConfigPathOverride = origConfigPath })
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"api_key": "server-kimi-key"})
+	}))
+	defer srv.Close()
+
+	if err := saveCredentials(&credentials{
+		ServerURL: srv.URL,
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
+
+	cfg := configs.DefaultConfig()
+	result, err := restoreProviderSelection(cfg)
+	if err != nil {
+		t.Fatalf("restoreProviderSelection() error = %v", err)
+	}
+	if !result.Restored {
+		t.Fatal("result.Restored = false, want true")
+	}
+	if got, want := result.ActivePresetID, "kimi-k2.5-free"; got != want {
+		t.Fatalf("result.ActivePresetID = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.Model, "kimi-k2.5"; got != want {
+		t.Fatalf("cfg.Model.Model = %q, want %q", got, want)
+	}
+}
+
+func TestRestoreProviderSelectionLeavesConfigUnsetWhenNotLoggedIn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origConfigPath := appConfigPathOverride
+	appConfigPathOverride = filepath.Join(home, ".mscli", "config.json")
+	t.Cleanup(func() { appConfigPathOverride = origConfigPath })
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+
+	cfg := configs.DefaultConfig()
+	result, err := restoreProviderSelection(cfg)
+	if err != nil {
+		t.Fatalf("restoreProviderSelection() error = %v", err)
+	}
+	if result.Restored {
+		t.Fatal("result.Restored = true, want false")
+	}
+	if got := cfg.Model.Model; got != "" {
+		t.Fatalf("cfg.Model.Model = %q, want empty", got)
+	}
+}

--- a/internal/app/provider_runtime.go
+++ b/internal/app/provider_runtime.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mindspore-lab/mindspore-cli/configs"
+)
+
+type providerRestoreResult struct {
+	Restored       bool
+	ActivePresetID string
+}
+
+func restoreProviderSelection(cfg *configs.Config) (providerRestoreResult, error) {
+	if cfg == nil {
+		return providerRestoreResult{}, nil
+	}
+
+	appCfg, err := loadAppConfig()
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+	catalog, err := loadProviderCatalogBlocking(appCfg.ExtraProviders)
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+	modelState, err := loadModelSelectionState()
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+
+	if modelState.Active != nil {
+		resolved, presetID, err := resolveRuntimeSelection(catalog, authState, *modelState.Active)
+		if err == nil {
+			applyResolvedModelConfig(cfg, resolved)
+			return providerRestoreResult{Restored: true, ActivePresetID: presetID}, nil
+		}
+	}
+
+	if strings.TrimSpace(appCfg.ModelPresetID) != "" {
+		if preset, ok := resolveBuiltinModelPreset(appCfg.ModelPresetID); ok {
+			apiKey, err := fetchPresetAPIKey(preset)
+			if err == nil {
+				applyResolvedModelConfig(cfg, configs.ModelConfig{
+					Provider: preset.Provider,
+					URL:      preset.BaseURL,
+					Model:    preset.Model,
+					Key:      apiKey,
+				})
+				return providerRestoreResult{Restored: true, ActivePresetID: preset.ID}, nil
+			}
+		}
+	}
+
+	if isLoggedIn() {
+		resolved, presetID, err := resolveRuntimeSelection(catalog, authState, modelRef{
+			ProviderID: mindsporeCLIFreeProviderID,
+			ModelID:    "kimi-k2.5",
+		})
+		if err == nil {
+			applyResolvedModelConfig(cfg, resolved)
+			return providerRestoreResult{Restored: true, ActivePresetID: presetID}, nil
+		}
+	}
+
+	cfg.Model.Model = ""
+	cfg.Model.Key = ""
+	return providerRestoreResult{}, nil
+}
+
+func resolveRuntimeSelection(catalog *providerCatalog, authState *providerAuthState, ref modelRef) (configs.ModelConfig, string, error) {
+	provider, ok := catalog.Provider(ref.ProviderID)
+	if !ok {
+		return configs.ModelConfig{}, "", fmt.Errorf("unknown provider %q", ref.ProviderID)
+	}
+
+	switch strings.TrimSpace(provider.Protocol) {
+	case "mindspore-cli-free":
+		preset, ok := freeProviderPresetForModel(ref.ModelID)
+		if !ok {
+			return configs.ModelConfig{}, "", fmt.Errorf("unknown free model %q", ref.ModelID)
+		}
+		apiKey, err := fetchPresetAPIKey(preset)
+		if err != nil {
+			return configs.ModelConfig{}, "", err
+		}
+		return configs.ModelConfig{
+			Provider: preset.Provider,
+			URL:      preset.BaseURL,
+			Model:    preset.Model,
+			Key:      apiKey,
+		}, preset.ID, nil
+	case "openai-chat":
+		return resolveAPIKeyBackedRuntimeConfig(provider, authState, ref, "openai-completion")
+	case "openai-responses":
+		return resolveAPIKeyBackedRuntimeConfig(provider, authState, ref, "openai-responses")
+	case "anthropic-messages":
+		return resolveAPIKeyBackedRuntimeConfig(provider, authState, ref, "anthropic")
+	default:
+		return configs.ModelConfig{}, "", fmt.Errorf("unsupported provider protocol %q", provider.Protocol)
+	}
+}
+
+func resolveAPIKeyBackedRuntimeConfig(provider providerCatalogEntry, authState *providerAuthState, ref modelRef, runtimeProvider string) (configs.ModelConfig, string, error) {
+	if authState == nil {
+		authState = emptyProviderAuthState()
+	}
+	entry, ok := authState.Providers[provider.ID]
+	if !ok || strings.TrimSpace(entry.APIKey) == "" {
+		return configs.ModelConfig{}, "", fmt.Errorf("provider %s is not connected", provider.ID)
+	}
+	return configs.ModelConfig{
+		Provider: runtimeProvider,
+		URL:      provider.BaseURL,
+		Model:    strings.TrimSpace(ref.ModelID),
+		Key:      strings.TrimSpace(entry.APIKey),
+	}, "", nil
+}
+
+func applyResolvedModelConfig(cfg *configs.Config, resolved configs.ModelConfig) {
+	if cfg == nil {
+		return
+	}
+	previousModel := cfg.Model.Model
+	cfg.Model.Provider = strings.TrimSpace(resolved.Provider)
+	cfg.Model.URL = strings.TrimSpace(resolved.URL)
+	cfg.Model.Model = strings.TrimSpace(resolved.Model)
+	cfg.Model.Key = strings.TrimSpace(resolved.Key)
+	configs.RefreshModelTokenDefaults(cfg, previousModel)
+}
+
+func freeProviderPresetForModel(modelID string) (builtinModelPreset, bool) {
+	switch strings.TrimSpace(modelID) {
+	case "kimi-k2.5":
+		return resolveBuiltinModelPreset("kimi-k2.5-free")
+	case "deepseek-chat":
+		return resolveBuiltinModelPreset("deepseek-v3")
+	default:
+		return builtinModelPreset{}, false
+	}
+}
+
+func isLoggedIn() bool {
+	cred, err := loadCredentials()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(cred.Token) != "" && strings.TrimSpace(cred.ServerURL) != ""
+}

--- a/internal/app/provider_runtime_test.go
+++ b/internal/app/provider_runtime_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/configs"
+)
+
+func TestResolveRuntimeSelectionForExtraProviderOpenAIChat(t *testing.T) {
+	catalog := &providerCatalog{
+		Providers: []providerCatalogEntry{
+			{
+				ID:       "openrouter",
+				Label:    "OpenRouter",
+				BaseURL:  "https://openrouter.ai/api/v1",
+				Protocol: "openai-chat",
+			},
+		},
+	}
+	auth := &providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+		},
+	}
+
+	cfg, presetID, err := resolveRuntimeSelection(catalog, auth, modelRef{
+		ProviderID: "openrouter",
+		ModelID:    "openai/gpt-4o-mini",
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSelection() error = %v", err)
+	}
+	if presetID != "" {
+		t.Fatalf("presetID = %q, want empty", presetID)
+	}
+	if got, want := cfg.Provider, "openai-completion"; got != want {
+		t.Fatalf("cfg.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.URL, "https://openrouter.ai/api/v1"; got != want {
+		t.Fatalf("cfg.URL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Key, "sk-openrouter"; got != want {
+		t.Fatalf("cfg.Key = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRuntimeSelectionForFreeProviderRequiresLogin(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	catalog := &providerCatalog{
+		Providers: builtinProviderCatalog(),
+	}
+	_, _, err := resolveRuntimeSelection(catalog, emptyProviderAuthState(), modelRef{
+		ProviderID: mindsporeCLIFreeProviderID,
+		ModelID:    "kimi-k2.5",
+	})
+	if err == nil {
+		t.Fatal("resolveRuntimeSelection() error = nil, want login requirement")
+	}
+}
+
+func TestResolveRuntimeSelectionForFreeProviderUsesPresetCredential(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Bearer user-token"; got != want {
+			t.Fatalf("Authorization = %q, want %q", got, want)
+		}
+		if r.URL.Path != "/model-presets/kimi-k2.5-free/credential" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/model-presets/kimi-k2.5-free/credential")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"api_key": "server-kimi-key"})
+	}))
+	defer srv.Close()
+
+	if err := saveCredentials(&credentials{
+		ServerURL: srv.URL,
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
+
+	catalog := &providerCatalog{
+		Providers: builtinProviderCatalog(),
+	}
+	cfg, presetID, err := resolveRuntimeSelection(catalog, emptyProviderAuthState(), modelRef{
+		ProviderID: mindsporeCLIFreeProviderID,
+		ModelID:    "kimi-k2.5",
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSelection() error = %v", err)
+	}
+	if got, want := presetID, "kimi-k2.5-free"; got != want {
+		t.Fatalf("presetID = %q, want %q", got, want)
+	}
+	if got, want := cfg.Provider, "anthropic"; got != want {
+		t.Fatalf("cfg.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Key, "server-kimi-key"; got != want {
+		t.Fatalf("cfg.Key = %q, want %q", got, want)
+	}
+}
+
+func TestApplyResolvedModelConfigMutatesConfig(t *testing.T) {
+	cfg := configs.DefaultConfig()
+	cfg.Model.Provider = "openai-completion"
+	cfg.Model.URL = "https://api.openai.com/v1"
+	cfg.Model.Model = ""
+	cfg.Model.Key = ""
+
+	applyResolvedModelConfig(cfg, configs.ModelConfig{
+		Provider: "anthropic",
+		URL:      "https://api.kimi.com/coding/",
+		Model:    "kimi-k2.5",
+		Key:      "server-kimi-key",
+	})
+
+	if got, want := cfg.Model.Provider, "anthropic"; got != want {
+		t.Fatalf("cfg.Model.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.URL, "https://api.kimi.com/coding/"; got != want {
+		t.Fatalf("cfg.Model.URL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.Model, "kimi-k2.5"; got != want {
+		t.Fatalf("cfg.Model.Model = %q, want %q", got, want)
+	}
+}

--- a/internal/app/provider_state.go
+++ b/internal/app/provider_state.go
@@ -1,0 +1,217 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	authStatePathOverride  string
+	modelStatePathOverride string
+)
+
+type providerAuthState struct {
+	Providers map[string]providerAuthEntry `json:"providers,omitempty"`
+}
+
+type providerAuthEntry struct {
+	ProviderID string `json:"provider_id"`
+	APIKey     string `json:"api_key,omitempty"`
+}
+
+type modelSelectionState struct {
+	Active    *modelRef  `json:"active,omitempty"`
+	Recents   []modelRef `json:"recent,omitempty"`
+	Favorites []modelRef `json:"favorites,omitempty"`
+}
+
+type modelRef struct {
+	ProviderID string `json:"provider_id"`
+	ModelID    string `json:"model_id"`
+}
+
+func authStatePath() string {
+	if authStatePathOverride != "" {
+		return authStatePathOverride
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mscli", "auth.json")
+}
+
+func modelStatePath() string {
+	if modelStatePathOverride != "" {
+		return modelStatePathOverride
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mscli", "model.json")
+}
+
+func loadProviderAuthState() (*providerAuthState, error) {
+	data, err := os.ReadFile(authStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return emptyProviderAuthState(), nil
+		}
+		return nil, err
+	}
+
+	var state providerAuthState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	state.normalize()
+	return &state, nil
+}
+
+func saveProviderAuthState(state *providerAuthState) error {
+	if state == nil {
+		state = emptyProviderAuthState()
+	}
+	state.normalize()
+
+	path := authStatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func loadModelSelectionState() (*modelSelectionState, error) {
+	data, err := os.ReadFile(modelStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return emptyModelSelectionState(), nil
+		}
+		return nil, err
+	}
+
+	var state modelSelectionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	state.normalize()
+	return &state, nil
+}
+
+func saveModelSelectionState(state *modelSelectionState) error {
+	if state == nil {
+		state = emptyModelSelectionState()
+	}
+	state.normalize()
+
+	path := modelStatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func emptyProviderAuthState() *providerAuthState {
+	return &providerAuthState{
+		Providers: map[string]providerAuthEntry{},
+	}
+}
+
+func emptyModelSelectionState() *modelSelectionState {
+	return &modelSelectionState{
+		Recents:   []modelRef{},
+		Favorites: []modelRef{},
+	}
+}
+
+func (s *providerAuthState) normalize() {
+	if s == nil {
+		return
+	}
+	if s.Providers == nil {
+		s.Providers = map[string]providerAuthEntry{}
+		return
+	}
+
+	normalized := make(map[string]providerAuthEntry, len(s.Providers))
+	for id, entry := range s.Providers {
+		entry.ProviderID = normalizedProviderID(entry.ProviderID)
+		key := normalizedProviderID(id)
+		if key == "" {
+			key = entry.ProviderID
+		}
+		if key == "" {
+			continue
+		}
+		if entry.ProviderID == "" {
+			entry.ProviderID = key
+		}
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		normalized[key] = entry
+	}
+	s.Providers = normalized
+}
+
+func (s *modelSelectionState) normalize() {
+	if s == nil {
+		return
+	}
+	if s.Active != nil {
+		normalized := s.Active.normalized()
+		if normalized.empty() {
+			s.Active = nil
+		} else {
+			s.Active = &normalized
+		}
+	}
+	s.Recents = normalizeModelRefs(s.Recents)
+	s.Favorites = normalizeModelRefs(s.Favorites)
+}
+
+func normalizeModelRefs(refs []modelRef) []modelRef {
+	if len(refs) == 0 {
+		return []modelRef{}
+	}
+
+	seen := make(map[string]struct{}, len(refs))
+	out := make([]modelRef, 0, len(refs))
+	for _, ref := range refs {
+		normalized := ref.normalized()
+		if normalized.empty() {
+			continue
+		}
+		key := normalized.key()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func (r modelRef) normalized() modelRef {
+	return modelRef{
+		ProviderID: normalizedProviderID(r.ProviderID),
+		ModelID:    strings.TrimSpace(r.ModelID),
+	}
+}
+
+func (r modelRef) key() string {
+	normalized := r.normalized()
+	return normalized.ProviderID + ":" + normalized.ModelID
+}
+
+func (r modelRef) empty() bool {
+	normalized := r.normalized()
+	return normalized.ProviderID == "" || normalized.ModelID == ""
+}
+
+func normalizedProviderID(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
+}

--- a/internal/app/provider_state_test.go
+++ b/internal/app/provider_state_test.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAuthStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	origPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(dir, "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origPath })
+
+	state := &providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {
+				ProviderID: "openrouter",
+				APIKey:     "sk-test",
+			},
+		},
+	}
+	if err := saveProviderAuthState(state); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
+	}
+
+	loaded, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	entry, ok := loaded.Providers["openrouter"]
+	if !ok {
+		t.Fatalf("loaded auth providers = %#v, want openrouter entry", loaded.Providers)
+	}
+	if got, want := entry.APIKey, "sk-test"; got != want {
+		t.Fatalf("entry.APIKey = %q, want %q", got, want)
+	}
+}
+
+func TestLoadProviderAuthStateMissingReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	origPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(dir, "missing", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origPath })
+
+	loaded, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	if len(loaded.Providers) != 0 {
+		t.Fatalf("len(loaded.Providers) = %d, want 0", len(loaded.Providers))
+	}
+}
+
+func TestModelStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	origPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(dir, "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origPath })
+
+	state := &modelSelectionState{
+		Active: &modelRef{
+			ProviderID: "mindspore-cli-free",
+			ModelID:    "kimi-k2.5",
+		},
+		Recents: []modelRef{
+			{ProviderID: "mindspore-cli-free", ModelID: "kimi-k2.5"},
+			{ProviderID: "openrouter", ModelID: "anthropic/claude-sonnet-4.5"},
+		},
+		Favorites: []modelRef{
+			{ProviderID: "openrouter", ModelID: "anthropic/claude-sonnet-4.5"},
+		},
+	}
+	if err := saveModelSelectionState(state); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
+
+	loaded, err := loadModelSelectionState()
+	if err != nil {
+		t.Fatalf("loadModelSelectionState() error = %v", err)
+	}
+	if loaded.Active == nil {
+		t.Fatal("loaded.Active = nil, want value")
+	}
+	if got, want := loaded.Active.ProviderID, "mindspore-cli-free"; got != want {
+		t.Fatalf("loaded.Active.ProviderID = %q, want %q", got, want)
+	}
+	if got, want := len(loaded.Recents), 2; got != want {
+		t.Fatalf("len(loaded.Recents) = %d, want %d", got, want)
+	}
+	if got, want := len(loaded.Favorites), 1; got != want {
+		t.Fatalf("len(loaded.Favorites) = %d, want %d", got, want)
+	}
+}
+
+func TestLoadModelSelectionStateMissingReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	origPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(dir, "missing", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origPath })
+
+	loaded, err := loadModelSelectionState()
+	if err != nil {
+		t.Fatalf("loadModelSelectionState() error = %v", err)
+	}
+	if loaded.Active != nil {
+		t.Fatalf("loaded.Active = %#v, want nil", loaded.Active)
+	}
+	if len(loaded.Recents) != 0 {
+		t.Fatalf("len(loaded.Recents) = %d, want 0", len(loaded.Recents))
+	}
+	if len(loaded.Favorites) != 0 {
+		t.Fatalf("len(loaded.Favorites) = %d, want 0", len(loaded.Favorites))
+	}
+}
+
+func TestModelSelectionStateNormalizeDeduplicatesRecentAndFavorites(t *testing.T) {
+	state := &modelSelectionState{
+		Recents: []modelRef{
+			{ProviderID: "openrouter", ModelID: "gpt-4o"},
+			{ProviderID: "openrouter", ModelID: "gpt-4o"},
+			{ProviderID: " mindspore-cli-free ", ModelID: " kimi-k2.5 "},
+		},
+		Favorites: []modelRef{
+			{ProviderID: " mindspore-cli-free ", ModelID: " kimi-k2.5 "},
+			{ProviderID: "mindspore-cli-free", ModelID: "kimi-k2.5"},
+		},
+	}
+
+	state.normalize()
+
+	if got, want := len(state.Recents), 2; got != want {
+		t.Fatalf("len(state.Recents) = %d, want %d", got, want)
+	}
+	if got, want := state.Recents[1].ProviderID, "mindspore-cli-free"; got != want {
+		t.Fatalf("state.Recents[1].ProviderID = %q, want %q", got, want)
+	}
+	if got, want := state.Recents[1].ModelID, "kimi-k2.5"; got != want {
+		t.Fatalf("state.Recents[1].ModelID = %q, want %q", got, want)
+	}
+	if got, want := len(state.Favorites), 1; got != want {
+		t.Fatalf("len(state.Favorites) = %d, want %d", got, want)
+	}
+}

--- a/internal/app/provider_workflow.go
+++ b/internal/app/provider_workflow.go
@@ -1,0 +1,469 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+type providerWorkflowState struct {
+	catalog    *providerCatalog
+	authState  *providerAuthState
+	modelState *modelSelectionState
+	loggedIn   bool
+}
+
+type logicalModelSelectionResult struct {
+	ProviderLabel string
+}
+
+type providerCatalogLoadMode int
+
+const (
+	providerCatalogLoadCacheFirst providerCatalogLoadMode = iota
+	providerCatalogLoadBlocking
+)
+
+func (a *Application) loadProviderWorkflowState(mode providerCatalogLoadMode) (*providerWorkflowState, error) {
+	appCfg, err := loadAppConfig()
+	if err != nil {
+		return nil, err
+	}
+	var catalog *providerCatalog
+	switch mode {
+	case providerCatalogLoadBlocking:
+		catalog, err = loadProviderCatalogBlocking(appCfg.ExtraProviders)
+	default:
+		catalog, err = loadProviderCatalog(nil, appCfg.ExtraProviders)
+	}
+	if err != nil {
+		return nil, err
+	}
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		return nil, err
+	}
+	modelState, err := loadModelSelectionState()
+	if err != nil {
+		return nil, err
+	}
+	return &providerWorkflowState{
+		catalog:    catalog,
+		authState:  authState,
+		modelState: modelState,
+		loggedIn:   isLoggedIn(),
+	}, nil
+}
+
+func (a *Application) emitConnectPopup(canEscape bool) {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		a.emitToolError("connect", "Failed to load provider catalog: %v", err)
+		return
+	}
+
+	options := buildConnectProviderOptions(state.catalog, state.loggedIn)
+
+	a.EventCh <- model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:         "Connect Provider",
+			InputLabel:    "API key",
+			Screen:        model.SetupScreenPresetPicker,
+			PresetOptions: options,
+			PresetSelected: (&model.SetupPopup{
+				PresetOptions: options,
+			}).FirstSelectablePreset(),
+			CanEscape:  canEscape,
+			BackCloses: true,
+		},
+	}
+}
+
+func (a *Application) emitModelPicker() {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		a.emitToolError("model", "Failed to load models: %v", err)
+		return
+	}
+	a.emitModelPickerWithState(state)
+}
+
+func (a *Application) emitModelPickerWithState(state *providerWorkflowState) {
+	if state == nil {
+		a.EventCh <- model.Event{
+			Type:    model.AgentReply,
+			Message: "No models available. Run /connect to configure a provider.",
+		}
+		return
+	}
+
+	options := buildModelPickerOptions(state.catalog, state.authState, state.modelState, state.loggedIn)
+	if len(options) == 0 {
+		a.EventCh <- model.Event{
+			Type:    model.AgentReply,
+			Message: "No models available. Run /connect to configure a provider.",
+		}
+		return
+	}
+
+	selected := 0
+	if state.modelState != nil && state.modelState.Active != nil {
+		activeID := state.modelState.Active.key()
+		for i, opt := range options {
+			if opt.ID == activeID {
+				selected = i
+				break
+			}
+		}
+	} else {
+		selected = firstSelectableOptionIndex(options)
+	}
+
+	a.EventCh <- model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title:       "Select model",
+			Options:     options,
+			Selected:    selected,
+			ActionID:    "model_picker",
+			SearchQuery: "",
+		},
+	}
+}
+
+func buildConnectProviderOptions(catalog *providerCatalog, loggedIn bool) []model.SelectionOption {
+	if catalog == nil {
+		return nil
+	}
+	popularProviders, otherProviders := partitionConnectProviders(catalog.Providers, loggedIn)
+	options := make([]model.SelectionOption, 0, len(catalog.Providers)+4)
+	if len(popularProviders) > 0 {
+		options = append(options, model.SelectionOption{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true})
+	}
+	for _, provider := range popularProviders {
+		options = append(options, connectProviderOption(provider, loggedIn))
+	}
+	if len(otherProviders) > 0 {
+		if len(options) > 0 {
+			options = append(options, model.SelectionOption{ID: "__separator__connect", Separator: true, Disabled: true})
+		}
+		options = append(options, model.SelectionOption{ID: "__header__other", Label: "Other", Header: true, Disabled: true})
+	}
+	for _, provider := range otherProviders {
+		options = append(options, connectProviderOption(provider, loggedIn))
+	}
+	return options
+}
+
+func connectProviderOption(provider providerCatalogEntry, loggedIn bool) model.SelectionOption {
+	opt := model.SelectionOption{
+		ID:            provider.ID,
+		Label:         provider.Label,
+		RequiresInput: provider.Protocol != "mindspore-cli-free",
+	}
+	if provider.Protocol == "mindspore-cli-free" {
+		if loggedIn {
+			opt.Desc = "(Recommended)"
+			opt.RequiresInput = false
+		} else {
+			opt.Desc = "(require login)"
+			opt.Disabled = true
+			opt.RequiresInput = false
+		}
+		return opt
+	}
+	return opt
+}
+
+func buildProviderScopedModelPicker(provider providerCatalogEntry) *model.SelectionPopup {
+	options := make([]model.SelectionOption, 0, len(provider.Models))
+	for _, m := range provider.Models {
+		options = append(options, model.SelectionOption{
+			ID:    modelRef{ProviderID: provider.ID, ModelID: m.ID}.key(),
+			Label: m.Label,
+		})
+	}
+	return &model.SelectionPopup{
+		Title:       "Select model",
+		Options:     options,
+		Selected:    firstSelectableOptionIndex(options),
+		ActionID:    "connect_provider_model_picker:" + provider.ID,
+		SearchQuery: "",
+	}
+}
+
+func firstSelectableOptionIndex(options []model.SelectionOption) int {
+	for i, opt := range options {
+		if opt.Selectable() {
+			return i
+		}
+	}
+	return 0
+}
+
+func buildModelPickerOptions(catalog *providerCatalog, authState *providerAuthState, modelState *modelSelectionState, loggedIn bool) []model.SelectionOption {
+	if catalog == nil {
+		return nil
+	}
+	usable := usableProviders(catalog, authState, loggedIn)
+	options := make([]model.SelectionOption, 0)
+	const recentDisplayLimit = 5
+
+	addModelRefs := func(title string, refs []modelRef, limit int, showProvider bool) {
+		if len(refs) == 0 {
+			return
+		}
+
+		group := make([]model.SelectionOption, 0, len(refs)+1)
+		group = append(group, model.SelectionOption{ID: "__header__" + title, Label: title, Header: true, Disabled: true})
+		count := 0
+		for _, ref := range refs {
+			provider, ok := findProviderInList(usable, ref.ProviderID)
+			if !ok {
+				continue
+			}
+			label := modelLabelForRef(provider, ref.ModelID)
+			desc := ""
+			if showProvider {
+				desc = "· " + provider.Label
+			}
+			group = append(group, model.SelectionOption{
+				ID:    ref.key(),
+				Label: label,
+				Desc:  desc,
+			})
+			count++
+			if limit > 0 && count >= limit {
+				break
+			}
+		}
+		if count == 0 {
+			return
+		}
+		if len(options) > 0 {
+			options = append(options, model.SelectionOption{ID: "__separator__" + title, Separator: true, Disabled: true})
+		}
+		options = append(options, group...)
+	}
+
+	if modelState != nil {
+		addModelRefs("Recent", modelState.Recents, recentDisplayLimit, true)
+		addModelRefs("Favorites", modelState.Favorites, 0, false)
+	}
+
+	for _, provider := range usable {
+		if len(options) > 0 {
+			options = append(options, model.SelectionOption{ID: "__separator__provider:" + provider.ID, Separator: true, Disabled: true})
+		}
+		options = append(options, model.SelectionOption{ID: "__header__provider:" + provider.ID, Label: provider.Label, Header: true, Disabled: true})
+		for _, m := range provider.Models {
+			options = append(options, model.SelectionOption{
+				ID:    modelRef{ProviderID: provider.ID, ModelID: m.ID}.key(),
+				Label: m.Label,
+			})
+		}
+	}
+	return options
+}
+
+func partitionConnectProviders(providers []providerCatalogEntry, loggedIn bool) ([]providerCatalogEntry, []providerCatalogEntry) {
+	popular := make([]providerCatalogEntry, 0, 5)
+	other := make([]providerCatalogEntry, 0, len(providers))
+
+	providerByID := make(map[string]providerCatalogEntry, len(providers))
+	for _, provider := range providers {
+		providerByID[provider.ID] = provider
+	}
+
+	if loggedIn {
+		if provider, ok := providerByID[mindsporeCLIFreeProviderID]; ok {
+			popular = append(popular, provider)
+			delete(providerByID, mindsporeCLIFreeProviderID)
+		}
+	}
+
+	for _, id := range connectPopularProviderIDs {
+		if provider, ok := providerByID[id]; ok {
+			popular = append(popular, provider)
+			delete(providerByID, id)
+		}
+	}
+
+	if !loggedIn {
+		if provider, ok := providerByID[mindsporeCLIFreeProviderID]; ok {
+			other = append(other, provider)
+			delete(providerByID, mindsporeCLIFreeProviderID)
+		}
+	}
+
+	rest := make([]providerCatalogEntry, 0, len(providerByID))
+	for _, provider := range providerByID {
+		rest = append(rest, provider)
+	}
+	sort.Slice(rest, func(i, j int) bool {
+		return strings.ToLower(rest[i].Label) < strings.ToLower(rest[j].Label)
+	})
+	other = append(other, rest...)
+	return popular, other
+}
+
+func usableProviders(catalog *providerCatalog, authState *providerAuthState, loggedIn bool) []providerCatalogEntry {
+	if catalog == nil {
+		return nil
+	}
+	out := make([]providerCatalogEntry, 0, len(catalog.Providers))
+	for _, provider := range catalog.Providers {
+		if provider.Protocol == "mindspore-cli-free" {
+			if loggedIn {
+				out = append(out, provider)
+			}
+			continue
+		}
+		if authState != nil {
+			if entry, ok := authState.Providers[provider.ID]; ok && strings.TrimSpace(entry.APIKey) != "" {
+				out = append(out, provider)
+			}
+		}
+	}
+	return out
+}
+
+func findProviderInList(providers []providerCatalogEntry, id string) (providerCatalogEntry, bool) {
+	for _, provider := range providers {
+		if provider.ID == normalizedProviderID(id) {
+			return provider, true
+		}
+	}
+	return providerCatalogEntry{}, false
+}
+
+func modelLabelForRef(provider providerCatalogEntry, modelID string) string {
+	for _, m := range provider.Models {
+		if m.ID == strings.TrimSpace(modelID) {
+			return m.Label
+		}
+	}
+	return strings.TrimSpace(modelID)
+}
+
+func providerDisplayLabel(catalog *providerCatalog, providerID string) string {
+	if catalog != nil {
+		if provider, ok := catalog.Provider(providerID); ok && strings.TrimSpace(provider.Label) != "" {
+			return strings.TrimSpace(provider.Label)
+		}
+	}
+	return runtimeProviderDisplayLabel(providerID)
+}
+
+func runtimeProviderDisplayLabel(providerID string) string {
+	switch normalizedProviderID(providerID) {
+	case "openai", "openai-completion":
+		return "OpenAI"
+	case "openai-responses":
+		return "OpenAI Responses"
+	case "anthropic":
+		return "Anthropic"
+	case mindsporeCLIFreeProviderID:
+		return "MindSpore CLI Free"
+	default:
+		if label := canonicalProviderLabel(providerID, ""); label != "" {
+			return label
+		}
+		return strings.TrimSpace(providerID)
+	}
+}
+
+func (a *Application) connectProvider(providerID, apiKey string) error {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		return err
+	}
+	provider, ok := state.catalog.Provider(providerID)
+	if !ok {
+		state, err = a.loadProviderWorkflowState(providerCatalogLoadBlocking)
+		if err != nil {
+			return err
+		}
+		provider, ok = state.catalog.Provider(providerID)
+	}
+	if !ok {
+		return fmt.Errorf("unknown provider %q", providerID)
+	}
+
+	if provider.Protocol == "mindspore-cli-free" {
+		if !state.loggedIn {
+			return fmt.Errorf("MindSpore CLI Free requires /login first")
+		}
+		a.EventCh <- model.Event{Type: model.ModelSetupClose}
+		a.emitModelPickerWithState(state)
+		return nil
+	}
+
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return fmt.Errorf("provider %s requires api key", provider.Label)
+	}
+	state.authState.Providers[provider.ID] = providerAuthEntry{
+		ProviderID: provider.ID,
+		APIKey:     apiKey,
+	}
+	if err := saveProviderAuthState(state.authState); err != nil {
+		return err
+	}
+
+	a.EventCh <- model.Event{Type: model.ModelSetupClose}
+	a.EventCh <- model.Event{
+		Type:  model.ModelPickerOpen,
+		Popup: buildProviderScopedModelPicker(provider),
+	}
+	return nil
+}
+
+func (a *Application) activateLogicalModelSelection(providerID, modelID string) (logicalModelSelectionResult, error) {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+	if _, ok := state.catalog.Provider(providerID); !ok {
+		state, err = a.loadProviderWorkflowState(providerCatalogLoadBlocking)
+		if err != nil {
+			return logicalModelSelectionResult{}, err
+		}
+	}
+
+	resolved, presetID, err := resolveRuntimeSelection(state.catalog, state.authState, modelRef{
+		ProviderID: providerID,
+		ModelID:    modelID,
+	})
+	if err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+
+	a.restoreModelConfigFromPreset()
+	a.Config.Model.URL = resolved.URL
+	if err := a.SetProvider(resolved.Provider, resolved.Model, resolved.Key); err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+
+	a.activeModelPresetID = presetID
+	if a.activeModelPresetID == "" {
+		a.activeModelPresetID = ""
+	}
+
+	if state.modelState == nil {
+		state.modelState = emptyModelSelectionState()
+	}
+	selected := modelRef{ProviderID: providerID, ModelID: modelID}.normalized()
+	state.modelState.Active = &selected
+	state.modelState.Recents = append([]modelRef{selected}, state.modelState.Recents...)
+	state.modelState.normalize()
+	if err := saveModelSelectionState(state.modelState); err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+	return logicalModelSelectionResult{
+		ProviderLabel: providerDisplayLabel(state.catalog, providerID),
+	}, nil
+}

--- a/internal/app/provider_workflow_test.go
+++ b/internal/app/provider_workflow_test.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestBuildModelPickerOptionsIncludesRecentGroup(t *testing.T) {
+	catalog := &providerCatalog{
+		Providers: []providerCatalogEntry{
+			{
+				ID:       "openai",
+				Label:    "OpenAI",
+				Protocol: "openai-chat",
+				Models: []modelCatalogEntry{
+					{ProviderID: "openai", ID: "gpt-4.1", Label: "GPT-4.1"},
+					{ProviderID: "openai", ID: "gpt-4.1-mini", Label: "GPT-4.1 Mini"},
+					{ProviderID: "openai", ID: "gpt-4o", Label: "GPT-4o"},
+					{ProviderID: "openai", ID: "gpt-4o-mini", Label: "GPT-4o Mini"},
+					{ProviderID: "openai", ID: "o3", Label: "o3"},
+					{ProviderID: "openai", ID: "o4-mini", Label: "o4-mini"},
+				},
+			},
+		},
+	}
+	authState := &providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openai": {ProviderID: "openai", APIKey: "sk-test"},
+		},
+	}
+	modelState := &modelSelectionState{
+		Recents: []modelRef{
+			{ProviderID: "missing", ModelID: "gone"},
+			{ProviderID: "openai", ModelID: "gpt-4.1"},
+			{ProviderID: "openai", ModelID: "gpt-4.1-mini"},
+			{ProviderID: "openai", ModelID: "gpt-4o"},
+			{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+			{ProviderID: "openai", ModelID: "o3"},
+			{ProviderID: "openai", ModelID: "o4-mini"},
+		},
+	}
+
+	options := buildModelPickerOptions(catalog, authState, modelState, false)
+
+	wantIDs := []string{
+		"__header__Recent",
+		"openai:gpt-4.1",
+		"openai:gpt-4.1-mini",
+		"openai:gpt-4o",
+		"openai:gpt-4o-mini",
+		"openai:o3",
+		"__separator__provider:openai",
+		"__header__provider:openai",
+	}
+	if len(options) < len(wantIDs) {
+		t.Fatalf("len(options) = %d, want at least %d", len(options), len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if got := options[i].ID; got != want {
+			t.Fatalf("options[%d].ID = %q, want %q", i, got, want)
+		}
+	}
+	if got, want := options[1].Label, "GPT-4.1"; got != want {
+		t.Fatalf("options[1].Label = %q, want %q", got, want)
+	}
+	if got, want := options[1].Desc, "· OpenAI"; got != want {
+		t.Fatalf("options[1].Desc = %q, want %q", got, want)
+	}
+	if got := options[7].Desc; got != "" {
+		t.Fatalf("options[7].Desc = %q, want empty provider-group entry desc", got)
+	}
+}
+
+func TestPartitionConnectProvidersUsesConfiguredPopularOrder(t *testing.T) {
+	providers := []providerCatalogEntry{
+		{ID: "openrouter", Label: "OpenRouter"},
+		{ID: "deepseek", Label: "DeepSeek"},
+		{ID: "openai", Label: "OpenAI"},
+		{ID: "kimi-for-coding", Label: "Kimi for Coding"},
+		{ID: "anthropic", Label: "Anthropic"},
+	}
+
+	popular, other := partitionConnectProviders(providers, false)
+
+	wantPopularIDs := []string{"anthropic", "openai", "kimi-for-coding", "deepseek"}
+	if len(popular) != len(wantPopularIDs) {
+		t.Fatalf("len(popular) = %d, want %d", len(popular), len(wantPopularIDs))
+	}
+	for i, want := range wantPopularIDs {
+		if got := popular[i].ID; got != want {
+			t.Fatalf("popular[%d].ID = %q, want %q", i, got, want)
+		}
+	}
+	if len(other) != 1 || other[0].ID != "openrouter" {
+		t.Fatalf("other = %#v, want only openrouter", other)
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mindspore-lab/mindspore-cli/ui/theme"
 )
 
-const provideAPIKeyFirstMsg = "LLM unavailable: provide api key first, or /login and switch to free model."
+const provideAPIKeyFirstMsg = "LLM unavailable: run /connect to configure a provider."
 const interruptActiveTaskToken = "__interrupt_active_task__"
 const internalPermissionsActionPrefix = "\x00permissions:"
 const historyReplayReadyToken = "__history_replay_ready__"
@@ -90,10 +90,11 @@ func (a *Application) runReal() error {
 	render.InitStyles()
 	ui.InitStyles()
 
+	providerDisplay := a.initialProviderDisplayLabel()
 	userCh := make(chan string, 8)
-	tui := ui.New(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window)
+	tui := ui.New(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window, providerDisplay)
 	if a.replayOnly {
-		tui = ui.NewReplay(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window)
+		tui = ui.NewReplay(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window, providerDisplay)
 	} else {
 		if history, err := loadInputHistoryForWorkdir(a.WorkDir); err == nil {
 			tui = tui.SeedInputHistory(history)
@@ -123,6 +124,26 @@ func (a *Application) runReal() error {
 	_, err := p.Run()
 	close(userCh)
 	return err
+}
+
+func (a *Application) initialProviderDisplayLabel() string {
+	if strings.TrimSpace(a.Config.Model.Model) == "" {
+		return ""
+	}
+	modelState, err := loadModelSelectionState()
+	if err == nil && modelState != nil && modelState.Active != nil {
+		if strings.TrimSpace(modelState.Active.ModelID) == strings.TrimSpace(a.Config.Model.Model) {
+			if appCfg, cfgErr := loadAppConfig(); cfgErr == nil {
+				for _, extra := range appCfg.ExtraProviders {
+					if normalizedProviderID(extra.ID) == normalizedProviderID(modelState.Active.ProviderID) && strings.TrimSpace(extra.Label) != "" {
+						return strings.TrimSpace(extra.Label)
+					}
+				}
+			}
+			return runtimeProviderDisplayLabel(modelState.Active.ProviderID)
+		}
+	}
+	return runtimeProviderDisplayLabel(a.Config.Model.Provider)
 }
 
 func tuiProgramOptions(extra ...tea.ProgramOption) []tea.ProgramOption {
@@ -190,6 +211,11 @@ func (a *Application) processInput(input string) {
 	if strings.HasPrefix(trimmed, modelSetupToken+" ") {
 		parts := strings.Fields(trimmed)
 		a.cmdModelSetup(parts[1:])
+		return
+	}
+	if strings.HasPrefix(trimmed, connectProviderToken+" ") {
+		parts := strings.Fields(trimmed)
+		a.cmdConnect(parts[1:])
 		return
 	}
 

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -163,41 +163,26 @@ func Wire(cfg BootstrapConfig) (*Application, error) {
 		}
 	}
 
-	// If LLM is not ready (missing API key), try detecting saved model config.
+	// If LLM is not ready (missing API key), try restoring the new persistent
+	// provider/model selection, then deprecated preset compatibility, then
+	// logged-in default free provider.
 	var needsSetupPopup bool
 	var activePresetID string
 	var savedModelToken string
 	if !llmReady {
-		mode, appCfg := detectModelMode()
-		switch mode {
-		case modelModeMSCLIProvided:
-			savedModelToken = appCfg.ModelToken
-			if preset, ok := resolveBuiltinModelPreset(appCfg.ModelPresetID); ok {
-				config.Model.URL = preset.BaseURL
-				config.Model.Provider = preset.Provider
-				config.Model.Model = preset.Model
-				// Always re-fetch the API key from the server instead of
-				// reusing the cached one — it may have been rotated.
-				apiKey := appCfg.ModelToken
-				if freshKey, fetchErr := fetchPresetAPIKey(preset); fetchErr == nil {
-					apiKey = freshKey
-					// Update the saved config with the fresh key.
-					appCfg.ModelToken = freshKey
-					_ = saveAppConfig(appCfg)
-				}
-				config.Model.Key = apiKey
-				savedModelToken = apiKey
-				configs.RefreshModelTokenDefaults(config, previousModel)
-				provider, err = initProvider(config.Model, llm.ResolveOptions{PreferConfigAPIKey: true})
-				if err == nil {
-					llmReady = true
-					activePresetID = preset.ID
-				}
+		restoreResult, restoreErr := restoreProviderSelection(config)
+		if restoreErr != nil {
+			return nil, fmt.Errorf("restore provider selection: %w", restoreErr)
+		}
+		if restoreResult.Restored {
+			provider, err = initProvider(config.Model, llm.ResolveOptions{
+				PreferConfigAPIKey:  true,
+				PreferConfigBaseURL: true,
+			})
+			if err == nil {
+				llmReady = true
+				activePresetID = restoreResult.ActivePresetID
 			}
-		case modelModeOwnEnv:
-			// Env vars were applied but init still failed for another reason.
-		default:
-			needsSetupPopup = true
 		}
 	}
 

--- a/ui/app.go
+++ b/ui/app.go
@@ -44,6 +44,7 @@ const (
 	interruptActiveTaskToken        = "__interrupt_active_task__"
 	internalPermissionsActionPrefix = "\x00permissions:"
 	modelSetupToken                 = "__model_setup"
+	connectProviderInputToken       = "__connect_provider__"
 )
 
 // Style vars are populated by InitStyles() below.
@@ -72,6 +73,27 @@ func agentMsg(source, msg string, done bool) string {
 		return fmt.Sprintf("%s %-12s: %s", marker, source, msg)
 	}
 	return fmt.Sprintf("%s %s", marker, msg)
+}
+
+func moveSelectionIndex(current, delta int, options []model.SelectionOption) int {
+	n := len(options)
+	if n == 0 {
+		return 0
+	}
+	if delta == 0 {
+		return current
+	}
+	if current < 0 || current >= n {
+		current = 0
+	}
+	next := current
+	for range n {
+		next = (next + delta%n + n) % n
+		if !options[next].Disabled {
+			return next
+		}
+	}
+	return current
 }
 
 var (
@@ -222,9 +244,9 @@ type toolOutputViewState struct {
 
 // New creates a new App driven by the given event channel.
 // userCh may be nil — user input won't be forwarded.
-func New(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int) App {
+func New(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) App {
 	return App{
-		state:            model.NewState(version, workDir, repoURL, modelName, ctxMax),
+		state:            model.NewState(version, workDir, repoURL, modelName, ctxMax, providerName...),
 		input:            components.NewTextInput().WithFileSuggestions(workDir),
 		thinking:         components.NewThinkingSpinner(),
 		eventCh:          ch,
@@ -242,8 +264,8 @@ func New(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL,
 }
 
 // NewReplay creates a TUI instance that starts directly in chat view for playback.
-func NewReplay(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int) App {
-	app := New(ch, userCh, version, workDir, repoURL, modelName, ctxMax)
+func NewReplay(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) App {
+	app := New(ch, userCh, version, workDir, repoURL, modelName, ctxMax, providerName...)
 	app.bootActive = false
 	return app
 }
@@ -807,19 +829,58 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				opt := a.setupPopup.PresetOptions[a.setupPopup.PresetSelected]
 				if !opt.Disabled {
 					a.setupPopup.SelectedPreset = opt
-					a.setupPopup.Screen = model.SetupScreenTokenInput
-					a.setupPopup.TokenError = ""
+					if opt.RequiresInput {
+						a.setupPopup.Screen = model.SetupScreenTokenInput
+						a.setupPopup.TokenError = ""
+					} else if a.userCh != nil {
+						select {
+						case a.userCh <- connectProviderInputToken + " " + a.setupPopup.SelectedPreset.ID:
+						default:
+						}
+					}
 				}
 				return a, nil
 			case "esc":
+				if a.setupPopup.BackCloses {
+					a.setupPopup = nil
+					return a, a.syncModalAltScreen()
+				}
 				a.setupPopup.Screen = model.SetupScreenModeSelect
 				return a, nil
+			case "backspace":
+				runes := []rune(a.setupPopup.SearchQuery)
+				if len(runes) > 0 {
+					a.setupPopup.SearchQuery = string(runes[:len(runes)-1])
+					if strings.TrimSpace(a.setupPopup.SearchQuery) == "" {
+						a.setupPopup.RestoreSearchBaseIfNeeded()
+					} else {
+						a.setupPopup.EnsureSelectablePreset()
+					}
+				}
+				return a, nil
+			default:
+				if msg.Type == tea.KeyRunes {
+					a.setupPopup.BeginSearchIfNeeded()
+					a.setupPopup.SearchQuery += string(msg.Runes)
+					a.setupPopup.EnsureSelectablePreset()
+					return a, nil
+				}
+				if msg.Type == tea.KeySpace {
+					a.setupPopup.BeginSearchIfNeeded()
+					a.setupPopup.SearchQuery += " "
+					a.setupPopup.EnsureSelectablePreset()
+					return a, nil
+				}
 			}
 		case model.SetupScreenTokenInput:
 			switch msg.String() {
 			case "enter":
 				if a.userCh != nil && strings.TrimSpace(a.setupPopup.TokenValue) != "" {
-					cmd := fmt.Sprintf("%s %s %s", modelSetupToken,
+					token := modelSetupToken
+					if a.setupPopup.InputLabel == "API key" {
+						token = connectProviderInputToken
+					}
+					cmd := fmt.Sprintf("%s %s %s", token,
 						a.setupPopup.SelectedPreset.ID,
 						strings.TrimSpace(a.setupPopup.TokenValue))
 					select {
@@ -866,16 +927,16 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		switch msg.String() {
 		case "up", "left":
-			p.Selected--
-			if p.Selected < 0 {
-				p.Selected = len(p.Options) - 1
-			}
+			p.MoveSelection(-1)
 			return a, nil
 		case "down", "right":
-			p.Selected = (p.Selected + 1) % len(p.Options)
+			p.MoveSelection(1)
 			return a, nil
 		case "enter":
 			selected := p.Options[p.Selected]
+			if !selected.Selectable() {
+				return a, nil
+			}
 			a.trainView.SelectionPopup = nil
 			a.modelPicker = nil
 			var input string
@@ -886,6 +947,10 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				input = "/train add perf-feature " + selected.ID
 			case "model_picker":
 				input = "/model " + selected.ID
+			default:
+				if strings.HasPrefix(p.ActionID, "connect_provider_model_picker:") {
+					input = "/model " + selected.ID
+				}
 			}
 			if input != "" && a.userCh != nil {
 				select {
@@ -903,6 +968,43 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return a, tea.Sequence(exitAlt, banner)
 			}
 			return a, combineCmds(exitAlt, banner)
+		case "ctrl+a":
+			if p.ActionID != "model_picker" {
+				return a, nil
+			}
+			a.trainView.SelectionPopup = nil
+			a.modelPicker = nil
+			if a.userCh != nil {
+				select {
+				case a.userCh <- "/connect":
+				default:
+				}
+			}
+			return a, a.syncModalAltScreen()
+		case "backspace":
+			runes := []rune(p.SearchQuery)
+			if len(runes) > 0 {
+				p.SearchQuery = string(runes[:len(runes)-1])
+				if strings.TrimSpace(p.SearchQuery) == "" {
+					p.RestoreSearchBaseIfNeeded()
+				} else {
+					p.EnsureSelectableSelection()
+				}
+			}
+			return a, nil
+		default:
+			if msg.Type == tea.KeyRunes {
+				p.BeginSearchIfNeeded()
+				p.SearchQuery += string(msg.Runes)
+				p.EnsureSelectableSelection()
+				return a, nil
+			}
+			if msg.Type == tea.KeySpace {
+				p.BeginSearchIfNeeded()
+				p.SearchQuery += " "
+				p.EnsureSelectableSelection()
+				return a, nil
+			}
 		}
 		return a, nil
 	}
@@ -1280,6 +1382,7 @@ func (a App) handleEvent(ev model.Event) (tea.Model, tea.Cmd) {
 	case model.ModelUpdate:
 		mi := a.state.Model
 		mi.Name = ev.Message
+		mi.Provider = ev.Provider
 		if ev.CtxMax > 0 {
 			mi.CtxMax = ev.CtxMax
 		}

--- a/ui/app_model_picker_test.go
+++ b/ui/app_model_picker_test.go
@@ -176,3 +176,261 @@ func TestModelSetupPopupSuppressesThinkingIndicatorWithoutClearingState(t *testi
 		t.Fatalf("expected thinking indicator to return after popup close, got:\n%s", view)
 	}
 }
+
+func TestSetupPopupPresetPickerSupportsSearch(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:  "Connect Provider",
+			Screen: model.SetupScreenPresetPicker,
+			PresetOptions: []model.SelectionOption{
+				{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true},
+				{ID: "anthropic", Label: "Anthropic"},
+				{ID: "openai", Label: "OpenAI"},
+			},
+			PresetSelected: 1,
+			CanEscape:      true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("open")})
+	app = next.(App)
+
+	if got, want := app.setupPopup.SearchQuery, "open"; got != want {
+		t.Fatalf("SearchQuery = %q, want %q", got, want)
+	}
+	view := app.View()
+	if !strings.Contains(view, "OpenAI") {
+		t.Fatalf("expected filtered match in view, got:\n%s", view)
+	}
+	if strings.Contains(view, "Anthropic") {
+		t.Fatalf("expected non-matching option filtered out, got:\n%s", view)
+	}
+}
+
+func TestSetupPopupSearchClearRestoresPreviousSelection(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:  "Connect Provider",
+			Screen: model.SetupScreenPresetPicker,
+			PresetOptions: []model.SelectionOption{
+				{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true},
+				{ID: "anthropic", Label: "Anthropic"},
+				{ID: "openai", Label: "OpenAI"},
+			},
+			PresetSelected: 1,
+			CanEscape:      true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("open")})
+	app = next.(App)
+	if got, want := app.setupPopup.PresetSelected, 2; got != want {
+		t.Fatalf("PresetSelected after search = %d, want %d", got, want)
+	}
+
+	for range 4 {
+		next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		app = next.(App)
+	}
+
+	if got, want := app.setupPopup.SearchQuery, ""; got != want {
+		t.Fatalf("SearchQuery after clear = %q, want %q", got, want)
+	}
+	if got, want := app.setupPopup.PresetSelected, 1; got != want {
+		t.Fatalf("PresetSelected after clear = %d, want %d", got, want)
+	}
+}
+
+func TestConnectPopupEscapeClosesInsteadOfShowingModeSelect(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:  "Connect Provider",
+			Screen: model.SetupScreenPresetPicker,
+			PresetOptions: []model.SelectionOption{
+				{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true},
+				{ID: "anthropic", Label: "Anthropic"},
+			},
+			PresetSelected: 1,
+			BackCloses:     true,
+			CanEscape:      true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEscape})
+	app = next.(App)
+
+	if app.setupPopup != nil {
+		t.Fatal("expected connect popup to close on esc")
+	}
+	if view := app.View(); strings.Contains(view, "mscli-provided model") {
+		t.Fatalf("expected old mode-select screen not to appear, got:\n%s", view)
+	}
+}
+
+func TestModelPickerSupportsSearch(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title: "Select model",
+			Options: []model.SelectionOption{
+				{ID: "__header__provider:free", Label: "MindSpore CLI Free", Header: true, Disabled: true},
+				{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+				{ID: "mindspore-cli-free:deepseek-chat", Label: "DeepSeek V3"},
+			},
+			Selected: 1,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("deep")})
+	app = next.(App)
+
+	if got, want := app.modelPicker.SearchQuery, "deep"; got != want {
+		t.Fatalf("SearchQuery = %q, want %q", got, want)
+	}
+	view := app.View()
+	if !strings.Contains(view, "DeepSeek V3") {
+		t.Fatalf("expected filtered match in view, got:\n%s", view)
+	}
+	if strings.Contains(view, "Kimi K2.5") {
+		t.Fatalf("expected non-matching option filtered out, got:\n%s", view)
+	}
+}
+
+func TestModelPickerSearchClearRestoresPreviousSelection(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title: "Select model",
+			Options: []model.SelectionOption{
+				{ID: "__header__provider:free", Label: "MindSpore CLI Free", Header: true, Disabled: true},
+				{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+				{ID: "mindspore-cli-free:deepseek-chat", Label: "DeepSeek V3"},
+			},
+			Selected: 1,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("deep")})
+	app = next.(App)
+	if got, want := app.modelPicker.Selected, 2; got != want {
+		t.Fatalf("Selected after search = %d, want %d", got, want)
+	}
+
+	for range 4 {
+		next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		app = next.(App)
+	}
+
+	if got, want := app.modelPicker.SearchQuery, ""; got != want {
+		t.Fatalf("SearchQuery after clear = %q, want %q", got, want)
+	}
+	if got, want := app.modelPicker.Selected, 1; got != want {
+		t.Fatalf("Selected after clear = %d, want %d", got, want)
+	}
+}
+
+func TestModelPickerCtrlAOpensConnect(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title:    "Select model",
+			ActionID: "model_picker",
+			Options: []model.SelectionOption{
+				{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+				{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+			},
+			Selected: 1,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyCtrlA})
+	app = next.(App)
+
+	if app.modelPicker != nil {
+		t.Fatal("expected model picker to close on ctrl+a")
+	}
+	select {
+	case got := <-userCh:
+		if got != "/connect" {
+			t.Fatalf("user input = %q, want %q", got, "/connect")
+		}
+	default:
+		t.Fatal("expected /connect shortcut to be sent")
+	}
+}
+
+func TestProviderScopedModelPickerEnterSelectsModel(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title:    "Select model",
+			ActionID: "connect_provider_model_picker:openrouter",
+			Options: []model.SelectionOption{
+				{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+			},
+			Selected: 0,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = next.(App)
+
+	if app.modelPicker != nil {
+		t.Fatal("expected provider-scoped model picker to close on enter")
+	}
+	select {
+	case got := <-userCh:
+		if got != "/model openrouter:openai/gpt-4o-mini" {
+			t.Fatalf("user input = %q, want %q", got, "/model openrouter:openai/gpt-4o-mini")
+		}
+	default:
+		t.Fatal("expected selected model command to be sent")
+	}
+}

--- a/ui/inline.go
+++ b/ui/inline.go
@@ -31,6 +31,9 @@ var (
 	bannerValueStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("252"))
 
+	bannerProviderStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("248"))
+
 	cmdOutputStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("245"))
 
@@ -52,13 +55,13 @@ func (a *App) maybePrintBanner() tea.Cmd {
 	}
 	a.bannerPrinted = true
 	return tea.Sequence(
-		tea.Println(RenderBanner(a.state.Version, a.state.WorkDir, a.state.RepoURL, a.state.Model.Name, a.state.Model.CtxMax)),
+		tea.Println(RenderBanner(a.state.Version, a.state.WorkDir, a.state.RepoURL, a.state.Model.Name, a.state.Model.CtxMax, a.state.Model.Provider)),
 		a.signalHistoryReplayReady(),
 	)
 }
 
 // RenderBanner renders the one-shot banner shown after boot in inline mode.
-func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int) string {
+func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) string {
 	ver := strings.TrimSpace(version)
 	// Strip product name prefix (e.g. "MindSpore CLI. v0.5.0" → "v0.5.0")
 	for _, prefix := range []string{"MindSpore CLI. ", "MindSpore CLI. "} {
@@ -69,8 +72,13 @@ func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int) strin
 	}
 	title := bannerTitleStyle.Render("MindSpore CLI") + " " + bannerValueStyle.Render("("+ver+")")
 
+	provider := ""
+	if len(providerName) > 0 {
+		provider = strings.TrimSpace(providerName[0])
+	}
+
 	rows := []string{
-		bannerRow("model", valueOrString(strings.TrimSpace(modelName), "unknown")),
+		bannerModelRow(strings.TrimSpace(modelName), provider),
 		bannerRow("directory", valueOrString(shortenPath(strings.TrimSpace(workDir)), ".")),
 	}
 
@@ -80,6 +88,14 @@ func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int) strin
 
 func bannerRow(label, value string) string {
 	return bannerLabelStyle.Render(label+":") + " " + bannerValueStyle.Render(value)
+}
+
+func bannerModelRow(modelName, providerName string) string {
+	row := bannerLabelStyle.Render("model:") + " " + bannerValueStyle.Render(valueOrString(strings.TrimSpace(modelName), "unknown"))
+	if strings.TrimSpace(providerName) != "" {
+		row += " " + bannerProviderStyle.Render(strings.TrimSpace(providerName))
+	}
+	return row
 }
 
 func (a *App) signalHistoryReplayReady() tea.Cmd {

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -17,6 +17,7 @@ type TaskInfo struct {
 // ModelInfo holds LLM model metadata for the top bar.
 type ModelInfo struct {
 	Name       string
+	Provider   string
 	CtxUsed    int
 	CtxMax     int
 	TokensUsed int
@@ -69,40 +70,40 @@ type Message struct {
 type EventType string
 
 const (
-	TaskUpdated      EventType = "TaskUpdated"
-	ToolCallStart    EventType = "ToolCallStart"
-	CmdStarted       EventType = "CmdStarted"
-	CmdOutput        EventType = "CmdOutput"
-	CmdFinished      EventType = "CmdFinished"
-	AnalysisReady    EventType = "AnalysisReady"
-	AgentReply       EventType = "AgentReply"
-	AgentReplyDelta  EventType = "AgentReplyDelta"
-	PermissionPrompt EventType = "PermissionPrompt"
-	PermissionsView  EventType = "PermissionsView"
-	AgentThinking    EventType = "AgentThinking"
-	ContextNotice    EventType = "ContextNotice"
-	UserInput        EventType = "UserInput"
-	ToolReplay       EventType = "ToolReplay"
-	TokenUpdate      EventType = "TokenUpdate"
-	ToolRead         EventType = "ToolRead"
-	ToolGrep         EventType = "ToolGrep"
-	ToolGlob         EventType = "ToolGlob"
-	ToolEdit         EventType = "ToolEdit"
-	ToolWrite        EventType = "ToolWrite"
-	ToolSkill        EventType = "ToolSkill"
-	ToolWarning      EventType = "ToolWarning"
-	ToolError        EventType = "ToolError"
-	ClearScreen      EventType = "ClearScreen"
-	ModelUpdate      EventType = "ModelUpdate"
+	TaskUpdated          EventType = "TaskUpdated"
+	ToolCallStart        EventType = "ToolCallStart"
+	CmdStarted           EventType = "CmdStarted"
+	CmdOutput            EventType = "CmdOutput"
+	CmdFinished          EventType = "CmdFinished"
+	AnalysisReady        EventType = "AnalysisReady"
+	AgentReply           EventType = "AgentReply"
+	AgentReplyDelta      EventType = "AgentReplyDelta"
+	PermissionPrompt     EventType = "PermissionPrompt"
+	PermissionsView      EventType = "PermissionsView"
+	AgentThinking        EventType = "AgentThinking"
+	ContextNotice        EventType = "ContextNotice"
+	UserInput            EventType = "UserInput"
+	ToolReplay           EventType = "ToolReplay"
+	TokenUpdate          EventType = "TokenUpdate"
+	ToolRead             EventType = "ToolRead"
+	ToolGrep             EventType = "ToolGrep"
+	ToolGlob             EventType = "ToolGlob"
+	ToolEdit             EventType = "ToolEdit"
+	ToolWrite            EventType = "ToolWrite"
+	ToolSkill            EventType = "ToolSkill"
+	ToolWarning          EventType = "ToolWarning"
+	ToolError            EventType = "ToolError"
+	ClearScreen          EventType = "ClearScreen"
+	ModelUpdate          EventType = "ModelUpdate"
 	ModelPickerOpen      EventType = "ModelPickerOpen"
 	ModelSetupOpen       EventType = "ModelSetupOpen"
 	ModelSetupClose      EventType = "ModelSetupClose"
 	ModelSetupTokenError EventType = "ModelSetupTokenError"
-	MouseModeToggle  EventType = "MouseModeToggle"
-	IssueUserUpdate  EventType = "IssueUserUpdate"
-	SkillsNoteUpdate EventType = "SkillsNoteUpdate"
-	TaskDone         EventType = "TaskDone"
-	Done             EventType = "Done"
+	MouseModeToggle      EventType = "MouseModeToggle"
+	IssueUserUpdate      EventType = "IssueUserUpdate"
+	SkillsNoteUpdate     EventType = "SkillsNoteUpdate"
+	TaskDone             EventType = "TaskDone"
+	Done                 EventType = "Done"
 )
 
 // Event is sent from the agent loop to the TUI.
@@ -111,6 +112,7 @@ type Event struct {
 	Type        EventType
 	Task        string
 	Message     string
+	Provider    string
 	RawANSI     bool
 	ToolName    string
 	ToolCallID  string
@@ -123,8 +125,8 @@ type Event struct {
 	Project     *ProjectStatusView
 	Permission  *PermissionPromptData
 	Permissions *PermissionsViewData
-	Popup      *SelectionPopup // non-nil for popup events only
-	SetupPopup *SetupPopup    // non-nil for model setup popup events
+	Popup       *SelectionPopup // non-nil for popup events only
+	SetupPopup  *SetupPopup     // non-nil for model setup popup events
 	BugView     *BugEventData   // non-nil for bug view events only
 	IssueView   *IssueEventData // non-nil for issue view events only
 	Bug         *bugs.Bug       // reserved for lightweight bug payloads
@@ -189,19 +191,24 @@ type State struct {
 }
 
 // NewState returns an initial empty state.
-func NewState(version, workDir, repoURL, modelName string, ctxMax int) State {
+func NewState(version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) State {
 	if modelName == "" {
-		modelName = "No model (/model to configure)"
+		modelName = "No model (/connect to config)"
 	}
 	if ctxMax == 0 {
 		ctxMax = 128000 // Default for models like gpt-4o
+	}
+	currentProvider := ""
+	if len(providerName) > 0 {
+		currentProvider = providerName[0]
 	}
 	return State{
 		Version: version,
 		Tasks:   []TaskInfo{},
 		Model: ModelInfo{
-			Name:   modelName,
-			CtxMax: ctxMax,
+			Name:     modelName,
+			Provider: currentProvider,
+			CtxMax:   ctxMax,
 		},
 		WorkDir:      workDir,
 		RepoURL:      repoURL,

--- a/ui/model/popup_test.go
+++ b/ui/model/popup_test.go
@@ -14,14 +14,14 @@ func TestSetupPopupPresetNavigatesAllItems(t *testing.T) {
 		PresetSelected: 0,
 	}
 
-	// Cursor moves to disabled items (they are visually navigable)
+	// Cursor skips disabled items.
 	popup.MovePresetSelection(1)
 	if popup.PresetSelected != 1 {
 		t.Errorf("expected 1, got %d", popup.PresetSelected)
 	}
 	popup.MovePresetSelection(1)
-	if popup.PresetSelected != 2 {
-		t.Errorf("expected 2, got %d", popup.PresetSelected)
+	if popup.PresetSelected != 0 {
+		t.Errorf("expected wrap to 0, got %d", popup.PresetSelected)
 	}
 	// Wraps around
 	popup.MovePresetSelection(1)

--- a/ui/model/train.go
+++ b/ui/model/train.go
@@ -1,5 +1,7 @@
 package model
 
+import "strings"
+
 // Train-specific UI event types.
 const (
 	TrainModeOpen      EventType = "TrainModeOpen"
@@ -224,17 +226,22 @@ type TrainActionsState struct {
 
 // SelectionPopup is a popup menu shown when an action needs user input.
 type SelectionPopup struct {
-	Title    string
-	Options  []SelectionOption
-	Selected int
-	ActionID string // which action triggered the popup
+	Title       string
+	SearchQuery string
+	Options     []SelectionOption
+	Selected    int
+	SearchBase  int
+	ActionID    string // which action triggered the popup
 }
 
 type SelectionOption struct {
-	ID       string
-	Label    string
-	Desc     string
-	Disabled bool // grayed out, not selectable (e.g. coming soon)
+	ID            string
+	Label         string
+	Desc          string
+	Header        bool
+	Separator     bool
+	Disabled      bool // grayed out, not selectable (e.g. coming soon)
+	RequiresInput bool
 }
 
 // SetupScreen identifies which screen of the model setup popup is shown.
@@ -242,23 +249,28 @@ type SetupScreen int
 
 const (
 	SetupScreenModeSelect   SetupScreen = iota // "mscli-provided" vs "your own model"
-	SetupScreenPresetPicker                     // pick from preset list
-	SetupScreenTokenInput                       // enter token for selected preset
-	SetupScreenEnvInfo                          // show env var examples
+	SetupScreenPresetPicker                    // pick from preset list
+	SetupScreenTokenInput                      // enter token for selected preset
+	SetupScreenEnvInfo                         // show env var examples
 )
 
 // SetupPopup holds the full state of the multi-step model setup popup.
 type SetupPopup struct {
+	Title          string
+	InputLabel     string
+	SearchQuery    string
 	Screen         SetupScreen
-	ModeSelected   int    // 0 = mscli-provided, 1 = your own model
+	ModeSelected   int // 0 = mscli-provided, 1 = your own model
 	PresetOptions  []SelectionOption
 	PresetSelected int
+	SearchBase     int
 	SelectedPreset SelectionOption // set when user picks a preset
 	TokenValue     string
 	TokenError     string // inline error message
 	CurrentMode    string // "mscli-provided", "own", or "" — for (current) badge
 	CurrentPreset  string // preset ID currently active — for (current) badge
 	CanEscape      bool   // false on first boot (no config to fall back to)
+	BackCloses     bool
 }
 
 // MoveModeSelection moves the mode cursor by delta, wrapping around 2 options.
@@ -267,13 +279,162 @@ func (p *SetupPopup) MoveModeSelection(delta int) {
 }
 
 // MovePresetSelection moves the preset cursor by delta, wrapping around all options.
-// Disabled options are visually navigable but cannot be confirmed with enter.
+// Disabled options are skipped.
 func (p *SetupPopup) MovePresetSelection(delta int) {
-	n := len(p.PresetOptions)
-	if n == 0 {
-		return
+	p.PresetSelected = moveFilteredSelection(p.PresetSelected, delta, p.PresetOptions, p.SearchQuery)
+}
+
+func (p *SetupPopup) FirstSelectablePreset() int {
+	return firstSelectableFilteredOption(p.PresetOptions, p.SearchQuery)
+}
+
+func (p *SetupPopup) EnsureSelectablePreset() {
+	p.PresetSelected = ensureFilteredSelection(p.PresetSelected, p.PresetOptions, p.SearchQuery)
+}
+
+func (p *SetupPopup) BeginSearchIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" {
+		p.SearchBase = p.PresetSelected
 	}
-	p.PresetSelected = (p.PresetSelected + delta%n + n) % n
+}
+
+func (p *SetupPopup) RestoreSearchBaseIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" && p.SearchBase >= 0 && p.SearchBase < len(p.PresetOptions) {
+		p.PresetSelected = p.SearchBase
+	}
+}
+
+func (p *SelectionPopup) MoveSelection(delta int) {
+	p.Selected = moveFilteredSelection(p.Selected, delta, p.Options, p.SearchQuery)
+}
+
+func (p *SelectionPopup) EnsureSelectableSelection() {
+	p.Selected = ensureFilteredSelection(p.Selected, p.Options, p.SearchQuery)
+}
+
+func (p *SelectionPopup) BeginSearchIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" {
+		p.SearchBase = p.Selected
+	}
+}
+
+func (p *SelectionPopup) RestoreSearchBaseIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" && p.SearchBase >= 0 && p.SearchBase < len(p.Options) {
+		p.Selected = p.SearchBase
+	}
+}
+
+func (o SelectionOption) Selectable() bool {
+	return !o.Disabled && !o.Header && !o.Separator
+}
+
+func filteredOptionIndices(options []SelectionOption, query string) []int {
+	if len(options) == 0 {
+		return nil
+	}
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		idxs := make([]int, 0, len(options))
+		for i := range options {
+			idxs = append(idxs, i)
+		}
+		return idxs
+	}
+
+	type group struct {
+		header int
+		items  []int
+	}
+	var (
+		groups        []group
+		currentHeader = -1
+		currentItems  []int
+	)
+	flush := func() {
+		if len(currentItems) == 0 {
+			return
+		}
+		items := make([]int, len(currentItems))
+		copy(items, currentItems)
+		groups = append(groups, group{header: currentHeader, items: items})
+		currentItems = nil
+	}
+
+	for i, opt := range options {
+		if opt.Separator {
+			continue
+		}
+		if opt.Header {
+			flush()
+			currentHeader = i
+			continue
+		}
+		if !opt.Selectable() {
+			continue
+		}
+		text := strings.ToLower(strings.TrimSpace(opt.Label + " " + opt.Desc))
+		if strings.Contains(text, query) {
+			currentItems = append(currentItems, i)
+		}
+	}
+	flush()
+
+	result := make([]int, 0)
+	for gi, group := range groups {
+		if gi > 0 {
+			result = append(result, -1)
+		}
+		if group.header >= 0 {
+			result = append(result, group.header)
+		}
+		result = append(result, group.items...)
+	}
+	return result
+}
+
+func FilteredOptionIndicesForRender(options []SelectionOption, query string) []int {
+	return filteredOptionIndices(options, query)
+}
+
+func firstSelectableFilteredOption(options []SelectionOption, query string) int {
+	for _, idx := range filteredOptionIndices(options, query) {
+		if idx >= 0 && options[idx].Selectable() {
+			return idx
+		}
+	}
+	return 0
+}
+
+func ensureFilteredSelection(current int, options []SelectionOption, query string) int {
+	for _, idx := range filteredOptionIndices(options, query) {
+		if idx >= 0 && idx == current && options[idx].Selectable() {
+			return current
+		}
+	}
+	return firstSelectableFilteredOption(options, query)
+}
+
+func moveFilteredSelection(current, delta int, options []SelectionOption, query string) int {
+	if delta == 0 {
+		return current
+	}
+	selectable := make([]int, 0)
+	for _, idx := range filteredOptionIndices(options, query) {
+		if idx >= 0 && options[idx].Selectable() {
+			selectable = append(selectable, idx)
+		}
+	}
+	if len(selectable) == 0 {
+		return 0
+	}
+	pos := 0
+	for i, idx := range selectable {
+		if idx == current {
+			pos = i
+			break
+		}
+	}
+	return selectable[(pos+delta%len(selectable)+len(selectable))%len(selectable)]
 }
 
 type TrainMetricsView struct {

--- a/ui/panels/hintbar.go
+++ b/ui/panels/hintbar.go
@@ -34,7 +34,12 @@ var hints = []hint{
 // RenderHintBar renders the bottom status bar with model, context, and workdir.
 func RenderHintBar(s model.State, width int) string {
 	sep := hintSepStyle.Render("  ")
-	left := hintKeyStyle.Render(s.Model.Name) + sep +
+	modelDisplay := hintKeyStyle.Render(s.Model.Name)
+	if strings.TrimSpace(s.Model.Provider) != "" {
+		providerStyle := hintKeyStyle.Foreground(lipgloss.Color("245"))
+		modelDisplay += " " + providerStyle.Render(strings.TrimSpace(s.Model.Provider))
+	}
+	left := modelDisplay + sep +
 		hintDescStyle.Render(formatCtxHint(s.Model.CtxUsed, s.Model.CtxMax)) + sep +
 		hintDescStyle.Render(shortenHintPath(s.WorkDir))
 

--- a/ui/panels/hintbar_test.go
+++ b/ui/panels/hintbar_test.go
@@ -1,0 +1,19 @@
+package panels
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+func TestRenderHintBarIncludesModelAndProvider(t *testing.T) {
+	state := model.NewState("test", "/tmp/project", "", "Kimi K2.5", 262144, "MindSpore CLI Free")
+
+	result := RenderHintBar(state, 120)
+	for _, want := range []string{"Kimi K2.5", "MindSpore CLI Free", "/tmp/project"} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("expected hint bar to include %q, got:\n%s", want, result)
+		}
+	}
+}

--- a/ui/panels/model_setup.go
+++ b/ui/panels/model_setup.go
@@ -9,16 +9,19 @@ import (
 
 // Style vars are populated by InitStyles() in styles.go.
 var (
-	setupTitleStyle    lipgloss.Style
-	setupNormalStyle   lipgloss.Style
-	setupSelectedStyle lipgloss.Style
-	setupDisabledStyle lipgloss.Style
-	setupHintStyle     lipgloss.Style
-	setupErrorStyle    lipgloss.Style
-	setupLabelStyle    lipgloss.Style
-	setupBadgeStyle    lipgloss.Style
-	setupBorderStyle   lipgloss.Style
+	setupTitleStyle      lipgloss.Style
+	setupNormalStyle     lipgloss.Style
+	setupSelectedStyle   lipgloss.Style
+	setupDisabledStyle   lipgloss.Style
+	setupHintStyle       lipgloss.Style
+	setupErrorStyle      lipgloss.Style
+	setupLabelStyle      lipgloss.Style
+	setupBadgeStyle      lipgloss.Style
+	modelPickerDescStyle lipgloss.Style
+	setupBorderStyle     lipgloss.Style
 )
+
+const popupVisibleOptions = 12
 
 // RenderSetupPopup renders the multi-step model setup popup.
 func RenderSetupPopup(popup *model.SetupPopup) string {
@@ -38,10 +41,15 @@ func RenderSetupPopup(popup *model.SetupPopup) string {
 
 const (
 	modeMSCLIProvided = "mscli-provided"
-	modeModeOwn        = "own"
+	modeModeOwn       = "own"
+	popupContentWidth = 56
 )
 
 func renderModeSelect(popup *model.SetupPopup) string {
+	title := popup.Title
+	if title == "" {
+		title = "Model Setup"
+	}
 	modes := []struct {
 		label string
 		mode  string
@@ -50,7 +58,7 @@ func renderModeSelect(popup *model.SetupPopup) string {
 		{"your own model", modeModeOwn},
 	}
 
-	maxW := len("Model Setup")
+	maxW := len(title)
 	for _, m := range modes {
 		if w := 2 + len(m.label) + 12; w > maxW {
 			maxW = w
@@ -58,7 +66,7 @@ func renderModeSelect(popup *model.SetupPopup) string {
 	}
 
 	var lines []string
-	lines = append(lines, setupTitleStyle.Width(maxW).Render("Model Setup"))
+	lines = append(lines, setupTitleStyle.Width(maxW).Render(title))
 	lines = append(lines, "")
 	for i, m := range modes {
 		marker := "  "
@@ -84,36 +92,52 @@ func renderModeSelect(popup *model.SetupPopup) string {
 }
 
 func renderPresetPicker(popup *model.SetupPopup) string {
-	maxW := len("mscli-provided")
-	for _, opt := range popup.PresetOptions {
-		if w := 2 + len(opt.Label) + 12; w > maxW {
-			maxW = w
-		}
+	title := popup.Title
+	if title == "" {
+		title = "mscli-provided"
 	}
+	filtered := filteredPopupOptions(popup.PresetOptions, popup.SearchQuery)
+	visible, start, end := popupOptionWindow(filtered, popup.PresetSelected, popupVisibleOptions)
+	maxW := popupContentWidth
 
 	var lines []string
-	lines = append(lines, setupTitleStyle.Width(maxW).Render("mscli-provided"))
+	lines = append(lines, setupTitleStyle.Width(maxW).Render(title))
 	lines = append(lines, "")
-	for i, opt := range popup.PresetOptions {
+	lines = append(lines, setupLabelStyle.Render("Search"))
+	lines = append(lines, renderSearchField(popup.SearchQuery, maxW))
+	lines = append(lines, "")
+	for _, row := range visible {
+		if row.Separator {
+			lines = append(lines, "")
+			continue
+		}
+		opt := row.Option
 		marker := "  "
 		style := setupNormalStyle
 		if opt.Disabled {
 			style = setupDisabledStyle
 		}
-		if i == popup.PresetSelected {
+		if row.Index == popup.PresetSelected {
 			marker = "❯ "
 			if !opt.Disabled {
 				style = setupSelectedStyle
 			}
 		}
 		label := opt.Label
+		if opt.Desc != "" {
+			label += " " + opt.Desc
+		}
 		if opt.ID == popup.CurrentPreset {
 			label += setupBadgeStyle.Render("  (current)")
 		}
-		lines = append(lines, marker+style.Render(label))
+		lines = append(lines, renderWrappedPopupOption(label, marker, style, maxW))
 	}
 	lines = append(lines, "")
-	lines = append(lines, setupHintStyle.Render("↑/↓ select · enter · esc back"))
+	scrollHint := "↑/↓ select · enter · esc back"
+	if start > 0 || end < len(filtered) {
+		scrollHint = "↑/↓ scroll · enter · esc back"
+	}
+	lines = append(lines, setupHintStyle.Render(scrollHint))
 
 	return setupBorderStyle.Render(strings.Join(lines, "\n"))
 }
@@ -123,11 +147,15 @@ func renderTokenInput(popup *model.SetupPopup) string {
 	if title == "" {
 		title = "Enter Token"
 	}
+	inputLabel := popup.InputLabel
+	if inputLabel == "" {
+		inputLabel = "Token"
+	}
 
 	var lines []string
 	lines = append(lines, setupTitleStyle.Width(40).Render(title))
 	lines = append(lines, "")
-	lines = append(lines, setupLabelStyle.Render("Token: ")+renderTokenField(popup.TokenValue))
+	lines = append(lines, setupLabelStyle.Render(inputLabel+": ")+renderTokenField(popup.TokenValue))
 	if popup.TokenError != "" {
 		lines = append(lines, "")
 		lines = append(lines, setupErrorStyle.Render(popup.TokenError))
@@ -176,4 +204,82 @@ func renderEnvInfo(popup *model.SetupPopup) string {
 	lines = append(lines, setupHintStyle.Render("esc back"))
 
 	return setupBorderStyle.Render(strings.Join(lines, "\n"))
+}
+
+func popupOptionWindow[T any](options []T, selected, maxVisible int) ([]T, int, int) {
+	total := len(options)
+	if total == 0 || maxVisible <= 0 || total <= maxVisible {
+		return options, 0, total
+	}
+	if selected < 0 {
+		selected = 0
+	}
+	if selected >= total {
+		selected = total - 1
+	}
+	start := selected - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxVisible
+	if end > total {
+		end = total
+		start = end - maxVisible
+	}
+	return options[start:end], start, end
+}
+
+type popupOptionRow struct {
+	Index     int
+	Option    model.SelectionOption
+	Separator bool
+}
+
+func filteredPopupOptions(options []model.SelectionOption, query string) []popupOptionRow {
+	rows := make([]popupOptionRow, 0)
+	indices := model.FilteredOptionIndicesForRender(options, query)
+	for _, idx := range indices {
+		if idx < 0 {
+			rows = append(rows, popupOptionRow{Separator: true})
+			continue
+		}
+		rows = append(rows, popupOptionRow{
+			Index:  idx,
+			Option: options[idx],
+		})
+	}
+	return rows
+}
+
+func renderWrappedPopupOption(text, marker string, style lipgloss.Style, width int) string {
+	if width < 4 {
+		width = 4
+	}
+	contentWidth := width - 2
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	wrapped := lipgloss.NewStyle().Width(contentWidth).Render(text)
+	lines := strings.Split(wrapped, "\n")
+	for i, line := range lines {
+		prefix := "  "
+		if i == 0 {
+			prefix = marker
+		}
+		lines[i] = prefix + style.Render(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderSearchField(query string, width int) string {
+	if width < 4 {
+		width = 4
+	}
+	text := query
+	style := setupNormalStyle
+	if strings.TrimSpace(text) == "" {
+		text = "Type to filter"
+		style = setupHintStyle
+	}
+	return style.Width(width).Render(text)
 }

--- a/ui/panels/model_setup_test.go
+++ b/ui/panels/model_setup_test.go
@@ -1,11 +1,15 @@
 package panels
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/mindspore-lab/mindspore-cli/ui/model"
 )
+
+var selectionPopupANSIPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func TestRenderSetupPopupModeSelect(t *testing.T) {
 	popup := &model.SetupPopup{
@@ -72,5 +76,102 @@ func TestRenderSetupPopupEnvInfo(t *testing.T) {
 	}
 	if !strings.Contains(result, "MSCLI_API_KEY") {
 		t.Error("expected MSCLI_API_KEY in output")
+	}
+}
+
+func TestRenderSetupPopupPresetPickerUsesWindowedOptions(t *testing.T) {
+	options := make([]model.SelectionOption, 0, 20)
+	for i := 0; i < 20; i++ {
+		options = append(options, model.SelectionOption{
+			ID:    "provider-" + strings.Repeat("x", i%3+1),
+			Label: fmt.Sprintf("provider option item-%02d", i),
+		})
+	}
+	popup := &model.SetupPopup{
+		Screen:         model.SetupScreenPresetPicker,
+		PresetOptions:  options,
+		PresetSelected: 15,
+		CanEscape:      true,
+	}
+	result := RenderSetupPopup(popup)
+	if !strings.Contains(result, "provider option item-15") {
+		t.Fatalf("expected selected window item in output, got:\n%s", result)
+	}
+	if strings.Contains(result, "provider option item-00") {
+		t.Fatalf("expected earliest option to be clipped from output, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupUsesWindowedOptions(t *testing.T) {
+	options := make([]model.SelectionOption, 0, 20)
+	for i := 0; i < 20; i++ {
+		options = append(options, model.SelectionOption{
+			ID:    "model-id",
+			Label: fmt.Sprintf("model option item-%02d", i),
+		})
+	}
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		Options:  options,
+		Selected: 14,
+	})
+	if !strings.Contains(result, "model option item-14") {
+		t.Fatalf("expected selected window item in output, got:\n%s", result)
+	}
+	if strings.Contains(result, "model option item-00") {
+		t.Fatalf("expected earliest option to be clipped from output, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupIncludesConnectProviderShortcut(t *testing.T) {
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		ActionID: "model_picker",
+		Options: []model.SelectionOption{
+			{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+			{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+		},
+		Selected: 1,
+	})
+	if !strings.Contains(result, "Connect Provider ctrl+a") {
+		t.Fatalf("expected connect provider shortcut in output, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupModelPickerFooterOnlyShowsConnectShortcut(t *testing.T) {
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		ActionID: "model_picker",
+		Options: []model.SelectionOption{
+			{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+			{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+		},
+		Selected: 1,
+	})
+	if strings.Contains(result, "↑/↓ select · enter confirm · esc cancel") {
+		t.Fatalf("expected model picker footer to omit nav hint, got:\n%s", result)
+	}
+	if strings.Contains(result, "↑/↓ scroll · enter confirm · esc cancel") {
+		t.Fatalf("expected model picker footer to omit scroll hint, got:\n%s", result)
+	}
+	if !strings.Contains(result, "Connect Provider ctrl+a") {
+		t.Fatalf("expected model picker footer to keep connect shortcut, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupModelPickerShowsProviderAfterRecentModel(t *testing.T) {
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		ActionID: "model_picker",
+		Options: []model.SelectionOption{
+			{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+			{ID: "openai:gpt-4.1", Label: "GPT-4.1", Desc: "· OpenAI"},
+		},
+		Selected: 1,
+	})
+
+	plain := selectionPopupANSIPattern.ReplaceAllString(result, "")
+	if !strings.Contains(plain, "GPT-4.1 · OpenAI") {
+		t.Fatalf("expected recent model to render provider suffix, got:\n%s", plain)
 	}
 }

--- a/ui/panels/styles.go
+++ b/ui/panels/styles.go
@@ -75,6 +75,7 @@ func InitStyles() {
 	setupErrorStyle = lipgloss.NewStyle().Foreground(t.Error)
 	setupLabelStyle = lipgloss.NewStyle().Foreground(t.TextPrimary)
 	setupBadgeStyle = lipgloss.NewStyle().Foreground(t.TextSecondary)
+	modelPickerDescStyle = lipgloss.NewStyle().Foreground(t.TextMuted)
 	setupBorderStyle = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.TextPrimary).

--- a/ui/panels/styles_test.go
+++ b/ui/panels/styles_test.go
@@ -1,0 +1,21 @@
+package panels
+
+import (
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/ui/theme"
+)
+
+func TestInitStyles_ModelPickerDescUsesMutedColor(t *testing.T) {
+	original := theme.Current
+	t.Cleanup(func() { theme.Current = original })
+
+	theme.Current = theme.Dark
+	InitStyles()
+
+	got := modelPickerDescStyle.GetForeground()
+	want := theme.Current.TextMuted
+	if got != want {
+		t.Fatalf("modelPickerDescStyle.GetForeground() = %v, want %v", got, want)
+	}
+}

--- a/ui/panels/train_workspace.go
+++ b/ui/panels/train_workspace.go
@@ -361,34 +361,54 @@ func RenderSelectionPopup(popup *model.SelectionPopup) string {
 	titleStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true).Align(lipgloss.Center)
 	normalStyle := lipgloss.NewStyle().Foreground(t.TextSecondary)
 	selectedStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true)
+	disabledStyle := lipgloss.NewStyle().Foreground(t.TextMuted)
 	hintStyle := lipgloss.NewStyle().Foreground(t.TextMuted).Italic(true)
 
-	// Find the widest option line to size the title
-	maxW := lipgloss.Width(popup.Title)
-	for _, opt := range popup.Options {
-		w := 2 + lipgloss.Width(opt.Label)
-		if opt.Desc != "" {
-			w += 1 + lipgloss.Width(opt.Desc)
-		}
-		if w > maxW {
-			maxW = w
-		}
-	}
+	filtered := filteredPopupOptions(popup.Options, popup.SearchQuery)
+	visible, start, end := popupOptionWindow(filtered, popup.Selected, popupVisibleOptions)
+	maxW := popupContentWidth
 
 	var lines []string
 	lines = append(lines, titleStyle.Width(maxW).Render(popup.Title))
 	lines = append(lines, "")
-	for i, opt := range popup.Options {
+	lines = append(lines, setupLabelStyle.Render("Search"))
+	lines = append(lines, renderSearchField(popup.SearchQuery, maxW))
+	lines = append(lines, "")
+	for _, row := range visible {
+		if row.Separator {
+			lines = append(lines, "")
+			continue
+		}
+		opt := row.Option
 		marker := "  "
 		style := normalStyle
-		if i == popup.Selected {
-			marker = "❯ "
-			style = selectedStyle
+		if opt.Disabled {
+			style = disabledStyle
 		}
-		lines = append(lines, marker+style.Render(opt.Label))
+		if row.Index == popup.Selected {
+			marker = "❯ "
+			if !opt.Disabled {
+				style = selectedStyle
+			}
+		}
+		label := opt.Label
+		if popup.ActionID == "model_picker" && opt.Desc != "" {
+			label += " " + modelPickerDescStyle.Render(opt.Desc)
+		} else if opt.Desc != "" {
+			label += " " + opt.Desc
+		}
+		lines = append(lines, renderWrappedPopupOption(label, marker, style, maxW))
 	}
 	lines = append(lines, "")
-	lines = append(lines, hintStyle.Render("↑/↓ select · enter confirm · esc cancel"))
+	if popup.ActionID == "model_picker" {
+		lines = append(lines, hintStyle.Render("Connect Provider ctrl+a"))
+	} else {
+		scrollHint := "↑/↓ select · enter confirm · esc cancel"
+		if start > 0 || end < len(filtered) {
+			scrollHint = "↑/↓ scroll · enter confirm · esc cancel"
+		}
+		lines = append(lines, hintStyle.Render(scrollHint))
+	}
 
 	content := strings.Join(lines, "\n")
 	return lipgloss.NewStyle().

--- a/ui/slash/commands.go
+++ b/ui/slash/commands.go
@@ -148,9 +148,15 @@ func Parse(input string) (string, []string) {
 
 func (r *Registry) registerDefaults() {
 	r.Register(Command{
+		Name:        "/connect",
+		Description: "Connect a model provider",
+		Usage:       "/connect [provider-id] [api-key]",
+	})
+
+	r.Register(Command{
 		Name:        "/model",
-		Description: "Open model setup or switch model",
-		Usage:       "/model [preset-id|provider:model|model]",
+		Description: "Open model picker or switch model",
+		Usage:       "/model [provider:model|model]",
 	})
 
 	r.Register(Command{
@@ -225,7 +231,6 @@ func (r *Registry) registerDefaults() {
 		Description: "List issues",
 		Usage:       "/issues [status]",
 	})
-
 
 	r.Register(Command{
 		Name:        "/diagnose",

--- a/ui/topbar_test.go
+++ b/ui/topbar_test.go
@@ -29,10 +29,11 @@ func TestViewOmitsPersistentTopBarAndViewportFill(t *testing.T) {
 }
 
 func TestRenderBannerIncludesMetadata(t *testing.T) {
-	banner := RenderBanner("MindSpore CLI. test", "/tmp/project", "github.com/mindspore-lab/mindspore-cli", "demo-model", 4096)
+	banner := RenderBanner("MindSpore CLI. test", "/tmp/project", "github.com/mindspore-lab/mindspore-cli", "demo-model", 4096, "MindSpore CLI Free")
 	for _, want := range []string{
 		"MindSpore CLI",
 		"demo-model",
+		"MindSpore CLI Free",
 		"/tmp/project",
 	} {
 		if !strings.Contains(banner, want) {
@@ -41,5 +42,28 @@ func TestRenderBannerIncludesMetadata(t *testing.T) {
 	}
 	if !strings.Contains(banner, "model: demo-model") {
 		t.Fatalf("expected banner rows to stay left aligned, got:\n%s", banner)
+	}
+	if strings.Contains(banner, "provider:") {
+		t.Fatalf("expected provider to render inline with model instead of its own row, got:\n%s", banner)
+	}
+}
+
+func TestModelUpdateSetsProviderDisplay(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type:     model.ModelUpdate,
+		Message:  "Kimi K2.5",
+		Provider: "MindSpore CLI Free",
+		CtxMax:   262144,
+	})
+	app = next.(App)
+
+	if got, want := app.state.Model.Name, "Kimi K2.5"; got != want {
+		t.Fatalf("state.Model.Name = %q, want %q", got, want)
+	}
+	if got, want := app.state.Model.Provider, "MindSpore CLI Free"; got != want {
+		t.Fatalf("state.Model.Provider = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
本次更新主要围绕“让用户更容易开始使用模型，并且更容易管理不同模型来源”展开，重点是把原来偏底层的模型配置流程，升级为更清晰的 provider + model 选择体验（OpenCode-like）。

功能更新

  - 新增 /connect 工作流，用户可以先连接模型供应商，再从该供应商下选择可用模型。
  - 保留 /model 命令，但职责调整为“在已可用的模型中切换当前使用模型”。
  - 引入内置的 MindSpore CLI Free 供应商体验：
      - 登录后可直接使用，默认提供可用模型
      - 未登录时会明确提示需要先登录
  - 支持从 models.dev 自动读取供应商目录，用户不需要手工维护大部分 provider 列表。
  - 支持 extra_providers，允许用户在配置文件里补充自定义 provider。
  - 新增最近使用模型能力，模型选择时可优先看到常用模型。
  - 增强模型/供应商状态持久化，用户重启后可以恢复上次使用状态。

  体验优化

  - /connect 和 /model 都改成弹窗式选择界面，支持搜索，避免手工输入复杂参数。
  - 供应商选择增加 Popular 和 Other 分组，常用供应商更容易找到。
  - 模型选择按 provider 分组展示，结构更清晰。
  - 增加快捷入口，例如在模型选择界面可直接跳转去连接新的 provider。
  - 主界面现在会同时展示当前模型和其所属 provider，状态更直观。
  - 未配置模型时，提示语更明确，统一引导用户使用 /connect 完成配置。

  性能与稳定性优化

  - 优化 provider 目录加载逻辑，/connect 和 /model 打开速度明显提升，不再因为远程目录请求产生明显卡顿。
  - 为远程 provider 目录增加本地缓存和后台刷新机制，兼顾打开速度与目录新鲜度。
  - 保留对旧配置字段的兼容，降低升级后用户的迁移成本。