### PR TITLE
feat(app): add guided provider setup and env-backed provider import

### DIFF
--- a/configs/model_profiles_test.go
+++ b/configs/model_profiles_test.go
@@ -27,7 +27,7 @@ func TestLoadWithEnv_AutoTokenLimitsByModelSeries(t *testing.T) {
 		{name: "claude-4.6-sonnet", model: "claude-sonnet-4.6", wantWindow: 1000000},
 		{name: "claude-4.5-haiku", model: "claude-haiku-4.5", wantWindow: 200000},
 		{name: "kimi-k2", model: "kimi-k2", wantWindow: 128000},
-		{name: "namespaced-kimi-k2.5", model: "moonshotai/kimi-k2.5", wantWindow: 256000},
+		{name: "namespaced-kimi-k2.5", model: "provider/kimi-k2.5", wantWindow: 256000},
 		{name: "deepseek-reasoner", model: "deepseek-reasoner", wantWindow: 128000},
 		{name: "qwen3", model: "qwen3-max", wantWindow: 262144},
 		{name: "qwen3.5", model: "qwen3.5-plus", wantWindow: 1000000},

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -77,6 +77,33 @@ runTask:
 No orchestrator, no planner, no adapter layer. The app calls the engine
 directly. The LLM plans inline within the agent loop.
 
+### Provider And Model Selection
+
+`mscli` now converges provider connection and model selection into `/model`:
+
+```text
+/model
+  -> merged provider catalog:
+       builtin MindSpore CLI Free
+       + models.dev cache/remote catalog
+       + ~/.mscli/config.json extra_providers
+  -> provider pane adds or refreshes connected providers in ~/.mscli/auth.json
+  -> model pane loads usable providers:
+       MindSpore CLI Free when logged in
+       + providers connected in ~/.mscli/auth.json
+  -> persist active/recent/favorite model refs in ~/.mscli/model.json
+  -> translate logical provider selection into current configs.ModelConfig
+  -> Application.SetProvider(...)
+```
+
+Local state files:
+
+- `~/.mscli/credentials.json`: MindSpore CLI login only
+- `~/.mscli/auth.json`: connected provider auth only
+- `~/.mscli/model.json`: active/recent/favorite model refs
+- `~/.mscli/cached/models-dev-api.json`: models.dev cache fallback
+- `~/.mscli/config.json`: deprecated model compatibility plus `extra_providers`
+
 ### Skill activation
 
 Skills are embedded in the binary at build time from the `mindspore-skills` repo.

--- a/docs/superpowers/plans/2026-04-09-provider-import-duplicate-options.md
+++ b/docs/superpowers/plans/2026-04-09-provider-import-duplicate-options.md
@@ -1,0 +1,42 @@
+# Provider Import Duplicate Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show both the env-backed import option and the original provider option while preserving their different API key flows.
+
+**Architecture:** Keep the provider catalog unchanged. Encode import selections with an internal option ID, decode that ID in the connect flow, and only allow detected env API key fallback for decoded import selections.
+
+**Tech Stack:** Go, Bubble Tea UI tests, application workflow tests
+
+---
+
+### Task 1: Lock expected behavior with tests
+
+**Files:**
+- Modify: `internal/app/commands_model_test.go`
+- Modify: `ui/app_model_browser_test.go`
+
+- [ ] **Step 1: Write failing tests**
+- [ ] **Step 2: Run narrow Go tests to verify the failures are for the intended behavior**
+- [ ] **Step 3: Keep test coverage focused on duplicate entries and import-vs-normal connect behavior**
+
+### Task 2: Implement minimal option/source separation
+
+**Files:**
+- Modify: `internal/app/provider_workflow.go`
+
+- [ ] **Step 1: Stop filtering catalog providers when import suggestions exist**
+- [ ] **Step 2: Add internal import option ID encoding/decoding helpers**
+- [ ] **Step 3: Route connect behavior through decoded import metadata**
+- [ ] **Step 4: Only allow env API key fallback for import-origin selections**
+
+### Task 3: Verify and clean up
+
+**Files:**
+- Modify: `internal/app/commands_model_test.go`
+- Modify: `ui/app_model_browser_test.go`
+- Modify: `internal/app/provider_workflow.go`
+
+- [ ] **Step 1: Run the narrowest relevant test commands**
+- [ ] **Step 2: Widen to related package tests if the narrow checks pass**
+- [ ] **Step 3: Confirm no unintended behavior changes are required**

--- a/docs/superpowers/specs/2026-04-09-provider-import-duplicate-options-design.md
+++ b/docs/superpowers/specs/2026-04-09-provider-import-duplicate-options-design.md
@@ -1,0 +1,28 @@
+# Provider Import Duplicate Options Design
+
+**Goal:** Keep env-detected provider import candidates visible in the `Import` section without removing the original provider from `Popular` or `Other`.
+
+## Problem
+
+When a provider such as `kimi-for-coding` is detected from Claude Code environment variables, the current `/model` provider list shows only the import candidate at the top. The original catalog provider entry disappears from the normal provider sections.
+
+This collapses two different behaviors into one visible choice:
+
+- Import candidate: may reuse the detected `ANTHROPIC_API_KEY` and skip manual API key entry
+- Normal provider entry: must behave like every other provider option and require manual API key entry
+
+## Approved Design
+
+- Keep both visible options in the provider list.
+- Preserve the current `Import` group presentation and detail rows.
+- Keep the visible label unchanged for both options.
+- Distinguish the import option only with an internal option ID.
+- Allow env API key fallback only when the selected option came from the `Import` group.
+- Require manual API key entry for the normal provider option even if matching env vars are present.
+
+## Minimal Change Boundary
+
+- Do not change provider catalog structures.
+- Do not change auth/model state persistence formats.
+- Do not change import detection or display copy.
+- Restrict logic changes to provider option construction, provider connect parsing, and targeted tests.

--- a/internal/app/appconfig.go
+++ b/internal/app/appconfig.go
@@ -4,21 +4,39 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
 	modelModeMSCLIProvided = "mscli-provided"
-	modelModeOwn            = "own"
-	modelModeOwnEnv         = "own-env"
-	modelSetupToken         = "__model_setup"
+	modelModeOwn           = "own"
+	modelModeOwnEnv        = "own-env"
+	modelSetupToken        = "__model_setup"
+	connectProviderToken   = "__connect_provider__"
+	selectModelToken       = "__select_model__"
+	deleteProviderToken    = "__delete_provider__"
 )
 
 // appConfig holds persistent local settings stored in ~/.mscli/config.json.
 // Separate from credentials.json (issue server auth) and configs/ (YAML + env).
 type appConfig struct {
-	ModelMode     string `json:"model_mode,omitempty"`      // "mscli-provided" or "own" or ""
-	ModelPresetID string `json:"model_preset_id,omitempty"` // e.g. "kimi-k2.5-free"
-	ModelToken    string `json:"model_token,omitempty"`     // API token for mscli-provided models
+	ModelMode      string                `json:"model_mode,omitempty"`      // "mscli-provided" or "own" or ""
+	ModelPresetID  string                `json:"model_preset_id,omitempty"` // e.g. "kimi-k2.5-free"
+	ModelToken     string                `json:"model_token,omitempty"`     // API token for mscli-provided models
+	ExtraProviders []extraProviderConfig `json:"extra_providers,omitempty"`
+}
+
+type extraProviderConfig struct {
+	ID       string                     `json:"id"`
+	Label    string                     `json:"label,omitempty"`
+	BaseURL  string                     `json:"base_url"`
+	Protocol string                     `json:"protocol"`
+	Models   []extraProviderModelConfig `json:"models,omitempty"`
+}
+
+type extraProviderModelConfig struct {
+	ID    string `json:"id"`
+	Label string `json:"label,omitempty"`
 }
 
 // appConfigPathOverride allows tests to redirect the config path.
@@ -44,11 +62,13 @@ func loadAppConfig() (*appConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	cfg.normalize()
 	return &cfg, nil
 }
 
 func saveAppConfig(cfg *appConfig) error {
 	path := appConfigPath()
+	cfg.normalize()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
@@ -57,4 +77,38 @@ func saveAppConfig(cfg *appConfig) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+func (c *appConfig) normalize() {
+	if c == nil {
+		return
+	}
+	if len(c.ExtraProviders) == 0 {
+		c.ExtraProviders = nil
+		return
+	}
+
+	out := make([]extraProviderConfig, 0, len(c.ExtraProviders))
+	for _, provider := range c.ExtraProviders {
+		provider.ID = strings.TrimSpace(provider.ID)
+		provider.Label = strings.TrimSpace(provider.Label)
+		provider.BaseURL = strings.TrimSpace(provider.BaseURL)
+		provider.Protocol = strings.TrimSpace(provider.Protocol)
+		if provider.ID == "" {
+			continue
+		}
+
+		models := make([]extraProviderModelConfig, 0, len(provider.Models))
+		for _, model := range provider.Models {
+			model.ID = strings.TrimSpace(model.ID)
+			model.Label = strings.TrimSpace(model.Label)
+			if model.ID == "" {
+				continue
+			}
+			models = append(models, model)
+		}
+		provider.Models = models
+		out = append(out, provider)
+	}
+	c.ExtraProviders = out
 }

--- a/internal/app/appconfig_test.go
+++ b/internal/app/appconfig_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -49,5 +51,88 @@ func TestLoadAppConfigMissing(t *testing.T) {
 	}
 	if cfg.ModelMode != "" {
 		t.Errorf("expected empty ModelMode, got %q", cfg.ModelMode)
+	}
+}
+
+func TestAppConfigRoundTripPreservesExtraProviders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	origPath := appConfigPathOverride
+	appConfigPathOverride = path
+	t.Cleanup(func() { appConfigPathOverride = origPath })
+
+	cfg := &appConfig{
+		ModelMode:     "mscli-provided",
+		ModelPresetID: "kimi-k2.5-free",
+		ModelToken:    "deprecated-token",
+		ExtraProviders: []extraProviderConfig{
+			{
+				ID:       "openrouter",
+				Label:    "OpenRouter",
+				BaseURL:  "https://openrouter.ai/api/v1",
+				Protocol: "openai-chat",
+				Models: []extraProviderModelConfig{
+					{ID: "openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+			},
+		},
+	}
+	if err := saveAppConfig(cfg); err != nil {
+		t.Fatalf("saveAppConfig: %v", err)
+	}
+
+	loaded, err := loadAppConfig()
+	if err != nil {
+		t.Fatalf("loadAppConfig: %v", err)
+	}
+	if got, want := len(loaded.ExtraProviders), 1; got != want {
+		t.Fatalf("len(loaded.ExtraProviders) = %d, want %d", got, want)
+	}
+	if got, want := loaded.ExtraProviders[0].ID, "openrouter"; got != want {
+		t.Fatalf("loaded.ExtraProviders[0].ID = %q, want %q", got, want)
+	}
+	if got, want := loaded.ExtraProviders[0].Models[0].ID, "openai/gpt-4o-mini"; got != want {
+		t.Fatalf("loaded.ExtraProviders[0].Models[0].ID = %q, want %q", got, want)
+	}
+	if got, want := loaded.ModelToken, "deprecated-token"; got != want {
+		t.Fatalf("loaded.ModelToken = %q, want %q", got, want)
+	}
+}
+
+func TestLoadAppConfigExtraProvidersLabelOptional(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	origPath := appConfigPathOverride
+	appConfigPathOverride = path
+	t.Cleanup(func() { appConfigPathOverride = origPath })
+
+	data, err := json.MarshalIndent(map[string]any{
+		"extra_providers": []map[string]any{
+			{
+				"id":       "my-gateway",
+				"base_url": "https://llm.example.com/v1",
+				"protocol": "openai-chat",
+			},
+		},
+	}, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	loaded, err := loadAppConfig()
+	if err != nil {
+		t.Fatalf("loadAppConfig() error = %v", err)
+	}
+	if got, want := len(loaded.ExtraProviders), 1; got != want {
+		t.Fatalf("len(loaded.ExtraProviders) = %d, want %d", got, want)
+	}
+	if got, want := loaded.ExtraProviders[0].ID, "my-gateway"; got != want {
+		t.Fatalf("loaded.ExtraProviders[0].ID = %q, want %q", got, want)
+	}
+	if got := loaded.ExtraProviders[0].Label; got != "" {
+		t.Fatalf("loaded.ExtraProviders[0].Label = %q, want empty", got)
 	}
 }

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -117,6 +117,16 @@ func (a *Application) cmdLogin(args []string) {
 	a.issueRole = me.Role
 
 	a.EventCh <- model.Event{Type: model.IssueUserUpdate, Message: me.User}
+	if !a.llmReady {
+		if result, err := a.activateLogicalModelSelection(mindsporeCLIFreeProviderID, "kimi-k2.5"); err == nil {
+			a.EventCh <- model.Event{
+				Type:     model.ModelUpdate,
+				Message:  a.Config.Model.Model,
+				Provider: result.ProviderLabel,
+				CtxMax:   a.Config.Context.Window,
+			}
+		}
+	}
 	a.EventCh <- model.Event{
 		Type:    model.AgentReply,
 		Message: fmt.Sprintf("logged in as %s (%s)", me.User, me.Role),

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mindspore-lab/mindspore-cli/agent/loop"
+	"github.com/mindspore-lab/mindspore-cli/configs"
 	"github.com/mindspore-lab/mindspore-cli/integrations/llm"
 	"github.com/mindspore-lab/mindspore-cli/internal/bugs"
 	issuepkg "github.com/mindspore-lab/mindspore-cli/internal/issues"
@@ -170,34 +172,38 @@ func (a *Application) handleSkillAliasCommand(commandName, rawRemainder string) 
 
 func (a *Application) cmdModel(args []string) {
 	if len(args) == 0 {
-		a.emitModelSetupPopup(true)
+		a.emitModelBrowser()
+		return
+	}
+	a.EventCh <- model.Event{
+		Type:    model.AgentReply,
+		Message: "/model no longer accepts arguments. Use /model and choose from the UI.",
+	}
+}
+
+func (a *Application) cmdConnect(args []string) {
+	if len(args) == 0 {
+		a.emitModelBrowser()
 		return
 	}
 
-	modelArg := strings.TrimSpace(strings.Join(args, " "))
-	if preset, ok := resolveBuiltinModelPreset(modelArg); ok {
-		a.switchToBuiltinModelPreset(preset)
-		return
+	providerID := strings.TrimSpace(args[0])
+	apiKey := ""
+	if len(args) > 1 {
+		apiKey = strings.TrimSpace(strings.Join(args[1:], " "))
 	}
 
-	a.restoreModelConfigFromPreset()
-	modelArg = args[0]
-	if strings.Contains(modelArg, ":") {
-		parts := strings.SplitN(modelArg, ":", 2)
-		providerName := llm.NormalizeProvider(parts[0])
-		modelName := strings.TrimSpace(parts[1])
-		if !llm.IsSupportedProvider(providerName) {
-			a.EventCh <- model.Event{
-				Type:    model.AgentReply,
-				Message: fmt.Sprintf("Unsupported provider prefix: %s (supported: openai-completion, openai-responses, anthropic)", providerName),
-			}
-			return
+	a.EventCh <- model.Event{Type: model.AgentThinking}
+	state, err := a.connectProvider(providerID, apiKey)
+	if err != nil {
+		a.EventCh <- model.Event{
+			Type:     model.ToolError,
+			ToolName: "connect",
+			Message:  fmt.Sprintf("Failed to connect provider: %v", err),
 		}
-		a.switchModel(providerName, modelName)
 		return
 	}
-
-	a.switchModel("", modelArg)
+	a.emitModelBrowserWithState(state, providerID)
 }
 
 // applyPreset applies a preset with the given API key. It saves the current
@@ -243,9 +249,10 @@ func (a *Application) switchToBuiltinModelPreset(preset builtinModelPreset) {
 	}
 
 	a.EventCh <- model.Event{
-		Type:    model.ModelUpdate,
-		Message: a.Config.Model.Model,
-		CtxMax:  a.Config.Context.Window,
+		Type:     model.ModelUpdate,
+		Message:  a.Config.Model.Model,
+		Provider: runtimeProviderDisplayLabel(a.Config.Model.Provider),
+		CtxMax:   a.Config.Context.Window,
 	}
 
 	a.EventCh <- model.Event{
@@ -277,15 +284,133 @@ func (a *Application) switchModel(providerName, modelName string) {
 	}
 
 	a.EventCh <- model.Event{
-		Type:    model.ModelUpdate,
-		Message: a.Config.Model.Model,
-		CtxMax:  a.Config.Context.Window,
+		Type:     model.ModelUpdate,
+		Message:  a.Config.Model.Model,
+		Provider: runtimeProviderDisplayLabel(a.Config.Model.Provider),
+		CtxMax:   a.Config.Context.Window,
 	}
 
 	a.EventCh <- model.Event{
 		Type:    model.AgentReply,
 		Message: fmt.Sprintf("Model switched to: %s", a.Config.Model.Model),
 	}
+}
+
+func (a *Application) cmdSelectModel(args []string) {
+	if len(args) == 0 {
+		a.EventCh <- model.Event{
+			Type:     model.ToolError,
+			ToolName: "model",
+			Message:  "model selection requires provider:model",
+		}
+		return
+	}
+
+	parts := strings.SplitN(strings.TrimSpace(args[0]), ":", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		a.EventCh <- model.Event{
+			Type:     model.ToolError,
+			ToolName: "model",
+			Message:  "model selection requires provider:model",
+		}
+		return
+	}
+
+	a.EventCh <- model.Event{Type: model.AgentThinking}
+	result, err := a.activateLogicalModelSelection(parts[0], parts[1])
+	if err != nil {
+		a.EventCh <- model.Event{
+			Type:     model.ToolError,
+			ToolName: "model",
+			Message:  fmt.Sprintf("Failed to switch model: %v", err),
+		}
+		return
+	}
+
+	a.EventCh <- model.Event{Type: model.ModelBrowserClose}
+	a.EventCh <- model.Event{
+		Type:     model.ModelUpdate,
+		Message:  a.Config.Model.Model,
+		Provider: result.ProviderLabel,
+		CtxMax:   a.Config.Context.Window,
+	}
+	a.EventCh <- model.Event{
+		Type:    model.AgentReply,
+		Message: fmt.Sprintf("Model switched to: %s", a.Config.Model.Model),
+	}
+}
+
+func (a *Application) cmdDeleteProvider(args []string) {
+	if len(args) == 0 {
+		a.EventCh <- model.Event{
+			Type:     model.ToolError,
+			ToolName: "model",
+			Message:  "provider deletion requires provider id",
+		}
+		return
+	}
+
+	providerID := strings.TrimSpace(args[0])
+	a.EventCh <- model.Event{Type: model.AgentThinking}
+	result, err := a.deleteConnectedProvider(providerID)
+	if err != nil {
+		a.EventCh <- model.Event{
+			Type:     model.ToolError,
+			ToolName: "model",
+			Message:  fmt.Sprintf("Failed to delete provider: %v", err),
+		}
+		return
+	}
+
+	if result.Fallback != nil {
+		a.EventCh <- model.Event{
+			Type:     model.ModelUpdate,
+			Message:  a.Config.Model.Model,
+			Provider: runtimeProviderDisplayLabel(result.Fallback.ProviderID),
+			CtxMax:   a.Config.Context.Window,
+		}
+	} else if result.Cleared {
+		a.EventCh <- model.Event{
+			Type:     model.ModelUpdate,
+			Message:  "No model (/model to configure)",
+			Provider: "",
+			CtxMax:   a.Config.Context.Window,
+		}
+	}
+
+	if state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst); err == nil {
+		a.emitModelBrowserWithState(state, "")
+	}
+}
+
+func (a *Application) clearActiveLogicalModel() error {
+	previousModel := a.Config.Model.Model
+	a.restoreModelConfigFromPreset()
+	a.Config.Model.Provider = ""
+	a.Config.Model.Model = ""
+	a.Config.Model.Key = ""
+	a.Config.Model.URL = ""
+	configs.RefreshModelTokenDefaults(a.Config, previousModel)
+	a.provider = nil
+	a.llmReady = false
+
+	systemPrompt := ""
+	if a.ctxManager != nil {
+		if msg := a.ctxManager.GetSystemPrompt(); msg != nil {
+			systemPrompt = msg.Content
+		}
+	}
+
+	engineCfg := newEngineConfig(a.Config, systemPrompt)
+	newEngine := loop.NewEngine(engineCfg, nil, a.toolRegistry)
+	if a.ctxManager != nil {
+		newEngine.SetContextManager(a.ctxManager)
+	}
+	newEngine.SetLLMDebugDumper(a.llmDebugDumper)
+	newEngine.SetPermissionService(a.permService)
+	newEngine.SetTrajectoryRecorder(newTrajectoryRecorder(a.session, a.ctxManager, a.noteLiveLLMActivity))
+	a.Engine = newEngine
+	return nil
 }
 
 func (a *Application) cmdModelSetup(args []string) {
@@ -386,9 +511,10 @@ func (a *Application) cmdModelSetup(args []string) {
 	// Step 6: Emit UI updates.
 	a.EventCh <- model.Event{Type: model.IssueUserUpdate, Message: userName}
 	a.EventCh <- model.Event{
-		Type:    model.ModelUpdate,
-		Message: a.Config.Model.Model,
-		CtxMax:  a.Config.Context.Window,
+		Type:     model.ModelUpdate,
+		Message:  a.Config.Model.Model,
+		Provider: runtimeProviderDisplayLabel(a.Config.Model.Provider),
+		CtxMax:   a.Config.Context.Window,
 	}
 	a.EventCh <- model.Event{Type: model.ModelSetupClose}
 	a.EventCh <- model.Event{
@@ -880,4 +1006,3 @@ func defaultSkillRequest(skillName string) string {
 		skillName,
 	)
 }
-

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -203,7 +203,7 @@ func (a *Application) cmdConnect(args []string) {
 		}
 		return
 	}
-	a.emitModelBrowserWithState(state, providerID)
+	a.emitModelBrowserWithState(state, parseConnectProviderSelection(providerID).ProviderID)
 }
 
 // applyPreset applies a preset with the given API key. It saves the current

--- a/internal/app/commands_model_test.go
+++ b/internal/app/commands_model_test.go
@@ -1,195 +1,397 @@
 package app
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/mindspore-lab/mindspore-cli/configs"
-	"github.com/mindspore-lab/mindspore-cli/integrations/llm"
 	"github.com/mindspore-lab/mindspore-cli/ui/model"
 )
 
-func TestCmdModel_UnprefixedKeepsProvider(t *testing.T) {
+func TestCmdModel_NoArgsShowsModelBrowser(t *testing.T) {
 	app := newModelCommandTestApp()
-	app.Config.Model.Provider = "anthropic"
-	app.Config.Model.Model = "claude-3-5-sonnet"
-
-	app.cmdModel([]string{"claude-3-5-haiku"})
-
-	drainUntilEventType(t, app, model.AgentThinking)
-	drainUntilEventType(t, app, model.ModelUpdate)
-	drainUntilEventType(t, app, model.AgentReply)
-
-	if got, want := app.Config.Model.Provider, "anthropic"; got != want {
-		t.Fatalf("provider = %q, want %q", got, want)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+	if err := writeModelsDevCache([]byte(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
 	}
-	if got, want := app.Config.Model.Model, "claude-3-5-haiku"; got != want {
-		t.Fatalf("model = %q, want %q", got, want)
+	if err := saveProviderAuthState(&providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+		},
+	}); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
 	}
-}
-
-func TestCmdModel_PrefixedUpdatesProviderAndModel(t *testing.T) {
-	app := newModelCommandTestApp()
-	app.Config.Model.Provider = "openai-completion"
-	app.Config.Model.Model = "gpt-4o-mini"
-
-	app.cmdModel([]string{"anthropic:claude-3-5-sonnet"})
-
-	drainUntilEventType(t, app, model.AgentThinking)
-	drainUntilEventType(t, app, model.ModelUpdate)
-	drainUntilEventType(t, app, model.AgentReply)
-
-	if got, want := app.Config.Model.Provider, "anthropic"; got != want {
-		t.Fatalf("provider = %q, want %q", got, want)
-	}
-	if got, want := app.Config.Model.Model, "claude-3-5-sonnet"; got != want {
-		t.Fatalf("model = %q, want %q", got, want)
-	}
-}
-
-func TestCmdModel_ModelUpdateCarriesContextWindow(t *testing.T) {
-	app := newModelCommandTestApp()
-	app.Config.Context.Window = 200000
-
-	app.cmdModel([]string{"gpt-4o"})
-
-	drainUntilEventType(t, app, model.AgentThinking)
-	ev := drainUntilEventType(t, app, model.ModelUpdate)
-
-	if got, want := ev.CtxMax, 200000; got != want {
-		t.Fatalf("model update ctx max = %d, want %d", got, want)
-	}
-}
-
-func TestCmdModel_InvalidPrefixNoMutation(t *testing.T) {
-	app := newModelCommandTestApp()
-	app.Config.Model.Provider = "openai-completion"
-	app.Config.Model.Model = "gpt-4o-mini"
-
-	app.cmdModel([]string{"invalid:gpt-4o"})
-
-	ev := drainUntilEventType(t, app, model.AgentReply)
-	if !strings.Contains(ev.Message, "Unsupported provider prefix") {
-		t.Fatalf("unexpected message: %q", ev.Message)
-	}
-
-	if got, want := app.Config.Model.Provider, "openai-completion"; got != want {
-		t.Fatalf("provider = %q, want %q", got, want)
-	}
-	if got, want := app.Config.Model.Model, "gpt-4o-mini"; got != want {
-		t.Fatalf("model = %q, want %q", got, want)
-	}
-}
-
-func TestCmdModel_NoArgsShowsSetupPopup(t *testing.T) {
-	app := newModelCommandTestApp()
 
 	app.cmdModel(nil)
 
-	ev := drainUntilEventType(t, app, model.ModelSetupOpen)
-	if ev.SetupPopup == nil {
-		t.Fatal("ModelSetupOpen popup = nil, want SetupPopup")
+	ev := drainUntilEventType(t, app, model.ModelBrowserOpen)
+	if ev.ModelBrowser == nil {
+		t.Fatal("ModelBrowserOpen popup = nil, want ModelBrowserPopup")
 	}
-	if !ev.SetupPopup.CanEscape {
-		t.Fatal("expected CanEscape=true from /model command")
+	if len(ev.ModelBrowser.Models.Options) == 0 {
+		t.Fatal("expected model browser model options")
 	}
-	if len(ev.SetupPopup.PresetOptions) == 0 || ev.SetupPopup.PresetOptions[0].ID != "kimi-k2.5-free" {
-		t.Fatalf("preset options = %#v, want kimi preset option", ev.SetupPopup.PresetOptions)
+	if len(ev.ModelBrowser.Providers.Options) == 0 {
+		t.Fatal("expected model browser provider options")
 	}
-}
-
-func TestCmdModel_BuiltinPresetRequiresLogin(t *testing.T) {
-	app := newModelCommandTestApp()
-	t.Setenv("HOME", t.TempDir())
-
-	app.cmdModel([]string{"kimi-k2.5-free"})
-
-	drainUntilEventType(t, app, model.AgentThinking)
-	ev := drainUntilEventType(t, app, model.ToolError)
-	if !strings.Contains(ev.Message, "not logged in") {
-		t.Fatalf("tool error = %q, want login requirement", ev.Message)
+	if got, want := ev.ModelBrowser.Focus, model.ModelBrowserFocusModel; got != want {
+		t.Fatalf("focus = %v, want %v", got, want)
 	}
 }
 
-func TestCmdModel_BuiltinPresetUsesServerCredentialAndRestoresOnSwitchBack(t *testing.T) {
+func TestCmdModel_NoArgsDoesNotAutoImportClaudeCodeProvider(t *testing.T) {
 	app := newModelCommandTestApp()
-	app.Config.Model.Provider = "openai-completion"
-	app.Config.Model.URL = "https://api.openai.com/v1"
-	app.Config.Model.Model = "gpt-4o-mini"
-	app.Config.Model.Key = "env-key"
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-kimi-test")
 
-	var capturedAuth string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedAuth = r.Header.Get("Authorization")
-		if r.URL.Path != "/model-presets/kimi-k2.5-free/credential" {
-			http.NotFound(w, r)
-			return
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"kimi-for-coding": {
+			"id": "kimi-for-coding",
+			"name": "Kimi For Coding",
+			"api": "https://api.kimi.com/coding/v1",
+			"npm": "@ai-sdk/anthropic",
+			"models": {
+				"k2p5": {"id": "k2p5", "name": "Kimi K2.5"}
+			}
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{"api_key": "server-kimi-key"})
-	}))
-	t.Cleanup(srv.Close)
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
 
-	t.Setenv("HOME", t.TempDir())
-	cred := credentials{
-		ServerURL: srv.URL,
-		Token:     "user-token",
-		User:      "alice",
-		Role:      "user",
+	app.cmdModel(nil)
+
+	ev := drainUntilEventType(t, app, model.ModelBrowserOpen)
+	if ev.ModelBrowser == nil {
+		t.Fatal("ModelBrowserOpen popup = nil, want ModelBrowserPopup")
 	}
-	if err := saveCredentials(&cred); err != nil {
-		t.Fatalf("saveCredentials() error = %v", err)
+	if got := len(ev.ModelBrowser.ImportSuggestions); got != 0 {
+		t.Fatalf("len(ev.ModelBrowser.ImportSuggestions) = %d, want 0", got)
+	}
+	for _, opt := range ev.ModelBrowser.Models.Options {
+		if opt.ID == "__provider__kimi-for-coding" || opt.ID == "kimi-for-coding:k2p5" {
+			t.Fatalf("unexpected auto-imported option %q", opt.ID)
+		}
+	}
+}
+
+func TestCmdModel_NoArgsUsesCachedCatalogWithoutBlocking(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+	if err := writeModelsDevCache([]byte(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {}
+		}
+	}`)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
 	}
 
-	var resolved llm.ResolvedConfig
-	origBuildProvider := buildProvider
-	buildProvider = func(cfg llm.ResolvedConfig) (llm.Provider, error) {
-		resolved = cfg
-		return &blockingStreamProvider{started: make(chan struct{})}, nil
+	start := time.Now()
+	app.cmdModel(nil)
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("cmdModel(nil) took %v, want under 500ms", elapsed)
 	}
-	defer func() { buildProvider = origBuildProvider }()
+	drainUntilEventType(t, app, model.ModelBrowserOpen)
+}
 
-	app.cmdModel([]string{"kimi-k2.5-free"})
+func TestCmdModel_NoArgsHidesFreeProviderWhenLoggedOut(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"anthropic": {"id": "anthropic", "name": "Anthropic", "npm": "@ai-sdk/anthropic", "models": {}}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+	if err := writeModelsDevCache([]byte(`{
+		"anthropic": {"id": "anthropic", "name": "Anthropic", "npm": "@ai-sdk/anthropic", "models": {}}
+	}`)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	app.cmdModel(nil)
+
+	ev := drainUntilEventType(t, app, model.ModelBrowserOpen)
+	if ev.ModelBrowser == nil {
+		t.Fatal("ModelBrowserOpen popup = nil, want ModelBrowserPopup")
+	}
+	for _, opt := range ev.ModelBrowser.Providers.Options {
+		if opt.ID == mindsporeCLIFreeProviderID {
+			t.Fatal("expected free provider to be hidden when logged out")
+		}
+	}
+}
+
+func TestCmdModel_WithArgsRejected(t *testing.T) {
+	app := newModelCommandTestApp()
+
+	app.cmdModel([]string{"openrouter:openai/gpt-4o-mini"})
+
+	ev := drainUntilEventType(t, app, model.AgentReply)
+	if !strings.Contains(ev.Message, "no longer accepts arguments") {
+		t.Fatalf("message = %q, want argument rejection", ev.Message)
+	}
+}
+
+func TestCmdConnect_WithAPIKeyPersistsAuthAndRefreshesModelBrowser(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	app.cmdConnect([]string{"openrouter", "sk-openrouter"})
+
 	drainUntilEventType(t, app, model.AgentThinking)
-	drainUntilEventType(t, app, model.ModelUpdate)
-	drainUntilEventType(t, app, model.AgentReply)
+	ev := drainUntilEventType(t, app, model.ModelBrowserOpen)
+	if ev.ModelBrowser == nil {
+		t.Fatal("expected refreshed model browser")
+	}
+	if got, want := ev.ModelBrowser.Focus, model.ModelBrowserFocusModel; got != want {
+		t.Fatalf("focus = %v, want %v", got, want)
+	}
+	if got, want := ev.ModelBrowser.Models.Options[1].ID, "openrouter:openai/gpt-4o-mini"; got != want {
+		t.Fatalf("first model option = %q, want %q", got, want)
+	}
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	entry, ok := authState.Providers["openrouter"]
+	if !ok {
+		t.Fatalf("authState.Providers = %#v, want openrouter entry", authState.Providers)
+	}
+	if got, want := entry.APIKey, "sk-openrouter"; got != want {
+		t.Fatalf("entry.APIKey = %q, want %q", got, want)
+	}
+}
 
-	if got, want := capturedAuth, "Bearer user-token"; got != want {
-		t.Fatalf("credential request auth = %q, want %q", got, want)
-	}
-	if got, want := string(resolved.Kind), "anthropic"; got != want {
-		t.Fatalf("resolved provider = %q, want %q", got, want)
-	}
-	if got, want := resolved.BaseURL, "https://api.kimi.com/coding/"; got != want {
-		t.Fatalf("resolved base url = %q, want %q", got, want)
-	}
-	if got, want := resolved.Model, "kimi-k2.5"; got != want {
-		t.Fatalf("resolved model = %q, want %q", got, want)
-	}
-	if got, want := resolved.APIKey, "server-kimi-key"; got != want {
-		t.Fatalf("resolved key = %q, want %q", got, want)
+func TestCmdSelectModel_LogicalProviderSelectionWorksWithoutCache(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	if err := saveProviderAuthState(&providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+		},
+	}); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
 	}
 
-	app.cmdModel([]string{"gpt-4o"})
+	app.cmdSelectModel([]string{"openrouter:openai/gpt-4o-mini"})
+
 	drainUntilEventType(t, app, model.AgentThinking)
+	drainUntilEventType(t, app, model.ModelBrowserClose)
 	drainUntilEventType(t, app, model.ModelUpdate)
 	drainUntilEventType(t, app, model.AgentReply)
 
 	if got, want := app.Config.Model.Provider, "openai-completion"; got != want {
-		t.Fatalf("provider after restore = %q, want %q", got, want)
+		t.Fatalf("provider = %q, want %q", got, want)
 	}
-	if got, want := app.Config.Model.URL, "https://api.openai.com/v1"; got != want {
-		t.Fatalf("url after restore = %q, want %q", got, want)
+	if got, want := app.Config.Model.Model, "openai/gpt-4o-mini"; got != want {
+		t.Fatalf("model = %q, want %q", got, want)
 	}
-	if got, want := app.Config.Model.Key, "env-key"; got != want {
-		t.Fatalf("key after restore = %q, want %q", got, want)
+}
+
+func TestCmdDeleteProvider_RemovesAuthStateAndFallsBackToOtherModel(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		},
+		"anthropic": {
+			"id": "anthropic",
+			"name": "Anthropic",
+			"api": "https://api.anthropic.com",
+			"npm": "@ai-sdk/anthropic",
+			"models": {"claude-3-5-haiku": {"id": "claude-3-5-haiku", "name": "Claude 3.5 Haiku"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	if err := saveProviderAuthState(&providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+			"anthropic":  {ProviderID: "anthropic", APIKey: "sk-anthropic"},
+		},
+	}); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
 	}
-	if got, want := app.Config.Model.Model, "gpt-4o"; got != want {
-		t.Fatalf("model after switch = %q, want %q", got, want)
+	if err := saveModelSelectionState(&modelSelectionState{
+		Active: &modelRef{ProviderID: "openrouter", ModelID: "openai/gpt-4o-mini"},
+		Recents: []modelRef{
+			{ProviderID: "openrouter", ModelID: "openai/gpt-4o-mini"},
+			{ProviderID: "anthropic", ModelID: "claude-3-5-haiku"},
+		},
+		Favorites: []modelRef{
+			{ProviderID: "openrouter", ModelID: "openai/gpt-4o-mini"},
+		},
+	}); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
+
+	app.cmdDeleteProvider([]string{"openrouter"})
+
+	drainUntilEventType(t, app, model.AgentThinking)
+	ev := drainUntilEventType(t, app, model.ModelUpdate)
+	if got, want := ev.Message, "claude-3-5-haiku"; got != want {
+		t.Fatalf("model update = %q, want %q", got, want)
+	}
+	drainUntilEventType(t, app, model.ModelBrowserOpen)
+
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	if _, ok := authState.Providers["openrouter"]; ok {
+		t.Fatalf("authState.Providers = %#v, want openrouter removed", authState.Providers)
+	}
+
+	modelState, err := loadModelSelectionState()
+	if err != nil {
+		t.Fatalf("loadModelSelectionState() error = %v", err)
+	}
+	if modelState.Active == nil || modelState.Active.ProviderID != "anthropic" {
+		t.Fatalf("active = %#v, want anthropic fallback", modelState.Active)
+	}
+	for _, ref := range append(append([]modelRef{}, modelState.Recents...), modelState.Favorites...) {
+		if ref.ProviderID == "openrouter" {
+			t.Fatalf("model state still references deleted provider: %#v", modelState)
+		}
 	}
 }
 

--- a/internal/app/commands_model_test.go
+++ b/internal/app/commands_model_test.go
@@ -68,7 +68,7 @@ func TestCmdModel_NoArgsShowsModelBrowser(t *testing.T) {
 	}
 }
 
-func TestCmdModel_NoArgsDoesNotAutoImportClaudeCodeProvider(t *testing.T) {
+func TestCmdModel_NoArgsShowsClaudeCodeImportCandidateAtTop(t *testing.T) {
 	app := newModelCommandTestApp()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -102,13 +102,98 @@ func TestCmdModel_NoArgsDoesNotAutoImportClaudeCodeProvider(t *testing.T) {
 	if ev.ModelBrowser == nil {
 		t.Fatal("ModelBrowserOpen popup = nil, want ModelBrowserPopup")
 	}
-	if got := len(ev.ModelBrowser.ImportSuggestions); got != 0 {
-		t.Fatalf("len(ev.ModelBrowser.ImportSuggestions) = %d, want 0", got)
+	if got, want := ev.ModelBrowser.Focus, model.ModelBrowserFocusProvider; got != want {
+		t.Fatalf("focus = %v, want %v", got, want)
 	}
-	for _, opt := range ev.ModelBrowser.Models.Options {
-		if opt.ID == "__provider__kimi-for-coding" || opt.ID == "kimi-for-coding:k2p5" {
-			t.Fatalf("unexpected auto-imported option %q", opt.ID)
+	if got, want := len(ev.ModelBrowser.Models.Options), 0; got != want {
+		t.Fatalf("len(ev.ModelBrowser.Models.Options) = %d, want %d", got, want)
+	}
+	if len(ev.ModelBrowser.Providers.Options) < 2 {
+		t.Fatalf("len(ev.ModelBrowser.Providers.Options) = %d, want at least 5", len(ev.ModelBrowser.Providers.Options))
+	}
+	if got, want := ev.ModelBrowser.Providers.Options[0].ID, "__header__detected"; got != want {
+		t.Fatalf("providers[0].ID = %q, want %q", got, want)
+	}
+	if got, want := ev.ModelBrowser.Providers.Options[0].Label, "Import"; got != want {
+		t.Fatalf("providers[0].Label = %q, want %q", got, want)
+	}
+	candidate := ev.ModelBrowser.Providers.Options[1]
+	if got, want := candidate.ID, "__import_provider__:kimi-for-coding"; got != want {
+		t.Fatalf("candidate.ID = %q, want %q", got, want)
+	}
+	if got, want := candidate.Label, "Kimi For Coding"; got != want {
+		t.Fatalf("candidate.Label = %q, want %q", got, want)
+	}
+	if candidate.RequiresInput {
+		t.Fatal("expected candidate with env api key to connect without input")
+	}
+	if got := candidate.Desc; got != "" {
+		t.Fatalf("candidate.Desc = %q, want empty", got)
+	}
+	if got, want := ev.ModelBrowser.Providers.Options[2].Label, "from Claude Code environment detected:"; got != want {
+		t.Fatalf("providers[2].Label = %q, want %q", got, want)
+	}
+	if !ev.ModelBrowser.Providers.Options[2].DetailRow {
+		t.Fatal("expected providers[2] to be a detail row")
+	}
+	if got, want := ev.ModelBrowser.Providers.Options[3].Label, "- ANTHROPIC_BASE_URL=https://api.kimi.com/coding/"; got != want {
+		t.Fatalf("providers[3].Label = %q, want %q", got, want)
+	}
+	if got, want := ev.ModelBrowser.Providers.Options[4].Label, "- ANTHROPIC_API_KEY=sk-kimi-****test"; got != want {
+		t.Fatalf("providers[4].Label = %q, want %q", got, want)
+	}
+	foundCatalogProvider := false
+	for _, opt := range ev.ModelBrowser.Providers.Options {
+		if opt.ID == "kimi-for-coding" && opt.Label == "Kimi For Coding" {
+			foundCatalogProvider = true
+			break
 		}
+	}
+	if !foundCatalogProvider {
+		t.Fatal("expected original kimi-for-coding provider option to remain in popular/other list")
+	}
+}
+
+func TestCmdModel_NoArgsShowsClaudeCodeImportCandidateWithoutAPIKey(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"kimi-for-coding": {
+			"id": "kimi-for-coding",
+			"name": "Kimi For Coding",
+			"api": "https://api.kimi.com/coding/v1",
+			"npm": "@ai-sdk/anthropic",
+			"models": {
+				"k2p5": {"id": "k2p5", "name": "Kimi K2.5"}
+			}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	app.cmdModel(nil)
+
+	ev := drainUntilEventType(t, app, model.ModelBrowserOpen)
+	if ev.ModelBrowser == nil || len(ev.ModelBrowser.Providers.Options) < 2 {
+		t.Fatal("expected provider import candidate")
+	}
+	candidate := ev.ModelBrowser.Providers.Options[1]
+	if !candidate.RequiresInput {
+		t.Fatal("expected candidate without env api key to require input")
+	}
+	if got, want := ev.ModelBrowser.Providers.Options[4].Label, "- ANTHROPIC_API_KEY is not set; you'll enter it next"; got != want {
+		t.Fatalf("providers[4].Label = %q, want %q", got, want)
 	}
 }
 
@@ -249,6 +334,101 @@ func TestCmdConnect_WithAPIKeyPersistsAuthAndRefreshesModelBrowser(t *testing.T)
 	}
 	if got, want := entry.APIKey, "sk-openrouter"; got != want {
 		t.Fatalf("entry.APIKey = %q, want %q", got, want)
+	}
+}
+
+func TestCmdConnect_ClaudeCodeImportCandidateUsesEnvAPIKey(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-kimi-env")
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"kimi-for-coding": {
+			"id": "kimi-for-coding",
+			"name": "Kimi For Coding",
+			"api": "https://api.kimi.com/coding/v1",
+			"npm": "@ai-sdk/anthropic",
+			"models": {"k2p5": {"id": "k2p5", "name": "Kimi K2.5"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	app.cmdConnect([]string{"__import_provider__:kimi-for-coding"})
+
+	drainUntilEventType(t, app, model.AgentThinking)
+	ev := drainUntilEventType(t, app, model.ModelBrowserOpen)
+	if ev.ModelBrowser == nil {
+		t.Fatal("expected refreshed model browser")
+	}
+	if got, want := ev.ModelBrowser.Focus, model.ModelBrowserFocusModel; got != want {
+		t.Fatalf("focus = %v, want %v", got, want)
+	}
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	entry, ok := authState.Providers["kimi-for-coding"]
+	if !ok {
+		t.Fatalf("authState.Providers = %#v, want kimi-for-coding entry", authState.Providers)
+	}
+	if got, want := entry.APIKey, "sk-kimi-env"; got != want {
+		t.Fatalf("entry.APIKey = %q, want %q", got, want)
+	}
+}
+
+func TestCmdConnect_NormalProviderStillRequiresManualAPIKeyEvenWhenEnvDetected(t *testing.T) {
+	app := newModelCommandTestApp()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-kimi-env")
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+	origURL := modelsDevAPIURL
+	server := newModelsDevTestServer(`{
+		"kimi-for-coding": {
+			"id": "kimi-for-coding",
+			"name": "Kimi For Coding",
+			"api": "https://api.kimi.com/coding/v1",
+			"npm": "@ai-sdk/anthropic",
+			"models": {"k2p5": {"id": "k2p5", "name": "Kimi K2.5"}}
+		}
+	}`)
+	defer server.Close()
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+	resetModelsDevProviderCacheForTest()
+	t.Cleanup(resetModelsDevProviderCacheForTest)
+
+	app.cmdConnect([]string{"kimi-for-coding"})
+
+	drainUntilEventType(t, app, model.AgentThinking)
+	ev := drainUntilEventType(t, app, model.ToolError)
+	if got := ev.Message; !strings.Contains(got, "requires api key") {
+		t.Fatalf("tool error = %q, want requires api key", got)
+	}
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	if _, ok := authState.Providers["kimi-for-coding"]; ok {
+		t.Fatalf("authState.Providers = %#v, want no persisted kimi-for-coding entry", authState.Providers)
 	}
 }
 

--- a/internal/app/model_presets.go
+++ b/internal/app/model_presets.go
@@ -15,7 +15,7 @@ import (
 type modelCredentialStrategy string
 
 const (
-	credentialStrategyStatic       modelCredentialStrategy = "static"
+	credentialStrategyStatic      modelCredentialStrategy = "static"
 	credentialStrategyMSCLIServer modelCredentialStrategy = "mscli-server"
 )
 
@@ -114,33 +114,7 @@ func fetchPresetAPIKey(preset builtinModelPreset) (string, error) {
 		if err != nil || strings.TrimSpace(cred.Token) == "" || strings.TrimSpace(cred.ServerURL) == "" {
 			return "", fmt.Errorf("not logged in")
 		}
-		path := strings.TrimSpace(preset.Credential.Path)
-		if path == "" {
-			path = "/model-presets/" + preset.ID + "/credential"
-		}
-		url := strings.TrimRight(strings.TrimSpace(cred.ServerURL), "/") + path
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
-		if err != nil {
-			return "", err
-		}
-		req.Header.Set("Authorization", "Bearer "+cred.Token)
-		client := &http.Client{Timeout: 5 * time.Second}
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("status %d", resp.StatusCode)
-		}
-		var payload struct {
-			APIKey string `json:"api_key"`
-		}
-		if err := json.Unmarshal(data, &payload); err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(payload.APIKey), nil
+		return requestPresetCredential(context.Background(), preset, cred)
 	default:
 		return "", fmt.Errorf("unsupported strategy %q", preset.Credential.Strategy)
 	}
@@ -165,6 +139,17 @@ func (a *Application) fetchPresetAPIKeyFromServer(ctx context.Context, preset bu
 	if err != nil || strings.TrimSpace(cred.Token) == "" || strings.TrimSpace(cred.ServerURL) == "" {
 		return "", fmt.Errorf("not logged in. run /login <token> first")
 	}
+	apiKey, err := requestPresetCredential(ctx, preset, cred)
+	if err != nil {
+		return "", fmt.Errorf("request preset credential: %w", err)
+	}
+	return apiKey, nil
+}
+
+func requestPresetCredential(ctx context.Context, preset builtinModelPreset, cred *credentials) (string, error) {
+	if cred == nil {
+		return "", fmt.Errorf("credentials unavailable")
+	}
 	path := strings.TrimSpace(preset.Credential.Path)
 	if path == "" {
 		path = "/model-presets/" + preset.ID + "/credential"
@@ -180,13 +165,13 @@ func (a *Application) fetchPresetAPIKeyFromServer(ctx context.Context, preset bu
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("request preset credential: %w", err)
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("request preset credential failed: status %d", resp.StatusCode)
+		return "", fmt.Errorf("status %d", resp.StatusCode)
 	}
 	var payload struct {
 		APIKey string `json:"api_key"`

--- a/internal/app/model_setup_integration_test.go
+++ b/internal/app/model_setup_integration_test.go
@@ -8,8 +8,25 @@ import (
 	"github.com/mindspore-lab/mindspore-cli/ui/model"
 )
 
-func TestModelCommand_OpensSetupPopupWithState(t *testing.T) {
+func TestModelCommand_OpensModelBrowserWithState(t *testing.T) {
 	eventCh := make(chan model.Event, 64)
+	t.Setenv("HOME", t.TempDir())
+	if err := saveCredentials(&credentials{
+		ServerURL: "https://mscli.dev",
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
+	if err := saveModelSelectionState(&modelSelectionState{
+		Active: &modelRef{
+			ProviderID: mindsporeCLIFreeProviderID,
+			ModelID:    "kimi-k2.5",
+		},
+	}); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
 	app := &Application{
 		EventCh:             eventCh,
 		Config:              configs.DefaultConfig(),
@@ -19,36 +36,27 @@ func TestModelCommand_OpensSetupPopupWithState(t *testing.T) {
 
 	app.cmdModel(nil)
 
-	var popup *model.SetupPopup
+	var popup *model.ModelBrowserPopup
 	for len(eventCh) > 0 {
 		ev := <-eventCh
-		if ev.Type == model.ModelSetupOpen {
-			popup = ev.SetupPopup
+		if ev.Type == model.ModelBrowserOpen {
+			popup = ev.ModelBrowser
 		}
 	}
 	if popup == nil {
-		t.Fatal("expected setup popup to open")
+		t.Fatal("expected model browser to open")
 	}
-	if !popup.CanEscape {
-		t.Error("expected CanEscape=true from /model")
+	if len(popup.Models.Options) == 0 {
+		t.Fatal("expected model options")
 	}
-	if popup.CurrentMode != modelModeMSCLIProvided {
-		t.Errorf("expected current mode %q, got %q", modelModeMSCLIProvided, popup.CurrentMode)
-	}
-	if popup.CurrentPreset != "kimi-k2.5-free" {
-		t.Errorf("expected current preset 'kimi-k2.5-free', got %q", popup.CurrentPreset)
-	}
-
-	disabledCount := 0
-	for _, opt := range popup.PresetOptions {
-		if opt.Disabled {
-			disabledCount++
-			if !strings.Contains(opt.Label, "coming soon") {
-				t.Errorf("disabled option %q should contain 'coming soon'", opt.Label)
-			}
+	foundFree := false
+	for _, opt := range popup.Models.Options {
+		if strings.Contains(opt.ID, "mindspore-cli-free:kimi-k2.5") {
+			foundFree = true
+			break
 		}
 	}
-	if disabledCount != 2 {
-		t.Errorf("expected 2 disabled (coming soon) presets, got %d", disabledCount)
+	if !foundFree {
+		t.Errorf("expected free model option, got %#v", popup.Models.Options)
 	}
 }

--- a/internal/app/project_test.go
+++ b/internal/app/project_test.go
@@ -450,20 +450,20 @@ func TestRenderMilestoneLines_TagsColumn(t *testing.T) {
 	}
 }
 
-func TestRenderTaskLines_LongTitleTruncated(t *testing.T) {
+func TestRenderTaskLines_LongSingleTokenPreservedWithoutEllipsis(t *testing.T) {
 	longTitle := strings.Repeat("a", 120)
 	tasks := []projectTask{
 		{ID: "1", Title: longTitle, Status: "doing", Progress: 50, Owner: "alice", Tags: "long"},
 	}
 	lines := renderTaskLines(tasks)
 	if len(lines) != 1 {
-		t.Fatalf("expected 1 line, got %d", len(lines))
+		t.Fatalf("expected 1 line for single-token title, got %d", len(lines))
 	}
-	if strings.Contains(lines[0], longTitle) {
-		t.Errorf("expected title to be truncated, got full title in:\n%s", lines[0])
+	if strings.Contains(lines[0], "...") {
+		t.Errorf("expected long single-token title to be preserved without ellipsis, got:\n%s", lines[0])
 	}
-	if !strings.Contains(lines[0], "...") {
-		t.Errorf("expected truncation marker '...', got:\n%s", lines[0])
+	if !strings.Contains(lines[0], longTitle) {
+		t.Errorf("expected full single-token title to be preserved, got:\n%s", lines[0])
 	}
 }
 

--- a/internal/app/provider_catalog.go
+++ b/internal/app/provider_catalog.go
@@ -1,0 +1,462 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	mindsporeCLIFreeProviderID = "mindspore-cli-free"
+	defaultModelsDevAPIURL     = "https://models.dev/api.json"
+)
+
+var (
+	connectPopularProviderIDs = []string{
+		"anthropic",
+		"openai",
+		"kimi-for-coding",
+		"deepseek",
+	}
+	defaultPopularProviderIDs = append(
+		[]string{mindsporeCLIFreeProviderID},
+		append(append([]string(nil), connectPopularProviderIDs...), "openrouter", "google", "groq")...,
+	)
+
+	modelsDevAPIURL            = defaultModelsDevAPIURL
+	modelsDevCachePathOverride string
+
+	modelsDevProvidersCacheMu      sync.Mutex
+	modelsDevProvidersCache        []providerCatalogEntry
+	modelsDevProvidersCacheLoaded  bool
+	modelsDevProvidersRefreshAt    time.Time
+	modelsDevProvidersRefreshAlive bool
+)
+
+const modelsDevRefreshTTL = 5 * time.Minute
+
+type providerCatalog struct {
+	Providers []providerCatalogEntry
+}
+
+type providerCatalogEntry struct {
+	ID          string
+	Label       string
+	BaseURL     string
+	Protocol    string
+	Description string
+	Builtin     bool
+	Popular     bool
+	Models      []modelCatalogEntry
+}
+
+type modelCatalogEntry struct {
+	ProviderID      string
+	ID              string
+	Label           string
+	Description     string
+	ContextWindow   int
+	MaxOutputTokens int
+	Tags            []string
+}
+
+type modelsDevProvider struct {
+	ID     string                    `json:"id"`
+	API    string                    `json:"api"`
+	Name   string                    `json:"name"`
+	Doc    string                    `json:"doc"`
+	NPM    string                    `json:"npm"`
+	Models map[string]modelsDevModel `json:"models"`
+}
+
+type modelsDevModel struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Limit struct {
+		Context int `json:"context"`
+		Output  int `json:"output"`
+	} `json:"limit"`
+}
+
+func loadProviderCatalog(httpClient *http.Client, extras []extraProviderConfig) (*providerCatalog, error) {
+	providers := make(map[string]providerCatalogEntry)
+
+	for _, provider := range builtinProviderCatalog() {
+		providers[provider.ID] = provider
+	}
+
+	var remote []providerCatalogEntry
+	var ok bool
+	if httpClient == nil {
+		remote, ok = loadModelsDevProvidersNonBlocking()
+	} else {
+		remote, ok = loadModelsDevProviders(httpClient)
+	}
+	if ok {
+		for _, provider := range remote {
+			providers[provider.ID] = provider
+		}
+	}
+
+	for _, provider := range extraProvidersToCatalog(extras) {
+		providers[provider.ID] = provider
+	}
+
+	out := make([]providerCatalogEntry, 0, len(providers))
+	for _, provider := range providers {
+		out = append(out, provider)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left, right := out[i], out[j]
+		if left.Popular != right.Popular {
+			return left.Popular
+		}
+		if left.Builtin != right.Builtin {
+			return left.Builtin
+		}
+		return left.Label < right.Label
+	})
+
+	return &providerCatalog{Providers: out}, nil
+}
+
+func loadProviderCatalogBlocking(extras []extraProviderConfig) (*providerCatalog, error) {
+	return loadProviderCatalog(&http.Client{Timeout: 5 * time.Second}, extras)
+}
+
+func loadModelsDevProvidersNonBlocking() ([]providerCatalogEntry, bool) {
+	if cached, ok := cachedModelsDevProviders(); ok {
+		maybeRefreshModelsDevProvidersAsync()
+		return cached, true
+	}
+	if disk, ok := loadModelsDevProvidersFromDisk(); ok {
+		setCachedModelsDevProvidersFromDisk(disk)
+		maybeRefreshModelsDevProvidersAsync()
+		return disk, true
+	}
+	maybeRefreshModelsDevProvidersAsync()
+	return nil, false
+}
+
+func (c *providerCatalog) Provider(id string) (providerCatalogEntry, bool) {
+	if c == nil {
+		return providerCatalogEntry{}, false
+	}
+	needle := normalizedProviderID(id)
+	for _, provider := range c.Providers {
+		if provider.ID == needle {
+			return provider, true
+		}
+	}
+	return providerCatalogEntry{}, false
+}
+
+func builtinProviderCatalog() []providerCatalogEntry {
+	return []providerCatalogEntry{
+		{
+			ID:       mindsporeCLIFreeProviderID,
+			Label:    "MindSpore CLI Free",
+			Protocol: "mindspore-cli-free",
+			Builtin:  true,
+			Popular:  true,
+			Models: []modelCatalogEntry{
+				{
+					ProviderID:      mindsporeCLIFreeProviderID,
+					ID:              "kimi-k2.5",
+					Label:           "Kimi K2.5",
+					ContextWindow:   262144,
+					MaxOutputTokens: 262144,
+				},
+				{
+					ProviderID:      mindsporeCLIFreeProviderID,
+					ID:              "deepseek-chat",
+					Label:           "DeepSeek V3",
+					ContextWindow:   128000,
+					MaxOutputTokens: 8000,
+				},
+			},
+		},
+	}
+}
+
+func loadModelsDevProviders(httpClient *http.Client) ([]providerCatalogEntry, bool) {
+	body, ok := fetchModelsDevCatalog(httpClient)
+	if ok {
+		_ = writeModelsDevCache(body)
+	} else {
+		cached, err := readModelsDevCache()
+		if err != nil {
+			return nil, false
+		}
+		body = cached
+	}
+
+	parsed, err := parseModelsDevCatalog(body)
+	if err != nil {
+		return nil, false
+	}
+	setCachedModelsDevProviders(parsed)
+	return parsed, true
+}
+
+func loadModelsDevProvidersFromDisk() ([]providerCatalogEntry, bool) {
+	cached, err := readModelsDevCache()
+	if err != nil {
+		return nil, false
+	}
+	parsed, err := parseModelsDevCatalog(cached)
+	if err != nil {
+		return nil, false
+	}
+	return parsed, true
+}
+
+func cachedModelsDevProviders() ([]providerCatalogEntry, bool) {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	if !modelsDevProvidersCacheLoaded || len(modelsDevProvidersCache) == 0 {
+		return nil, false
+	}
+	return cloneProviderCatalogEntries(modelsDevProvidersCache), true
+}
+
+func setCachedModelsDevProviders(providers []providerCatalogEntry) {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	modelsDevProvidersCache = cloneProviderCatalogEntries(providers)
+	modelsDevProvidersCacheLoaded = true
+	modelsDevProvidersRefreshAt = time.Now()
+}
+
+func setCachedModelsDevProvidersFromDisk(providers []providerCatalogEntry) {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	modelsDevProvidersCache = cloneProviderCatalogEntries(providers)
+	modelsDevProvidersCacheLoaded = true
+}
+
+func maybeRefreshModelsDevProvidersAsync() {
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+
+	modelsDevProvidersCacheMu.Lock()
+	if modelsDevProvidersRefreshAlive {
+		modelsDevProvidersCacheMu.Unlock()
+		return
+	}
+	if !modelsDevProvidersRefreshAt.IsZero() && time.Since(modelsDevProvidersRefreshAt) < modelsDevRefreshTTL {
+		modelsDevProvidersCacheMu.Unlock()
+		return
+	}
+	modelsDevProvidersRefreshAlive = true
+	modelsDevProvidersRefreshAt = time.Now()
+	modelsDevProvidersCacheMu.Unlock()
+
+	go func() {
+		defer func() {
+			modelsDevProvidersCacheMu.Lock()
+			modelsDevProvidersRefreshAlive = false
+			modelsDevProvidersCacheMu.Unlock()
+		}()
+
+		body, ok := fetchModelsDevCatalog(httpClient)
+		if !ok {
+			return
+		}
+		parsed, err := parseModelsDevCatalog(body)
+		if err != nil {
+			return
+		}
+		_ = writeModelsDevCache(body)
+		setCachedModelsDevProviders(parsed)
+	}()
+}
+
+func cloneProviderCatalogEntries(in []providerCatalogEntry) []providerCatalogEntry {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]providerCatalogEntry, len(in))
+	for i, provider := range in {
+		cloned := provider
+		if len(provider.Models) > 0 {
+			cloned.Models = append([]modelCatalogEntry(nil), provider.Models...)
+		}
+		out[i] = cloned
+	}
+	return out
+}
+
+func resetModelsDevProviderCacheForTest() {
+	modelsDevProvidersCacheMu.Lock()
+	defer modelsDevProvidersCacheMu.Unlock()
+	modelsDevProvidersCache = nil
+	modelsDevProvidersCacheLoaded = false
+	modelsDevProvidersRefreshAt = time.Time{}
+	modelsDevProvidersRefreshAlive = false
+}
+
+func fetchModelsDevCatalog(httpClient *http.Client) ([]byte, bool) {
+	req, err := http.NewRequest(http.MethodGet, modelsDevAPIURL, nil)
+	if err != nil {
+		return nil, false
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, false
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024*1024))
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+func parseModelsDevCatalog(body []byte) ([]providerCatalogEntry, error) {
+	var payload map[string]modelsDevProvider
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	out := make([]providerCatalogEntry, 0, len(payload))
+	for _, provider := range payload {
+		id := normalizedProviderID(provider.ID)
+		if id == "" {
+			continue
+		}
+		models := make([]modelCatalogEntry, 0, len(provider.Models))
+		for modelID, model := range provider.Models {
+			normalizedModelID := strings.TrimSpace(model.ID)
+			if normalizedModelID == "" {
+				normalizedModelID = strings.TrimSpace(modelID)
+			}
+			if normalizedModelID == "" {
+				continue
+			}
+			label := strings.TrimSpace(model.Name)
+			if label == "" {
+				label = normalizedModelID
+			}
+			models = append(models, modelCatalogEntry{
+				ProviderID:      id,
+				ID:              normalizedModelID,
+				Label:           label,
+				ContextWindow:   model.Limit.Context,
+				MaxOutputTokens: model.Limit.Output,
+			})
+		}
+		sort.Slice(models, func(i, j int) bool { return models[i].Label < models[j].Label })
+
+		label := strings.TrimSpace(provider.Name)
+		if label == "" {
+			label = id
+		}
+		label = canonicalProviderLabel(id, label)
+		out = append(out, providerCatalogEntry{
+			ID:          id,
+			Label:       label,
+			BaseURL:     strings.TrimSpace(provider.API),
+			Protocol:    inferProtocolFromModelsDev(provider),
+			Description: strings.TrimSpace(provider.Doc),
+			Popular:     isPopularProviderID(id),
+			Models:      models,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Label < out[j].Label })
+	return out, nil
+}
+
+func extraProvidersToCatalog(extras []extraProviderConfig) []providerCatalogEntry {
+	out := make([]providerCatalogEntry, 0, len(extras))
+	for _, provider := range extras {
+		id := normalizedProviderID(provider.ID)
+		if id == "" {
+			continue
+		}
+		label := strings.TrimSpace(provider.Label)
+		if label == "" {
+			label = provider.ID
+		}
+		label = canonicalProviderLabel(id, label)
+		models := make([]modelCatalogEntry, 0, len(provider.Models))
+		for _, model := range provider.Models {
+			modelID := strings.TrimSpace(model.ID)
+			if modelID == "" {
+				continue
+			}
+			modelLabel := strings.TrimSpace(model.Label)
+			if modelLabel == "" {
+				modelLabel = modelID
+			}
+			models = append(models, modelCatalogEntry{
+				ProviderID: id,
+				ID:         modelID,
+				Label:      modelLabel,
+			})
+		}
+		out = append(out, providerCatalogEntry{
+			ID:       id,
+			Label:    label,
+			BaseURL:  strings.TrimSpace(provider.BaseURL),
+			Protocol: strings.TrimSpace(provider.Protocol),
+			Popular:  isPopularProviderID(id),
+			Models:   models,
+		})
+	}
+	return out
+}
+
+func inferProtocolFromModelsDev(provider modelsDevProvider) string {
+	npm := strings.ToLower(strings.TrimSpace(provider.NPM))
+	switch {
+	case strings.Contains(npm, "anthropic"):
+		return "anthropic-messages"
+	case strings.Contains(npm, "responses"):
+		return "openai-responses"
+	default:
+		return "openai-chat"
+	}
+}
+
+func isPopularProviderID(id string) bool {
+	needle := normalizedProviderID(id)
+	for _, candidate := range defaultPopularProviderIDs {
+		if needle == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalProviderLabel(id, fallback string) string {
+	return strings.TrimSpace(fallback)
+}
+
+func modelsDevCachePath() string {
+	if modelsDevCachePathOverride != "" {
+		return modelsDevCachePathOverride
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+}
+
+func writeModelsDevCache(body []byte) error {
+	path := modelsDevCachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o600)
+}
+
+func readModelsDevCache() ([]byte, error) {
+	return os.ReadFile(modelsDevCachePath())
+}

--- a/internal/app/provider_catalog_test.go
+++ b/internal/app/provider_catalog_test.go
@@ -1,0 +1,344 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestProviderCatalogIncludesBuiltinFreeProvider(t *testing.T) {
+	server := newModelsDevTestServer(`{}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	provider, ok := catalog.Provider(mindsporeCLIFreeProviderID)
+	if !ok {
+		t.Fatalf("catalog.Provider(%q) ok = false", mindsporeCLIFreeProviderID)
+	}
+	if got, want := provider.Label, "MindSpore CLI Free"; got != want {
+		t.Fatalf("provider.Label = %q, want %q", got, want)
+	}
+	if got, want := provider.Models[0].ID, "kimi-k2.5"; got != want {
+		t.Fatalf("provider.Models[0].ID = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogMergesModelsDevAndExtraProviders(t *testing.T) {
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {
+				"openai/gpt-4o-mini": {
+					"id": "openai/gpt-4o-mini",
+					"name": "GPT-4o mini",
+					"limit": {"context": 128000, "output": 16384}
+				}
+			}
+		}
+	}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, []extraProviderConfig{
+		{
+			ID:       "my-gateway",
+			Label:    "My Gateway",
+			BaseURL:  "https://llm.example.com/v1",
+			Protocol: "openai-chat",
+			Models: []extraProviderModelConfig{
+				{ID: "my-model", Label: "My Model"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	if _, ok := catalog.Provider("openrouter"); !ok {
+		t.Fatal("expected openrouter in merged catalog")
+	}
+	custom, ok := catalog.Provider("my-gateway")
+	if !ok {
+		t.Fatal("expected my-gateway in merged catalog")
+	}
+	if got, want := custom.Models[0].ID, "my-model"; got != want {
+		t.Fatalf("custom.Models[0].ID = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogLocalOverridesTakePrecedence(t *testing.T) {
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {
+				"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}
+			}
+		}
+	}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, []extraProviderConfig{
+		{
+			ID:       "openrouter",
+			Label:    "OpenRouter Custom",
+			BaseURL:  "https://custom.example/v1",
+			Protocol: "openai-chat",
+			Models: []extraProviderModelConfig{
+				{ID: "custom-model", Label: "Custom Model"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	provider, ok := catalog.Provider("openrouter")
+	if !ok {
+		t.Fatal("expected openrouter in catalog")
+	}
+	if got, want := provider.Label, "OpenRouter Custom"; got != want {
+		t.Fatalf("provider.Label = %q, want %q", got, want)
+	}
+	if got, want := provider.BaseURL, "https://custom.example/v1"; got != want {
+		t.Fatalf("provider.BaseURL = %q, want %q", got, want)
+	}
+	if got, want := provider.Models[0].ID, "custom-model"; got != want {
+		t.Fatalf("provider.Models[0].ID = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogFallsBackToCacheOnFetchFailure(t *testing.T) {
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	cached := `{
+		"anthropic": {
+			"id": "anthropic",
+			"name": "Anthropic",
+			"npm": "@ai-sdk/anthropic",
+			"models": {
+				"claude-sonnet-4-5": {"id": "claude-sonnet-4-5", "name": "Claude Sonnet 4.5"}
+			}
+		}
+	}`
+	if err := writeModelsDevCache([]byte(cached)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = "http://127.0.0.1:1"
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	if _, ok := catalog.Provider("anthropic"); !ok {
+		t.Fatal("expected cached anthropic provider")
+	}
+}
+
+func TestProviderCatalogFallsBackToBuiltinAndExtraWithoutCache(t *testing.T) {
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "missing", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = "http://127.0.0.1:1"
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, []extraProviderConfig{
+		{
+			ID:       "my-gateway",
+			BaseURL:  "https://llm.example.com/v1",
+			Protocol: "openai-chat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+
+	if _, ok := catalog.Provider(mindsporeCLIFreeProviderID); !ok {
+		t.Fatal("expected builtin free provider")
+	}
+	if _, ok := catalog.Provider("my-gateway"); !ok {
+		t.Fatal("expected extra provider fallback")
+	}
+}
+
+func TestProviderCatalogPreservesProviderIDAndName(t *testing.T) {
+	server := newModelsDevTestServer(`{
+		"acmeai": {
+			"id": "acmeai",
+			"name": "Acme AI",
+			"api": "https://api.acme.ai/v1",
+			"npm": "@ai-sdk/openai-compatible",
+			"models": {}
+		}
+	}`)
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	catalog, err := loadProviderCatalog(http.DefaultClient, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	provider, ok := catalog.Provider("acmeai")
+	if !ok {
+		t.Fatal("expected acmeai in catalog")
+	}
+	if got, want := provider.ID, "acmeai"; got != want {
+		t.Fatalf("provider.ID = %q, want %q", got, want)
+	}
+	if got, want := provider.Label, "Acme AI"; got != want {
+		t.Fatalf("provider.Label = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCatalogUsesCacheWithoutBlockingWhenNilClient(t *testing.T) {
+	resetModelsDevProviderCacheForTest()
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	cached := `{
+		"anthropic": {
+			"id": "anthropic",
+			"name": "Anthropic",
+			"npm": "@ai-sdk/anthropic",
+			"models": {}
+		}
+	}`
+	if err := writeModelsDevCache([]byte(cached)); err != nil {
+		t.Fatalf("writeModelsDevCache() error = %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	start := time.Now()
+	catalog, err := loadProviderCatalog(nil, nil)
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("loadProviderCatalog() took %v, want under 500ms", elapsed)
+	}
+	if _, ok := catalog.Provider("anthropic"); !ok {
+		t.Fatal("expected cached anthropic provider")
+	}
+}
+
+func TestProviderCatalogNilClientReturnsBuiltinAndExtraWithoutBlockingWhenCacheMissing(t *testing.T) {
+	resetModelsDevProviderCacheForTest()
+
+	dir := t.TempDir()
+	origCache := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(dir, "missing", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCache })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"openrouter": {
+				"id": "openrouter",
+				"name": "OpenRouter",
+				"npm": "@openrouter/ai-sdk-provider",
+				"models": {}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	start := time.Now()
+	catalog, err := loadProviderCatalog(nil, []extraProviderConfig{
+		{
+			ID:       "my-gateway",
+			BaseURL:  "https://llm.example.com/v1",
+			Protocol: "openai-chat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadProviderCatalog() error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("loadProviderCatalog() took %v, want under 500ms", elapsed)
+	}
+	if _, ok := catalog.Provider(mindsporeCLIFreeProviderID); !ok {
+		t.Fatal("expected builtin free provider")
+	}
+	if _, ok := catalog.Provider("my-gateway"); !ok {
+		t.Fatal("expected extra provider")
+	}
+}
+
+func newModelsDevTestServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}

--- a/internal/app/provider_env_import.go
+++ b/internal/app/provider_env_import.go
@@ -1,0 +1,292 @@
+package app
+
+import (
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+const (
+	providerImportSourceClaudeCode    = "claude-code-env"
+	providerImportSourceClaudeCodeUI  = "Claude Code env"
+	providerProtocolAnthropicMessages = "anthropic-messages"
+)
+
+var providerVersionSuffixPattern = regexp.MustCompile(`^v[0-9][a-z0-9.-]*$`)
+
+type providerImportSuggestion struct {
+	ProviderID    string
+	ProviderLabel string
+	Source        string
+	SourceLabel   string
+	Protocol      string
+	BaseURL       string
+	APIKey        string
+	APIKeyEnvVar  string
+	BaseURLEnvVar string
+}
+
+type providerEnvCandidate struct {
+	Source        string
+	SourceLabel   string
+	Protocol      string
+	BaseURL       string
+	APIKey        string
+	APIKeyEnvVar  string
+	BaseURLEnvVar string
+}
+
+func detectProviderImportSuggestions(catalog *providerCatalog, persistedAuth *providerAuthState) []providerImportSuggestion {
+	if catalog == nil {
+		return nil
+	}
+
+	connected := map[string]struct{}{}
+	if persistedAuth != nil {
+		for providerID, entry := range persistedAuth.Providers {
+			if strings.TrimSpace(entry.APIKey) == "" {
+				continue
+			}
+			connected[normalizedProviderID(providerID)] = struct{}{}
+		}
+	}
+
+	seen := map[string]struct{}{}
+	out := make([]providerImportSuggestion, 0)
+	for _, candidate := range detectClaudeCodeEnvCandidates() {
+		provider, ok := matchProviderCatalogForEnvCandidate(catalog, candidate)
+		if !ok {
+			continue
+		}
+		if _, ok := connected[provider.ID]; ok {
+			continue
+		}
+		if _, ok := seen[provider.ID]; ok {
+			continue
+		}
+		seen[provider.ID] = struct{}{}
+		out = append(out, providerImportSuggestion{
+			ProviderID:    provider.ID,
+			ProviderLabel: provider.Label,
+			Source:        candidate.Source,
+			SourceLabel:   candidate.SourceLabel,
+			Protocol:      provider.Protocol,
+			BaseURL:       provider.BaseURL,
+			APIKey:        candidate.APIKey,
+			APIKeyEnvVar:  candidate.APIKeyEnvVar,
+			BaseURLEnvVar: candidate.BaseURLEnvVar,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ProviderLabel != out[j].ProviderLabel {
+			return out[i].ProviderLabel < out[j].ProviderLabel
+		}
+		return out[i].ProviderID < out[j].ProviderID
+	})
+	return out
+}
+
+func detectClaudeCodeEnvCandidates() []providerEnvCandidate {
+	baseURL := strings.TrimSpace(os.Getenv("ANTHROPIC_BASE_URL"))
+	apiKey := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	if baseURL == "" || apiKey == "" {
+		return nil
+	}
+	return []providerEnvCandidate{
+		{
+			Source:        providerImportSourceClaudeCode,
+			SourceLabel:   providerImportSourceClaudeCodeUI,
+			Protocol:      providerProtocolAnthropicMessages,
+			BaseURL:       baseURL,
+			APIKey:        apiKey,
+			APIKeyEnvVar:  "ANTHROPIC_API_KEY",
+			BaseURLEnvVar: "ANTHROPIC_BASE_URL",
+		},
+	}
+}
+
+func hasProviderEnvCandidates() bool {
+	return len(detectClaudeCodeEnvCandidates()) > 0
+}
+
+func matchProviderCatalogForEnvCandidate(catalog *providerCatalog, candidate providerEnvCandidate) (providerCatalogEntry, bool) {
+	if catalog == nil {
+		return providerCatalogEntry{}, false
+	}
+
+	bestScore := 0
+	best := providerCatalogEntry{}
+	for _, provider := range catalog.Providers {
+		if normalizedProviderProtocol(provider.Protocol) != normalizedProviderProtocol(candidate.Protocol) {
+			continue
+		}
+		score := providerBaseURLMatchScore(provider.BaseURL, candidate.BaseURL)
+		if score > bestScore {
+			bestScore = score
+			best = provider
+		}
+	}
+	if bestScore == 0 {
+		return providerCatalogEntry{}, false
+	}
+	return best, true
+}
+
+func normalizedProviderProtocol(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
+}
+
+func providerBaseURLMatchScore(catalogBaseURL, envBaseURL string) int {
+	catalogVariants := comparableProviderBaseURLVariants(catalogBaseURL)
+	envVariants := comparableProviderBaseURLVariants(envBaseURL)
+	if len(catalogVariants) == 0 || len(envVariants) == 0 {
+		return 0
+	}
+
+	for i, left := range catalogVariants {
+		for j, right := range envVariants {
+			if left != right {
+				continue
+			}
+			if i == 0 && j == 0 {
+				return 2
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+func comparableProviderBaseURLVariants(raw string) []string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return []string{strings.ToLower(strings.TrimRight(trimmed, "/"))}
+	}
+
+	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
+	host := strings.ToLower(strings.TrimSpace(parsed.Host))
+	basePath := normalizeComparableURLPath(parsed.Path)
+
+	seen := map[string]struct{}{}
+	add := func(pathValue string, out *[]string) {
+		value := scheme + "://" + host + pathValue
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		*out = append(*out, value)
+	}
+
+	out := make([]string, 0, 3)
+	add(basePath, &out)
+
+	if trimmedVersion := trimVersionSuffixFromPath(basePath); trimmedVersion != basePath {
+		add(trimmedVersion, &out)
+	}
+
+	return out
+}
+
+func normalizeComparableURLPath(rawPath string) string {
+	if strings.TrimSpace(rawPath) == "" {
+		return ""
+	}
+	cleaned := path.Clean("/" + strings.TrimSpace(rawPath))
+	if cleaned == "/" {
+		return ""
+	}
+	return strings.TrimRight(cleaned, "/")
+}
+
+func trimVersionSuffixFromPath(rawPath string) string {
+	trimmed := strings.Trim(strings.TrimSpace(rawPath), "/")
+	if trimmed == "" {
+		return ""
+	}
+	segments := strings.Split(trimmed, "/")
+	last := strings.ToLower(strings.TrimSpace(segments[len(segments)-1]))
+	if !providerVersionSuffixPattern.MatchString(last) {
+		return rawPath
+	}
+	if len(segments) == 1 {
+		return ""
+	}
+	return "/" + strings.Join(segments[:len(segments)-1], "/")
+}
+
+func mergeProviderAuthStateWithImports(persistedAuth *providerAuthState, suggestions []providerImportSuggestion) *providerAuthState {
+	merged := cloneProviderAuthState(persistedAuth)
+	if merged == nil {
+		merged = emptyProviderAuthState()
+	}
+	for _, suggestion := range suggestions {
+		if strings.TrimSpace(suggestion.ProviderID) == "" || strings.TrimSpace(suggestion.APIKey) == "" {
+			continue
+		}
+		if entry, ok := merged.Providers[suggestion.ProviderID]; ok && strings.TrimSpace(entry.APIKey) != "" {
+			continue
+		}
+		merged.Providers[suggestion.ProviderID] = providerAuthEntry{
+			ProviderID: suggestion.ProviderID,
+			APIKey:     suggestion.APIKey,
+		}
+	}
+	merged.normalize()
+	return merged
+}
+
+func cloneProviderAuthState(in *providerAuthState) *providerAuthState {
+	if in == nil {
+		return nil
+	}
+	out := &providerAuthState{
+		Providers: make(map[string]providerAuthEntry, len(in.Providers)),
+	}
+	for key, entry := range in.Providers {
+		out.Providers[key] = entry
+	}
+	out.normalize()
+	return out
+}
+
+func providerImportSuggestionByID(suggestions []providerImportSuggestion) map[string]providerImportSuggestion {
+	if len(suggestions) == 0 {
+		return nil
+	}
+	out := make(map[string]providerImportSuggestion, len(suggestions))
+	for _, suggestion := range suggestions {
+		out[normalizedProviderID(suggestion.ProviderID)] = suggestion
+	}
+	return out
+}
+
+func toModelProviderImportSuggestions(in []providerImportSuggestion) []model.ProviderImportSuggestion {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]model.ProviderImportSuggestion, 0, len(in))
+	for _, suggestion := range in {
+		out = append(out, model.ProviderImportSuggestion{
+			ProviderID:    suggestion.ProviderID,
+			ProviderLabel: suggestion.ProviderLabel,
+			Source:        suggestion.Source,
+			SourceLabel:   suggestion.SourceLabel,
+			Protocol:      suggestion.Protocol,
+			BaseURL:       suggestion.BaseURL,
+			APIKeyEnvVar:  suggestion.APIKeyEnvVar,
+			BaseURLEnvVar: suggestion.BaseURLEnvVar,
+		})
+	}
+	return out
+}

--- a/internal/app/provider_env_import.go
+++ b/internal/app/provider_env_import.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -95,7 +96,7 @@ func detectProviderImportSuggestions(catalog *providerCatalog, persistedAuth *pr
 func detectClaudeCodeEnvCandidates() []providerEnvCandidate {
 	baseURL := strings.TrimSpace(os.Getenv("ANTHROPIC_BASE_URL"))
 	apiKey := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
-	if baseURL == "" || apiKey == "" {
+	if baseURL == "" {
 		return nil
 	}
 	return []providerEnvCandidate{
@@ -113,6 +114,43 @@ func detectClaudeCodeEnvCandidates() []providerEnvCandidate {
 
 func hasProviderEnvCandidates() bool {
 	return len(detectClaudeCodeEnvCandidates()) > 0
+}
+
+func providerImportBaseURLLine(suggestion providerImportSuggestion) string {
+	return "- " + suggestion.BaseURLEnvVar + "=" + strings.TrimSpace(os.Getenv(suggestion.BaseURLEnvVar))
+}
+
+func providerImportAPIKeyLine(suggestion providerImportSuggestion) string {
+	if strings.TrimSpace(suggestion.APIKey) == "" {
+		return fmt.Sprintf("- %s is not set; you'll enter it next", suggestion.APIKeyEnvVar)
+	}
+	return "- " + suggestion.APIKeyEnvVar + "=" + maskImportedAPIKey(suggestion.APIKey)
+}
+
+func maskImportedAPIKey(raw string) string {
+	token := strings.TrimSpace(raw)
+	if token == "" {
+		return ""
+	}
+	runes := []rune(token)
+	if len(runes) <= 8 {
+		prefix := 4
+		if len(runes) < prefix {
+			prefix = len(runes)
+		}
+		return string(runes[:prefix]) + "****"
+	}
+	if len(runes) <= 16 {
+		return string(runes[:8]) + "****" + string(runes[len(runes)-4:])
+	}
+	prefix := 12
+	if prefix > len(runes)-4 {
+		prefix = len(runes) - 4
+	}
+	if prefix < 4 {
+		prefix = 4
+	}
+	return string(runes[:prefix]) + "****" + string(runes[len(runes)-4:])
 }
 
 func matchProviderCatalogForEnvCandidate(catalog *providerCatalog, candidate providerEnvCandidate) (providerCatalogEntry, bool) {

--- a/internal/app/provider_env_import_test.go
+++ b/internal/app/provider_env_import_test.go
@@ -1,0 +1,37 @@
+package app
+
+import "testing"
+
+func TestDetectProviderImportSuggestionsMatchesClaudeCodeKimiConfig(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-kimi-test")
+
+	catalog := &providerCatalog{
+		Providers: []providerCatalogEntry{
+			{
+				ID:       "kimi-for-coding",
+				Label:    "Kimi For Coding",
+				BaseURL:  "https://api.kimi.com/coding/v1",
+				Protocol: "anthropic-messages",
+			},
+		},
+	}
+
+	suggestions := detectProviderImportSuggestions(catalog, emptyProviderAuthState())
+	if got, want := len(suggestions), 1; got != want {
+		t.Fatalf("len(suggestions) = %d, want %d", got, want)
+	}
+	suggestion := suggestions[0]
+	if got, want := suggestion.ProviderID, "kimi-for-coding"; got != want {
+		t.Fatalf("suggestion.ProviderID = %q, want %q", got, want)
+	}
+	if got, want := suggestion.Protocol, "anthropic-messages"; got != want {
+		t.Fatalf("suggestion.Protocol = %q, want %q", got, want)
+	}
+	if got, want := suggestion.APIKeyEnvVar, "ANTHROPIC_API_KEY"; got != want {
+		t.Fatalf("suggestion.APIKeyEnvVar = %q, want %q", got, want)
+	}
+	if got, want := suggestion.BaseURLEnvVar, "ANTHROPIC_BASE_URL"; got != want {
+		t.Fatalf("suggestion.BaseURLEnvVar = %q, want %q", got, want)
+	}
+}

--- a/internal/app/provider_env_import_test.go
+++ b/internal/app/provider_env_import_test.go
@@ -35,3 +35,27 @@ func TestDetectProviderImportSuggestionsMatchesClaudeCodeKimiConfig(t *testing.T
 		t.Fatalf("suggestion.BaseURLEnvVar = %q, want %q", got, want)
 	}
 }
+
+func TestDetectProviderImportSuggestionsMatchesClaudeCodeKimiConfigWithoutAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	catalog := &providerCatalog{
+		Providers: []providerCatalogEntry{
+			{
+				ID:       "kimi-for-coding",
+				Label:    "Kimi For Coding",
+				BaseURL:  "https://api.kimi.com/coding/v1",
+				Protocol: "anthropic-messages",
+			},
+		},
+	}
+
+	suggestions := detectProviderImportSuggestions(catalog, emptyProviderAuthState())
+	if got, want := len(suggestions), 1; got != want {
+		t.Fatalf("len(suggestions) = %d, want %d", got, want)
+	}
+	if got, want := suggestions[0].APIKey, ""; got != want {
+		t.Fatalf("suggestions[0].APIKey = %q, want empty", got)
+	}
+}

--- a/internal/app/provider_restore_test.go
+++ b/internal/app/provider_restore_test.go
@@ -1,0 +1,198 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/configs"
+)
+
+func TestRestoreProviderSelectionUsesPersistentState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origConfigPath := appConfigPathOverride
+	appConfigPathOverride = filepath.Join(home, ".mscli", "config.json")
+	t.Cleanup(func() { appConfigPathOverride = origConfigPath })
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+	origCachePath := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCachePath })
+
+	server := newModelsDevTestServer(`{
+		"openrouter": {
+			"id": "openrouter",
+			"name": "OpenRouter",
+			"api": "https://openrouter.ai/api/v1",
+			"npm": "@openrouter/ai-sdk-provider",
+			"models": {"openai/gpt-4o-mini": {"id": "openai/gpt-4o-mini", "name": "GPT-4o mini"}}
+		}
+	}`)
+	defer server.Close()
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	if err := saveProviderAuthState(&providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+		},
+	}); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
+	}
+	if err := saveModelSelectionState(&modelSelectionState{
+		Active: &modelRef{ProviderID: "openrouter", ModelID: "openai/gpt-4o-mini"},
+	}); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
+
+	cfg := configs.DefaultConfig()
+	result, err := restoreProviderSelection(cfg)
+	if err != nil {
+		t.Fatalf("restoreProviderSelection() error = %v", err)
+	}
+	if !result.Restored {
+		t.Fatal("result.Restored = false, want true")
+	}
+	if got, want := cfg.Model.Provider, "openai-completion"; got != want {
+		t.Fatalf("cfg.Model.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.Model, "openai/gpt-4o-mini"; got != want {
+		t.Fatalf("cfg.Model.Model = %q, want %q", got, want)
+	}
+}
+
+func TestRestoreProviderSelectionDoesNotUseClaudeCodeEnvImportWithoutConfirmation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.kimi.com/coding/")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-kimi-env")
+
+	origConfigPath := appConfigPathOverride
+	appConfigPathOverride = filepath.Join(home, ".mscli", "config.json")
+	t.Cleanup(func() { appConfigPathOverride = origConfigPath })
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+	origCachePath := modelsDevCachePathOverride
+	modelsDevCachePathOverride = filepath.Join(home, ".mscli", "cached", "models-dev-api.json")
+	t.Cleanup(func() { modelsDevCachePathOverride = origCachePath })
+
+	server := newModelsDevTestServer(`{
+		"kimi-for-coding": {
+			"id": "kimi-for-coding",
+			"name": "Kimi For Coding",
+			"api": "https://api.kimi.com/coding/v1",
+			"npm": "@ai-sdk/anthropic",
+			"models": {"k2p5": {"id": "k2p5", "name": "Kimi K2.5"}}
+		}
+	}`)
+	defer server.Close()
+	origURL := modelsDevAPIURL
+	modelsDevAPIURL = server.URL
+	t.Cleanup(func() { modelsDevAPIURL = origURL })
+
+	if err := saveModelSelectionState(&modelSelectionState{
+		Active: &modelRef{ProviderID: "kimi-for-coding", ModelID: "k2p5"},
+	}); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
+
+	cfg := configs.DefaultConfig()
+	result, err := restoreProviderSelection(cfg)
+	if err != nil {
+		t.Fatalf("restoreProviderSelection() error = %v", err)
+	}
+	if result.Restored {
+		t.Fatal("result.Restored = true, want false")
+	}
+	if got := cfg.Model.Model; got != "" {
+		t.Fatalf("cfg.Model.Model = %q, want empty", got)
+	}
+	if got := cfg.Model.Key; got != "" {
+		t.Fatalf("cfg.Model.Key = %q, want empty", got)
+	}
+}
+
+func TestRestoreProviderSelectionDefaultsToFreeWhenLoggedIn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origConfigPath := appConfigPathOverride
+	appConfigPathOverride = filepath.Join(home, ".mscli", "config.json")
+	t.Cleanup(func() { appConfigPathOverride = origConfigPath })
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"api_key": "server-kimi-key"})
+	}))
+	defer srv.Close()
+
+	if err := saveCredentials(&credentials{
+		ServerURL: srv.URL,
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
+
+	cfg := configs.DefaultConfig()
+	result, err := restoreProviderSelection(cfg)
+	if err != nil {
+		t.Fatalf("restoreProviderSelection() error = %v", err)
+	}
+	if !result.Restored {
+		t.Fatal("result.Restored = false, want true")
+	}
+	if got, want := result.ActivePresetID, "kimi-k2.5-free"; got != want {
+		t.Fatalf("result.ActivePresetID = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.Model, "kimi-k2.5"; got != want {
+		t.Fatalf("cfg.Model.Model = %q, want %q", got, want)
+	}
+}
+
+func TestRestoreProviderSelectionLeavesConfigUnsetWhenNotLoggedIn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origConfigPath := appConfigPathOverride
+	appConfigPathOverride = filepath.Join(home, ".mscli", "config.json")
+	t.Cleanup(func() { appConfigPathOverride = origConfigPath })
+	origAuthPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(home, ".mscli", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origAuthPath })
+	origModelPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(home, ".mscli", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origModelPath })
+
+	cfg := configs.DefaultConfig()
+	result, err := restoreProviderSelection(cfg)
+	if err != nil {
+		t.Fatalf("restoreProviderSelection() error = %v", err)
+	}
+	if result.Restored {
+		t.Fatal("result.Restored = true, want false")
+	}
+	if got := cfg.Model.Model; got != "" {
+		t.Fatalf("cfg.Model.Model = %q, want empty", got)
+	}
+}

--- a/internal/app/provider_runtime.go
+++ b/internal/app/provider_runtime.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mindspore-lab/mindspore-cli/configs"
+)
+
+type providerRestoreResult struct {
+	Restored       bool
+	ActivePresetID string
+}
+
+func restoreProviderSelection(cfg *configs.Config) (providerRestoreResult, error) {
+	if cfg == nil {
+		return providerRestoreResult{}, nil
+	}
+
+	appCfg, err := loadAppConfig()
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+	catalog, err := loadProviderCatalogBlocking(appCfg.ExtraProviders)
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+	modelState, err := loadModelSelectionState()
+	if err != nil {
+		return providerRestoreResult{}, err
+	}
+
+	if modelState.Active != nil {
+		resolved, presetID, err := resolveRuntimeSelection(catalog, authState, *modelState.Active)
+		if err == nil {
+			applyResolvedModelConfig(cfg, resolved)
+			return providerRestoreResult{Restored: true, ActivePresetID: presetID}, nil
+		}
+	}
+
+	if strings.TrimSpace(appCfg.ModelPresetID) != "" {
+		if preset, ok := resolveBuiltinModelPreset(appCfg.ModelPresetID); ok {
+			apiKey, err := fetchPresetAPIKey(preset)
+			if err == nil {
+				applyResolvedModelConfig(cfg, configs.ModelConfig{
+					Provider: preset.Provider,
+					URL:      preset.BaseURL,
+					Model:    preset.Model,
+					Key:      apiKey,
+				})
+				return providerRestoreResult{Restored: true, ActivePresetID: preset.ID}, nil
+			}
+		}
+	}
+
+	if isLoggedIn() {
+		resolved, presetID, err := resolveRuntimeSelection(catalog, authState, modelRef{
+			ProviderID: mindsporeCLIFreeProviderID,
+			ModelID:    "kimi-k2.5",
+		})
+		if err == nil {
+			applyResolvedModelConfig(cfg, resolved)
+			return providerRestoreResult{Restored: true, ActivePresetID: presetID}, nil
+		}
+	}
+
+	cfg.Model.Model = ""
+	cfg.Model.Key = ""
+	return providerRestoreResult{}, nil
+}
+
+func resolveRuntimeSelection(catalog *providerCatalog, authState *providerAuthState, ref modelRef) (configs.ModelConfig, string, error) {
+	provider, ok := catalog.Provider(ref.ProviderID)
+	if !ok {
+		return configs.ModelConfig{}, "", fmt.Errorf("unknown provider %q", ref.ProviderID)
+	}
+
+	switch strings.TrimSpace(provider.Protocol) {
+	case "mindspore-cli-free":
+		preset, ok := freeProviderPresetForModel(ref.ModelID)
+		if !ok {
+			return configs.ModelConfig{}, "", fmt.Errorf("unknown free model %q", ref.ModelID)
+		}
+		apiKey, err := fetchPresetAPIKey(preset)
+		if err != nil {
+			return configs.ModelConfig{}, "", err
+		}
+		return configs.ModelConfig{
+			Provider: preset.Provider,
+			URL:      preset.BaseURL,
+			Model:    preset.Model,
+			Key:      apiKey,
+		}, preset.ID, nil
+	case "openai-chat":
+		return resolveAPIKeyBackedRuntimeConfig(provider, authState, ref, "openai-completion")
+	case "openai-responses":
+		return resolveAPIKeyBackedRuntimeConfig(provider, authState, ref, "openai-responses")
+	case "anthropic-messages":
+		return resolveAPIKeyBackedRuntimeConfig(provider, authState, ref, "anthropic")
+	default:
+		return configs.ModelConfig{}, "", fmt.Errorf("unsupported provider protocol %q", provider.Protocol)
+	}
+}
+
+func resolveAPIKeyBackedRuntimeConfig(provider providerCatalogEntry, authState *providerAuthState, ref modelRef, runtimeProvider string) (configs.ModelConfig, string, error) {
+	if authState == nil {
+		authState = emptyProviderAuthState()
+	}
+	entry, ok := authState.Providers[provider.ID]
+	if !ok || strings.TrimSpace(entry.APIKey) == "" {
+		return configs.ModelConfig{}, "", fmt.Errorf("provider %s is not connected", provider.ID)
+	}
+	return configs.ModelConfig{
+		Provider: runtimeProvider,
+		URL:      provider.BaseURL,
+		Model:    strings.TrimSpace(ref.ModelID),
+		Key:      strings.TrimSpace(entry.APIKey),
+	}, "", nil
+}
+
+func applyResolvedModelConfig(cfg *configs.Config, resolved configs.ModelConfig) {
+	if cfg == nil {
+		return
+	}
+	previousModel := cfg.Model.Model
+	cfg.Model.Provider = strings.TrimSpace(resolved.Provider)
+	cfg.Model.URL = strings.TrimSpace(resolved.URL)
+	cfg.Model.Model = strings.TrimSpace(resolved.Model)
+	cfg.Model.Key = strings.TrimSpace(resolved.Key)
+	configs.RefreshModelTokenDefaults(cfg, previousModel)
+}
+
+func freeProviderPresetForModel(modelID string) (builtinModelPreset, bool) {
+	switch strings.TrimSpace(modelID) {
+	case "kimi-k2.5":
+		return resolveBuiltinModelPreset("kimi-k2.5-free")
+	case "deepseek-chat":
+		return resolveBuiltinModelPreset("deepseek-v3")
+	default:
+		return builtinModelPreset{}, false
+	}
+}
+
+func isLoggedIn() bool {
+	cred, err := loadCredentials()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(cred.Token) != "" && strings.TrimSpace(cred.ServerURL) != ""
+}

--- a/internal/app/provider_runtime_test.go
+++ b/internal/app/provider_runtime_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/configs"
+)
+
+func TestResolveRuntimeSelectionForExtraProviderOpenAIChat(t *testing.T) {
+	catalog := &providerCatalog{
+		Providers: []providerCatalogEntry{
+			{
+				ID:       "openrouter",
+				Label:    "OpenRouter",
+				BaseURL:  "https://openrouter.ai/api/v1",
+				Protocol: "openai-chat",
+			},
+		},
+	}
+	auth := &providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {ProviderID: "openrouter", APIKey: "sk-openrouter"},
+		},
+	}
+
+	cfg, presetID, err := resolveRuntimeSelection(catalog, auth, modelRef{
+		ProviderID: "openrouter",
+		ModelID:    "openai/gpt-4o-mini",
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSelection() error = %v", err)
+	}
+	if presetID != "" {
+		t.Fatalf("presetID = %q, want empty", presetID)
+	}
+	if got, want := cfg.Provider, "openai-completion"; got != want {
+		t.Fatalf("cfg.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.URL, "https://openrouter.ai/api/v1"; got != want {
+		t.Fatalf("cfg.URL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Key, "sk-openrouter"; got != want {
+		t.Fatalf("cfg.Key = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRuntimeSelectionForFreeProviderRequiresLogin(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	catalog := &providerCatalog{
+		Providers: builtinProviderCatalog(),
+	}
+	_, _, err := resolveRuntimeSelection(catalog, emptyProviderAuthState(), modelRef{
+		ProviderID: mindsporeCLIFreeProviderID,
+		ModelID:    "kimi-k2.5",
+	})
+	if err == nil {
+		t.Fatal("resolveRuntimeSelection() error = nil, want login requirement")
+	}
+}
+
+func TestResolveRuntimeSelectionForFreeProviderUsesPresetCredential(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Bearer user-token"; got != want {
+			t.Fatalf("Authorization = %q, want %q", got, want)
+		}
+		if r.URL.Path != "/model-presets/kimi-k2.5-free/credential" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/model-presets/kimi-k2.5-free/credential")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"api_key": "server-kimi-key"})
+	}))
+	defer srv.Close()
+
+	if err := saveCredentials(&credentials{
+		ServerURL: srv.URL,
+		Token:     "user-token",
+		User:      "alice",
+		Role:      "user",
+	}); err != nil {
+		t.Fatalf("saveCredentials() error = %v", err)
+	}
+
+	catalog := &providerCatalog{
+		Providers: builtinProviderCatalog(),
+	}
+	cfg, presetID, err := resolveRuntimeSelection(catalog, emptyProviderAuthState(), modelRef{
+		ProviderID: mindsporeCLIFreeProviderID,
+		ModelID:    "kimi-k2.5",
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSelection() error = %v", err)
+	}
+	if got, want := presetID, "kimi-k2.5-free"; got != want {
+		t.Fatalf("presetID = %q, want %q", got, want)
+	}
+	if got, want := cfg.Provider, "anthropic"; got != want {
+		t.Fatalf("cfg.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Key, "server-kimi-key"; got != want {
+		t.Fatalf("cfg.Key = %q, want %q", got, want)
+	}
+}
+
+func TestApplyResolvedModelConfigMutatesConfig(t *testing.T) {
+	cfg := configs.DefaultConfig()
+	cfg.Model.Provider = "openai-completion"
+	cfg.Model.URL = "https://api.openai.com/v1"
+	cfg.Model.Model = ""
+	cfg.Model.Key = ""
+
+	applyResolvedModelConfig(cfg, configs.ModelConfig{
+		Provider: "anthropic",
+		URL:      "https://api.kimi.com/coding/",
+		Model:    "kimi-k2.5",
+		Key:      "server-kimi-key",
+	})
+
+	if got, want := cfg.Model.Provider, "anthropic"; got != want {
+		t.Fatalf("cfg.Model.Provider = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.URL, "https://api.kimi.com/coding/"; got != want {
+		t.Fatalf("cfg.Model.URL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.Model, "kimi-k2.5"; got != want {
+		t.Fatalf("cfg.Model.Model = %q, want %q", got, want)
+	}
+}

--- a/internal/app/provider_state.go
+++ b/internal/app/provider_state.go
@@ -1,0 +1,217 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	authStatePathOverride  string
+	modelStatePathOverride string
+)
+
+type providerAuthState struct {
+	Providers map[string]providerAuthEntry `json:"providers,omitempty"`
+}
+
+type providerAuthEntry struct {
+	ProviderID string `json:"provider_id"`
+	APIKey     string `json:"api_key,omitempty"`
+}
+
+type modelSelectionState struct {
+	Active    *modelRef  `json:"active,omitempty"`
+	Recents   []modelRef `json:"recent,omitempty"`
+	Favorites []modelRef `json:"favorites,omitempty"`
+}
+
+type modelRef struct {
+	ProviderID string `json:"provider_id"`
+	ModelID    string `json:"model_id"`
+}
+
+func authStatePath() string {
+	if authStatePathOverride != "" {
+		return authStatePathOverride
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mscli", "auth.json")
+}
+
+func modelStatePath() string {
+	if modelStatePathOverride != "" {
+		return modelStatePathOverride
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".mscli", "model.json")
+}
+
+func loadProviderAuthState() (*providerAuthState, error) {
+	data, err := os.ReadFile(authStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return emptyProviderAuthState(), nil
+		}
+		return nil, err
+	}
+
+	var state providerAuthState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	state.normalize()
+	return &state, nil
+}
+
+func saveProviderAuthState(state *providerAuthState) error {
+	if state == nil {
+		state = emptyProviderAuthState()
+	}
+	state.normalize()
+
+	path := authStatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func loadModelSelectionState() (*modelSelectionState, error) {
+	data, err := os.ReadFile(modelStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return emptyModelSelectionState(), nil
+		}
+		return nil, err
+	}
+
+	var state modelSelectionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	state.normalize()
+	return &state, nil
+}
+
+func saveModelSelectionState(state *modelSelectionState) error {
+	if state == nil {
+		state = emptyModelSelectionState()
+	}
+	state.normalize()
+
+	path := modelStatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func emptyProviderAuthState() *providerAuthState {
+	return &providerAuthState{
+		Providers: map[string]providerAuthEntry{},
+	}
+}
+
+func emptyModelSelectionState() *modelSelectionState {
+	return &modelSelectionState{
+		Recents:   []modelRef{},
+		Favorites: []modelRef{},
+	}
+}
+
+func (s *providerAuthState) normalize() {
+	if s == nil {
+		return
+	}
+	if s.Providers == nil {
+		s.Providers = map[string]providerAuthEntry{}
+		return
+	}
+
+	normalized := make(map[string]providerAuthEntry, len(s.Providers))
+	for id, entry := range s.Providers {
+		entry.ProviderID = normalizedProviderID(entry.ProviderID)
+		key := normalizedProviderID(id)
+		if key == "" {
+			key = entry.ProviderID
+		}
+		if key == "" {
+			continue
+		}
+		if entry.ProviderID == "" {
+			entry.ProviderID = key
+		}
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		normalized[key] = entry
+	}
+	s.Providers = normalized
+}
+
+func (s *modelSelectionState) normalize() {
+	if s == nil {
+		return
+	}
+	if s.Active != nil {
+		normalized := s.Active.normalized()
+		if normalized.empty() {
+			s.Active = nil
+		} else {
+			s.Active = &normalized
+		}
+	}
+	s.Recents = normalizeModelRefs(s.Recents)
+	s.Favorites = normalizeModelRefs(s.Favorites)
+}
+
+func normalizeModelRefs(refs []modelRef) []modelRef {
+	if len(refs) == 0 {
+		return []modelRef{}
+	}
+
+	seen := make(map[string]struct{}, len(refs))
+	out := make([]modelRef, 0, len(refs))
+	for _, ref := range refs {
+		normalized := ref.normalized()
+		if normalized.empty() {
+			continue
+		}
+		key := normalized.key()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func (r modelRef) normalized() modelRef {
+	return modelRef{
+		ProviderID: normalizedProviderID(r.ProviderID),
+		ModelID:    strings.TrimSpace(r.ModelID),
+	}
+}
+
+func (r modelRef) key() string {
+	normalized := r.normalized()
+	return normalized.ProviderID + ":" + normalized.ModelID
+}
+
+func (r modelRef) empty() bool {
+	normalized := r.normalized()
+	return normalized.ProviderID == "" || normalized.ModelID == ""
+}
+
+func normalizedProviderID(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
+}

--- a/internal/app/provider_state_test.go
+++ b/internal/app/provider_state_test.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAuthStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	origPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(dir, "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origPath })
+
+	state := &providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openrouter": {
+				ProviderID: "openrouter",
+				APIKey:     "sk-test",
+			},
+		},
+	}
+	if err := saveProviderAuthState(state); err != nil {
+		t.Fatalf("saveProviderAuthState() error = %v", err)
+	}
+
+	loaded, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	entry, ok := loaded.Providers["openrouter"]
+	if !ok {
+		t.Fatalf("loaded auth providers = %#v, want openrouter entry", loaded.Providers)
+	}
+	if got, want := entry.APIKey, "sk-test"; got != want {
+		t.Fatalf("entry.APIKey = %q, want %q", got, want)
+	}
+}
+
+func TestLoadProviderAuthStateMissingReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	origPath := authStatePathOverride
+	authStatePathOverride = filepath.Join(dir, "missing", "auth.json")
+	t.Cleanup(func() { authStatePathOverride = origPath })
+
+	loaded, err := loadProviderAuthState()
+	if err != nil {
+		t.Fatalf("loadProviderAuthState() error = %v", err)
+	}
+	if len(loaded.Providers) != 0 {
+		t.Fatalf("len(loaded.Providers) = %d, want 0", len(loaded.Providers))
+	}
+}
+
+func TestModelStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	origPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(dir, "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origPath })
+
+	state := &modelSelectionState{
+		Active: &modelRef{
+			ProviderID: "mindspore-cli-free",
+			ModelID:    "kimi-k2.5",
+		},
+		Recents: []modelRef{
+			{ProviderID: "mindspore-cli-free", ModelID: "kimi-k2.5"},
+			{ProviderID: "openrouter", ModelID: "anthropic/claude-sonnet-4.5"},
+		},
+		Favorites: []modelRef{
+			{ProviderID: "openrouter", ModelID: "anthropic/claude-sonnet-4.5"},
+		},
+	}
+	if err := saveModelSelectionState(state); err != nil {
+		t.Fatalf("saveModelSelectionState() error = %v", err)
+	}
+
+	loaded, err := loadModelSelectionState()
+	if err != nil {
+		t.Fatalf("loadModelSelectionState() error = %v", err)
+	}
+	if loaded.Active == nil {
+		t.Fatal("loaded.Active = nil, want value")
+	}
+	if got, want := loaded.Active.ProviderID, "mindspore-cli-free"; got != want {
+		t.Fatalf("loaded.Active.ProviderID = %q, want %q", got, want)
+	}
+	if got, want := len(loaded.Recents), 2; got != want {
+		t.Fatalf("len(loaded.Recents) = %d, want %d", got, want)
+	}
+	if got, want := len(loaded.Favorites), 1; got != want {
+		t.Fatalf("len(loaded.Favorites) = %d, want %d", got, want)
+	}
+}
+
+func TestLoadModelSelectionStateMissingReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	origPath := modelStatePathOverride
+	modelStatePathOverride = filepath.Join(dir, "missing", "model.json")
+	t.Cleanup(func() { modelStatePathOverride = origPath })
+
+	loaded, err := loadModelSelectionState()
+	if err != nil {
+		t.Fatalf("loadModelSelectionState() error = %v", err)
+	}
+	if loaded.Active != nil {
+		t.Fatalf("loaded.Active = %#v, want nil", loaded.Active)
+	}
+	if len(loaded.Recents) != 0 {
+		t.Fatalf("len(loaded.Recents) = %d, want 0", len(loaded.Recents))
+	}
+	if len(loaded.Favorites) != 0 {
+		t.Fatalf("len(loaded.Favorites) = %d, want 0", len(loaded.Favorites))
+	}
+}
+
+func TestModelSelectionStateNormalizeDeduplicatesRecentAndFavorites(t *testing.T) {
+	state := &modelSelectionState{
+		Recents: []modelRef{
+			{ProviderID: "openrouter", ModelID: "gpt-4o"},
+			{ProviderID: "openrouter", ModelID: "gpt-4o"},
+			{ProviderID: " mindspore-cli-free ", ModelID: " kimi-k2.5 "},
+		},
+		Favorites: []modelRef{
+			{ProviderID: " mindspore-cli-free ", ModelID: " kimi-k2.5 "},
+			{ProviderID: "mindspore-cli-free", ModelID: "kimi-k2.5"},
+		},
+	}
+
+	state.normalize()
+
+	if got, want := len(state.Recents), 2; got != want {
+		t.Fatalf("len(state.Recents) = %d, want %d", got, want)
+	}
+	if got, want := state.Recents[1].ProviderID, "mindspore-cli-free"; got != want {
+		t.Fatalf("state.Recents[1].ProviderID = %q, want %q", got, want)
+	}
+	if got, want := state.Recents[1].ModelID, "kimi-k2.5"; got != want {
+		t.Fatalf("state.Recents[1].ModelID = %q, want %q", got, want)
+	}
+	if got, want := len(state.Favorites), 1; got != want {
+		t.Fatalf("len(state.Favorites) = %d, want %d", got, want)
+	}
+}

--- a/internal/app/provider_workflow.go
+++ b/internal/app/provider_workflow.go
@@ -1,0 +1,700 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+type providerWorkflowState struct {
+	catalog            *providerCatalog
+	authState          *providerAuthState
+	effectiveAuthState *providerAuthState
+	importSuggestions  []providerImportSuggestion
+	modelState         *modelSelectionState
+	loggedIn           bool
+}
+
+type logicalModelSelectionResult struct {
+	ProviderLabel string
+}
+
+type providerCatalogLoadMode int
+
+const (
+	providerCatalogLoadCacheFirst providerCatalogLoadMode = iota
+	providerCatalogLoadBlocking
+)
+
+func (a *Application) loadProviderWorkflowState(mode providerCatalogLoadMode) (*providerWorkflowState, error) {
+	appCfg, err := loadAppConfig()
+	if err != nil {
+		return nil, err
+	}
+	var catalog *providerCatalog
+	switch mode {
+	case providerCatalogLoadBlocking:
+		catalog, err = loadProviderCatalogBlocking(appCfg.ExtraProviders)
+	default:
+		catalog, err = loadProviderCatalog(nil, appCfg.ExtraProviders)
+	}
+	if err != nil {
+		return nil, err
+	}
+	authState, err := loadProviderAuthState()
+	if err != nil {
+		return nil, err
+	}
+	modelState, err := loadModelSelectionState()
+	if err != nil {
+		return nil, err
+	}
+	state := &providerWorkflowState{
+		catalog:    catalog,
+		authState:  authState,
+		modelState: modelState,
+		loggedIn:   isLoggedIn(),
+	}
+	state.refreshDerivedProviderState()
+	return state, nil
+}
+
+func (s *providerWorkflowState) refreshDerivedProviderState() {
+	if s == nil {
+		return
+	}
+	s.importSuggestions = detectProviderImportSuggestions(s.catalog, s.authState)
+	s.effectiveAuthState = cloneProviderAuthState(s.authState)
+	if s.effectiveAuthState == nil {
+		s.effectiveAuthState = emptyProviderAuthState()
+	}
+}
+
+func (a *Application) emitConnectPopup(canEscape bool) {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		a.emitToolError("connect", "Failed to load provider catalog: %v", err)
+		return
+	}
+
+	options := buildConnectProviderOptions(state.catalog, state.loggedIn)
+
+	a.EventCh <- model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:         "Connect Provider",
+			InputLabel:    "API key",
+			Screen:        model.SetupScreenPresetPicker,
+			PresetOptions: options,
+			PresetSelected: (&model.SetupPopup{
+				PresetOptions: options,
+			}).FirstSelectablePreset(),
+			CanEscape:  canEscape,
+			BackCloses: true,
+		},
+	}
+}
+
+func (a *Application) emitModelBrowser() {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		a.emitToolError("model", "Failed to load models: %v", err)
+		return
+	}
+	a.emitModelBrowserWithState(state, "")
+}
+
+func (a *Application) emitModelBrowserWithState(state *providerWorkflowState, preferredProviderID string) {
+	if state == nil {
+		a.emitToolError("model", "Failed to load model browser state")
+		return
+	}
+
+	a.EventCh <- model.Event{
+		Type:         model.ModelBrowserOpen,
+		ModelBrowser: buildModelBrowserPopup(state, preferredProviderID),
+	}
+}
+
+func (a *Application) emitModelPicker() {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		a.emitToolError("model", "Failed to load models: %v", err)
+		return
+	}
+	a.emitModelPickerWithState(state)
+}
+
+func (a *Application) emitModelPickerWithState(state *providerWorkflowState) {
+	if state == nil {
+		a.EventCh <- model.Event{
+			Type:    model.AgentReply,
+			Message: "No models available. Run /model to configure a provider.",
+		}
+		return
+	}
+
+	options := buildModelPickerOptions(state.catalog, state.effectiveAuthState, state.modelState, state.loggedIn, state.importSuggestions)
+	if len(options) == 0 {
+		a.EventCh <- model.Event{
+			Type:    model.AgentReply,
+			Message: "No models available. Run /model to configure a provider.",
+		}
+		return
+	}
+
+	selected := 0
+	if state.modelState != nil && state.modelState.Active != nil {
+		activeID := state.modelState.Active.key()
+		for i, opt := range options {
+			if opt.ID == activeID {
+				selected = i
+				break
+			}
+		}
+	} else {
+		selected = firstSelectableOptionIndex(options)
+	}
+
+	a.EventCh <- model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title:       "Select model",
+			Options:     options,
+			Selected:    selected,
+			ActionID:    "model_picker",
+			SearchQuery: "",
+		},
+	}
+}
+
+func buildModelBrowserPopup(state *providerWorkflowState, preferredProviderID string) *model.ModelBrowserPopup {
+	providerOptions := buildConnectProviderOptions(state.catalog, state.loggedIn)
+	modelOptions := buildModelPickerOptions(state.catalog, state.effectiveAuthState, state.modelState, state.loggedIn, state.importSuggestions)
+
+	providerSelected := firstSelectableOptionIndex(providerOptions)
+	if activeProviderID := activeModelProviderID(state.modelState); activeProviderID != "" {
+		if idx := optionIndexByID(providerOptions, activeProviderID); idx >= 0 {
+			providerSelected = idx
+		}
+	}
+	if preferredProviderID = normalizedProviderID(preferredProviderID); preferredProviderID != "" {
+		if idx := optionIndexByID(providerOptions, preferredProviderID); idx >= 0 {
+			providerSelected = idx
+		}
+	}
+
+	modelSelected := firstSelectableModelIndex(modelOptions)
+	if state.modelState != nil && state.modelState.Active != nil {
+		if idx := optionIndexByID(modelOptions, state.modelState.Active.key()); idx >= 0 {
+			modelSelected = idx
+		}
+	}
+	if preferredProviderID != "" {
+		for i, opt := range modelOptions {
+			if strings.HasPrefix(opt.ID, preferredProviderID+":") && opt.Selectable() {
+				modelSelected = i
+				break
+			}
+		}
+	}
+
+	popup := &model.ModelBrowserPopup{
+		Providers: model.SelectionPopup{
+			Title:    "Providers",
+			Options:  providerOptions,
+			Selected: providerSelected,
+		},
+		Models: model.SelectionPopup{
+			Title:    "Models",
+			Options:  modelOptions,
+			Selected: modelSelected,
+		},
+		Focus:            model.ModelBrowserFocusModel,
+		ProvidersVisible: false,
+	}
+	if len(modelOptions) == 0 {
+		popup.Focus = model.ModelBrowserFocusProvider
+		popup.ProvidersVisible = true
+	}
+	return popup
+}
+
+func buildConnectProviderOptions(catalog *providerCatalog, loggedIn bool) []model.SelectionOption {
+	if catalog == nil {
+		return nil
+	}
+	popularProviders, otherProviders := partitionConnectProviders(catalog.Providers, loggedIn)
+	options := make([]model.SelectionOption, 0, len(catalog.Providers)+4)
+	if len(popularProviders) > 0 {
+		options = append(options, model.SelectionOption{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true})
+	}
+	for _, provider := range popularProviders {
+		options = append(options, connectProviderOption(provider, loggedIn))
+	}
+	if len(otherProviders) > 0 {
+		if len(options) > 0 {
+			options = append(options, model.SelectionOption{ID: "__separator__connect", Separator: true, Disabled: true})
+		}
+		options = append(options, model.SelectionOption{ID: "__header__other", Label: "Other", Header: true, Disabled: true})
+	}
+	for _, provider := range otherProviders {
+		options = append(options, connectProviderOption(provider, loggedIn))
+	}
+	return options
+}
+
+func connectProviderOption(provider providerCatalogEntry, loggedIn bool) model.SelectionOption {
+	opt := model.SelectionOption{
+		ID:            provider.ID,
+		Label:         provider.Label,
+		RequiresInput: provider.Protocol != "mindspore-cli-free",
+	}
+	if provider.Protocol == "mindspore-cli-free" {
+		opt.Desc = "(Recommended)"
+		opt.RequiresInput = false
+		return opt
+	}
+	return opt
+}
+
+func buildProviderScopedModelPicker(provider providerCatalogEntry) *model.SelectionPopup {
+	options := make([]model.SelectionOption, 0, len(provider.Models))
+	for _, m := range provider.Models {
+		options = append(options, model.SelectionOption{
+			ID:    modelRef{ProviderID: provider.ID, ModelID: m.ID}.key(),
+			Label: m.Label,
+		})
+	}
+	return &model.SelectionPopup{
+		Title:       "Select model",
+		Options:     options,
+		Selected:    firstSelectableOptionIndex(options),
+		ActionID:    "connect_provider_model_picker:" + provider.ID,
+		SearchQuery: "",
+	}
+}
+
+func firstSelectableOptionIndex(options []model.SelectionOption) int {
+	for i, opt := range options {
+		if opt.Selectable() {
+			return i
+		}
+	}
+	return 0
+}
+
+func optionIndexByID(options []model.SelectionOption, id string) int {
+	needle := strings.TrimSpace(id)
+	for i, opt := range options {
+		if opt.ID == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+func firstSelectableModelIndex(options []model.SelectionOption) int {
+	for i, opt := range options {
+		if opt.Selectable() && !opt.ProviderRow {
+			return i
+		}
+	}
+	return firstSelectableOptionIndex(options)
+}
+
+func activeModelProviderID(state *modelSelectionState) string {
+	if state == nil || state.Active == nil {
+		return ""
+	}
+	return normalizedProviderID(state.Active.ProviderID)
+}
+
+func buildModelPickerOptions(catalog *providerCatalog, authState *providerAuthState, modelState *modelSelectionState, loggedIn bool, importSuggestions []providerImportSuggestion) []model.SelectionOption {
+	if catalog == nil {
+		return nil
+	}
+	usable := usableProviders(catalog, authState, loggedIn)
+	importSuggestionsByID := providerImportSuggestionByID(importSuggestions)
+	options := make([]model.SelectionOption, 0)
+	const recentDisplayLimit = 5
+
+	addModelRefs := func(title string, refs []modelRef, limit int, showProvider bool) {
+		if len(refs) == 0 {
+			return
+		}
+
+		group := make([]model.SelectionOption, 0, len(refs)+1)
+		group = append(group, model.SelectionOption{ID: "__header__" + title, Label: title, Header: true, Disabled: true})
+		count := 0
+		for _, ref := range refs {
+			provider, ok := findProviderInList(usable, ref.ProviderID)
+			if !ok {
+				continue
+			}
+			label := modelLabelForRef(provider, ref.ModelID)
+			desc := ""
+			if showProvider {
+				desc = "· " + provider.Label
+			}
+			group = append(group, model.SelectionOption{
+				ID:    ref.key(),
+				Label: label,
+				Desc:  desc,
+			})
+			count++
+			if limit > 0 && count >= limit {
+				break
+			}
+		}
+		if count == 0 {
+			return
+		}
+		if len(options) > 0 {
+			options = append(options, model.SelectionOption{ID: "__separator__" + title, Separator: true, Disabled: true})
+		}
+		options = append(options, group...)
+	}
+
+	if modelState != nil {
+		addModelRefs("Recent", modelState.Recents, recentDisplayLimit, true)
+		addModelRefs("Favorites", modelState.Favorites, 0, false)
+	}
+
+	for _, provider := range usable {
+		if len(options) > 0 {
+			options = append(options, model.SelectionOption{ID: "__separator__provider:" + provider.ID, Separator: true, Disabled: true})
+		}
+		providerRow := model.SelectionOption{
+			ID:          "__provider__" + provider.ID,
+			Label:       provider.Label,
+			ProviderRow: true,
+		}
+		if suggestion, ok := importSuggestionsByID[provider.ID]; ok {
+			providerRow.Desc = suggestion.SourceLabel
+		}
+		if provider.Protocol == "mindspore-cli-free" {
+			providerRow.Disabled = true
+		} else if importSuggestionsByID[provider.ID].ProviderID == "" {
+			providerRow.DeleteProviderID = provider.ID
+		}
+		options = append(options, providerRow)
+		for _, m := range provider.Models {
+			options = append(options, model.SelectionOption{
+				ID:    modelRef{ProviderID: provider.ID, ModelID: m.ID}.key(),
+				Label: m.Label,
+			})
+		}
+	}
+	return options
+}
+
+type deleteProviderResult struct {
+	Fallback *modelRef
+	Cleared  bool
+	State    *providerWorkflowState
+}
+
+func (a *Application) deleteConnectedProvider(providerID string) (deleteProviderResult, error) {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		return deleteProviderResult{}, err
+	}
+	providerID = normalizedProviderID(providerID)
+	if providerID == "" {
+		return deleteProviderResult{}, fmt.Errorf("provider id is empty")
+	}
+	if state.authState == nil {
+		state.authState = emptyProviderAuthState()
+	}
+	delete(state.authState.Providers, providerID)
+	if err := saveProviderAuthState(state.authState); err != nil {
+		return deleteProviderResult{}, err
+	}
+	state.refreshDerivedProviderState()
+
+	if state.modelState == nil {
+		state.modelState = emptyModelSelectionState()
+	}
+	wasActive := state.modelState.Active != nil && normalizedProviderID(state.modelState.Active.ProviderID) == providerID
+	state.modelState.Active = removeActiveProviderRef(state.modelState.Active, providerID)
+	state.modelState.Recents = removeProviderRefs(state.modelState.Recents, providerID)
+	state.modelState.Favorites = removeProviderRefs(state.modelState.Favorites, providerID)
+	if err := saveModelSelectionState(state.modelState); err != nil {
+		return deleteProviderResult{}, err
+	}
+
+	result := deleteProviderResult{State: state}
+	if !wasActive {
+		return result, nil
+	}
+
+	fallback := firstAvailableModelRef(state.catalog, state.effectiveAuthState, state.modelState, state.loggedIn)
+	if fallback == nil {
+		if blockingState, blockingErr := a.loadProviderWorkflowState(providerCatalogLoadBlocking); blockingErr == nil {
+			state = blockingState
+			result.State = blockingState
+			fallback = firstAvailableModelRef(state.catalog, state.effectiveAuthState, state.modelState, state.loggedIn)
+		}
+	}
+	if fallback == nil {
+		if err := a.clearActiveLogicalModel(); err != nil {
+			return deleteProviderResult{}, err
+		}
+		result.Cleared = true
+		return result, nil
+	}
+	if _, err := a.activateLogicalModelSelection(fallback.ProviderID, fallback.ModelID); err != nil {
+		return deleteProviderResult{}, err
+	}
+	result.Fallback = fallback
+	return result, nil
+}
+
+func removeActiveProviderRef(ref *modelRef, providerID string) *modelRef {
+	if ref == nil {
+		return nil
+	}
+	if normalizedProviderID(ref.ProviderID) == normalizedProviderID(providerID) {
+		return nil
+	}
+	normalized := ref.normalized()
+	return &normalized
+}
+
+func removeProviderRefs(refs []modelRef, providerID string) []modelRef {
+	out := make([]modelRef, 0, len(refs))
+	for _, ref := range refs {
+		if normalizedProviderID(ref.ProviderID) == normalizedProviderID(providerID) {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func firstAvailableModelRef(catalog *providerCatalog, authState *providerAuthState, modelState *modelSelectionState, loggedIn bool) *modelRef {
+	usable := usableProviders(catalog, authState, loggedIn)
+	tryRefs := func(refs []modelRef) *modelRef {
+		for _, ref := range refs {
+			provider, ok := findProviderInList(usable, ref.ProviderID)
+			if !ok {
+				continue
+			}
+			for _, m := range provider.Models {
+				if m.ID == strings.TrimSpace(ref.ModelID) {
+					normalized := ref.normalized()
+					return &normalized
+				}
+			}
+		}
+		return nil
+	}
+	if modelState != nil {
+		if ref := tryRefs(modelState.Recents); ref != nil {
+			return ref
+		}
+		if ref := tryRefs(modelState.Favorites); ref != nil {
+			return ref
+		}
+	}
+	for _, provider := range usable {
+		if len(provider.Models) == 0 {
+			continue
+		}
+		ref := modelRef{ProviderID: provider.ID, ModelID: provider.Models[0].ID}.normalized()
+		return &ref
+	}
+	return nil
+}
+
+func partitionConnectProviders(providers []providerCatalogEntry, loggedIn bool) ([]providerCatalogEntry, []providerCatalogEntry) {
+	popular := make([]providerCatalogEntry, 0, 5)
+	other := make([]providerCatalogEntry, 0, len(providers))
+
+	providerByID := make(map[string]providerCatalogEntry, len(providers))
+	for _, provider := range providers {
+		providerByID[provider.ID] = provider
+	}
+
+	if loggedIn {
+		if provider, ok := providerByID[mindsporeCLIFreeProviderID]; ok {
+			popular = append(popular, provider)
+			delete(providerByID, mindsporeCLIFreeProviderID)
+		}
+	}
+
+	for _, id := range connectPopularProviderIDs {
+		if provider, ok := providerByID[id]; ok {
+			popular = append(popular, provider)
+			delete(providerByID, id)
+		}
+	}
+
+	if !loggedIn {
+		delete(providerByID, mindsporeCLIFreeProviderID)
+	}
+
+	rest := make([]providerCatalogEntry, 0, len(providerByID))
+	for _, provider := range providerByID {
+		rest = append(rest, provider)
+	}
+	sort.Slice(rest, func(i, j int) bool {
+		return strings.ToLower(rest[i].Label) < strings.ToLower(rest[j].Label)
+	})
+	other = append(other, rest...)
+	return popular, other
+}
+
+func usableProviders(catalog *providerCatalog, authState *providerAuthState, loggedIn bool) []providerCatalogEntry {
+	if catalog == nil {
+		return nil
+	}
+	out := make([]providerCatalogEntry, 0, len(catalog.Providers))
+	for _, provider := range catalog.Providers {
+		if provider.Protocol == "mindspore-cli-free" {
+			if loggedIn {
+				out = append(out, provider)
+			}
+			continue
+		}
+		if authState != nil {
+			if entry, ok := authState.Providers[provider.ID]; ok && strings.TrimSpace(entry.APIKey) != "" {
+				out = append(out, provider)
+			}
+		}
+	}
+	return out
+}
+
+func findProviderInList(providers []providerCatalogEntry, id string) (providerCatalogEntry, bool) {
+	for _, provider := range providers {
+		if provider.ID == normalizedProviderID(id) {
+			return provider, true
+		}
+	}
+	return providerCatalogEntry{}, false
+}
+
+func modelLabelForRef(provider providerCatalogEntry, modelID string) string {
+	for _, m := range provider.Models {
+		if m.ID == strings.TrimSpace(modelID) {
+			return m.Label
+		}
+	}
+	return strings.TrimSpace(modelID)
+}
+
+func providerDisplayLabel(catalog *providerCatalog, providerID string) string {
+	if catalog != nil {
+		if provider, ok := catalog.Provider(providerID); ok && strings.TrimSpace(provider.Label) != "" {
+			return strings.TrimSpace(provider.Label)
+		}
+	}
+	return runtimeProviderDisplayLabel(providerID)
+}
+
+func runtimeProviderDisplayLabel(providerID string) string {
+	switch normalizedProviderID(providerID) {
+	case "openai", "openai-completion":
+		return "OpenAI"
+	case "openai-responses":
+		return "OpenAI Responses"
+	case "anthropic":
+		return "Anthropic"
+	case mindsporeCLIFreeProviderID:
+		return "MindSpore CLI Free"
+	default:
+		if label := canonicalProviderLabel(providerID, ""); label != "" {
+			return label
+		}
+		return strings.TrimSpace(providerID)
+	}
+}
+
+func (a *Application) connectProvider(providerID, apiKey string) (*providerWorkflowState, error) {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		return nil, err
+	}
+	provider, ok := state.catalog.Provider(providerID)
+	if !ok {
+		state, err = a.loadProviderWorkflowState(providerCatalogLoadBlocking)
+		if err != nil {
+			return nil, err
+		}
+		provider, ok = state.catalog.Provider(providerID)
+	}
+	if !ok {
+		return nil, fmt.Errorf("unknown provider %q", providerID)
+	}
+
+	if provider.Protocol == "mindspore-cli-free" {
+		if !state.loggedIn {
+			return nil, fmt.Errorf("MindSpore CLI Free requires /login first")
+		}
+		return state, nil
+	}
+
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("provider %s requires api key", provider.Label)
+	}
+	state.authState.Providers[provider.ID] = providerAuthEntry{
+		ProviderID: provider.ID,
+		APIKey:     apiKey,
+	}
+	if err := saveProviderAuthState(state.authState); err != nil {
+		return nil, err
+	}
+	state.refreshDerivedProviderState()
+	return state, nil
+}
+
+func (a *Application) activateLogicalModelSelection(providerID, modelID string) (logicalModelSelectionResult, error) {
+	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
+	if err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+	if _, ok := state.catalog.Provider(providerID); !ok {
+		state, err = a.loadProviderWorkflowState(providerCatalogLoadBlocking)
+		if err != nil {
+			return logicalModelSelectionResult{}, err
+		}
+	}
+
+	resolved, presetID, err := resolveRuntimeSelection(state.catalog, state.effectiveAuthState, modelRef{
+		ProviderID: providerID,
+		ModelID:    modelID,
+	})
+	if err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+
+	a.restoreModelConfigFromPreset()
+	a.Config.Model.URL = resolved.URL
+	if err := a.SetProvider(resolved.Provider, resolved.Model, resolved.Key); err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+
+	a.activeModelPresetID = presetID
+	if a.activeModelPresetID == "" {
+		a.activeModelPresetID = ""
+	}
+
+	if state.modelState == nil {
+		state.modelState = emptyModelSelectionState()
+	}
+	selected := modelRef{ProviderID: providerID, ModelID: modelID}.normalized()
+	state.modelState.Active = &selected
+	state.modelState.Recents = append([]modelRef{selected}, state.modelState.Recents...)
+	state.modelState.normalize()
+	if err := saveModelSelectionState(state.modelState); err != nil {
+		return logicalModelSelectionResult{}, err
+	}
+	return logicalModelSelectionResult{
+		ProviderLabel: providerDisplayLabel(state.catalog, providerID),
+	}, nil
+}

--- a/internal/app/provider_workflow.go
+++ b/internal/app/provider_workflow.go
@@ -26,7 +26,13 @@ type providerCatalogLoadMode int
 const (
 	providerCatalogLoadCacheFirst providerCatalogLoadMode = iota
 	providerCatalogLoadBlocking
+	importProviderOptionPrefix = "__import_provider__:"
 )
+
+type connectProviderSelection struct {
+	ProviderID          string
+	AllowDetectedAPIKey bool
+}
 
 func (a *Application) loadProviderWorkflowState(mode providerCatalogLoadMode) (*providerWorkflowState, error) {
 	appCfg, err := loadAppConfig()
@@ -58,6 +64,13 @@ func (a *Application) loadProviderWorkflowState(mode providerCatalogLoadMode) (*
 		loggedIn:   isLoggedIn(),
 	}
 	state.refreshDerivedProviderState()
+	if mode == providerCatalogLoadCacheFirst && len(state.importSuggestions) == 0 && hasProviderEnvCandidates() {
+		blockingCatalog, blockingErr := loadProviderCatalogBlocking(appCfg.ExtraProviders)
+		if blockingErr == nil {
+			state.catalog = blockingCatalog
+			state.refreshDerivedProviderState()
+		}
+	}
 	return state, nil
 }
 
@@ -79,7 +92,7 @@ func (a *Application) emitConnectPopup(canEscape bool) {
 		return
 	}
 
-	options := buildConnectProviderOptions(state.catalog, state.loggedIn)
+	options := buildConnectProviderOptions(state.catalog, state.loggedIn, state.importSuggestions)
 
 	a.EventCh <- model.Event{
 		Type: model.ModelSetupOpen,
@@ -171,7 +184,7 @@ func (a *Application) emitModelPickerWithState(state *providerWorkflowState) {
 }
 
 func buildModelBrowserPopup(state *providerWorkflowState, preferredProviderID string) *model.ModelBrowserPopup {
-	providerOptions := buildConnectProviderOptions(state.catalog, state.loggedIn)
+	providerOptions := buildConnectProviderOptions(state.catalog, state.loggedIn, state.importSuggestions)
 	modelOptions := buildModelPickerOptions(state.catalog, state.effectiveAuthState, state.modelState, state.loggedIn, state.importSuggestions)
 
 	providerSelected := firstSelectableOptionIndex(providerOptions)
@@ -222,12 +235,27 @@ func buildModelBrowserPopup(state *providerWorkflowState, preferredProviderID st
 	return popup
 }
 
-func buildConnectProviderOptions(catalog *providerCatalog, loggedIn bool) []model.SelectionOption {
+func buildConnectProviderOptions(catalog *providerCatalog, loggedIn bool, importSuggestions []providerImportSuggestion) []model.SelectionOption {
 	if catalog == nil {
 		return nil
 	}
 	popularProviders, otherProviders := partitionConnectProviders(catalog.Providers, loggedIn)
-	options := make([]model.SelectionOption, 0, len(catalog.Providers)+4)
+	options := make([]model.SelectionOption, 0, len(catalog.Providers)+6)
+	if len(importSuggestions) > 0 {
+		options = append(options, model.SelectionOption{
+			ID:       "__header__detected",
+			Label:    "Import",
+			Header:   true,
+			Disabled: true,
+		})
+		for _, suggestion := range importSuggestions {
+			options = append(options, connectImportedProviderOption(suggestion))
+			options = append(options, connectImportedProviderDetailOptions(suggestion)...)
+		}
+		if len(popularProviders) > 0 || len(otherProviders) > 0 {
+			options = append(options, model.SelectionOption{ID: "__separator__detected", Separator: true, Disabled: true})
+		}
+	}
 	if len(popularProviders) > 0 {
 		options = append(options, model.SelectionOption{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true})
 	}
@@ -244,6 +272,41 @@ func buildConnectProviderOptions(catalog *providerCatalog, loggedIn bool) []mode
 		options = append(options, connectProviderOption(provider, loggedIn))
 	}
 	return options
+}
+
+func connectImportedProviderOption(suggestion providerImportSuggestion) model.SelectionOption {
+	label := strings.TrimSpace(suggestion.ProviderLabel)
+	if label == "" {
+		label = strings.TrimSpace(suggestion.ProviderID)
+	}
+	return model.SelectionOption{
+		ID:            importProviderOptionID(suggestion.ProviderID),
+		Label:         label,
+		RequiresInput: strings.TrimSpace(suggestion.APIKey) == "",
+	}
+}
+
+func connectImportedProviderDetailOptions(suggestion providerImportSuggestion) []model.SelectionOption {
+	return []model.SelectionOption{
+		{
+			ID:        "__detail__" + suggestion.ProviderID + "__source",
+			Label:     "from Claude Code environment detected:",
+			Disabled:  true,
+			DetailRow: true,
+		},
+		{
+			ID:        "__detail__" + suggestion.ProviderID + "__base_url",
+			Label:     providerImportBaseURLLine(suggestion),
+			Disabled:  true,
+			DetailRow: true,
+		},
+		{
+			ID:        "__detail__" + suggestion.ProviderID + "__api_key",
+			Label:     providerImportAPIKeyLine(suggestion),
+			Disabled:  true,
+			DetailRow: true,
+		},
+	}
 }
 
 func connectProviderOption(provider providerCatalogEntry, loggedIn bool) model.SelectionOption {
@@ -615,6 +678,8 @@ func runtimeProviderDisplayLabel(providerID string) string {
 }
 
 func (a *Application) connectProvider(providerID, apiKey string) (*providerWorkflowState, error) {
+	selection := parseConnectProviderSelection(providerID)
+	providerID = selection.ProviderID
 	state, err := a.loadProviderWorkflowState(providerCatalogLoadCacheFirst)
 	if err != nil {
 		return nil, err
@@ -639,6 +704,11 @@ func (a *Application) connectProvider(providerID, apiKey string) (*providerWorkf
 	}
 
 	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" && selection.AllowDetectedAPIKey {
+		if suggestion, ok := findProviderImportSuggestion(state.importSuggestions, provider.ID); ok && strings.TrimSpace(suggestion.APIKey) != "" {
+			apiKey = strings.TrimSpace(suggestion.APIKey)
+		}
+	}
 	if apiKey == "" {
 		return nil, fmt.Errorf("provider %s requires api key", provider.Label)
 	}
@@ -651,6 +721,31 @@ func (a *Application) connectProvider(providerID, apiKey string) (*providerWorkf
 	}
 	state.refreshDerivedProviderState()
 	return state, nil
+}
+
+func findProviderImportSuggestion(suggestions []providerImportSuggestion, providerID string) (providerImportSuggestion, bool) {
+	needle := normalizedProviderID(providerID)
+	for _, suggestion := range suggestions {
+		if normalizedProviderID(suggestion.ProviderID) == needle {
+			return suggestion, true
+		}
+	}
+	return providerImportSuggestion{}, false
+}
+
+func importProviderOptionID(providerID string) string {
+	return importProviderOptionPrefix + normalizedProviderID(providerID)
+}
+
+func parseConnectProviderSelection(optionID string) connectProviderSelection {
+	trimmed := strings.TrimSpace(optionID)
+	if strings.HasPrefix(trimmed, importProviderOptionPrefix) {
+		return connectProviderSelection{
+			ProviderID:          normalizedProviderID(strings.TrimPrefix(trimmed, importProviderOptionPrefix)),
+			AllowDetectedAPIKey: true,
+		}
+	}
+	return connectProviderSelection{ProviderID: normalizedProviderID(trimmed)}
 }
 
 func (a *Application) activateLogicalModelSelection(providerID, modelID string) (logicalModelSelectionResult, error) {

--- a/internal/app/provider_workflow_test.go
+++ b/internal/app/provider_workflow_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestBuildModelPickerOptionsIncludesRecentGroup(t *testing.T) {
+	catalog := &providerCatalog{
+		Providers: []providerCatalogEntry{
+			{
+				ID:       "openai",
+				Label:    "OpenAI",
+				Protocol: "openai-chat",
+				Models: []modelCatalogEntry{
+					{ProviderID: "openai", ID: "gpt-4.1", Label: "GPT-4.1"},
+					{ProviderID: "openai", ID: "gpt-4.1-mini", Label: "GPT-4.1 Mini"},
+					{ProviderID: "openai", ID: "gpt-4o", Label: "GPT-4o"},
+					{ProviderID: "openai", ID: "gpt-4o-mini", Label: "GPT-4o Mini"},
+					{ProviderID: "openai", ID: "o3", Label: "o3"},
+					{ProviderID: "openai", ID: "o4-mini", Label: "o4-mini"},
+				},
+			},
+		},
+	}
+	authState := &providerAuthState{
+		Providers: map[string]providerAuthEntry{
+			"openai": {ProviderID: "openai", APIKey: "sk-test"},
+		},
+	}
+	modelState := &modelSelectionState{
+		Recents: []modelRef{
+			{ProviderID: "missing", ModelID: "gone"},
+			{ProviderID: "openai", ModelID: "gpt-4.1"},
+			{ProviderID: "openai", ModelID: "gpt-4.1-mini"},
+			{ProviderID: "openai", ModelID: "gpt-4o"},
+			{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+			{ProviderID: "openai", ModelID: "o3"},
+			{ProviderID: "openai", ModelID: "o4-mini"},
+		},
+	}
+
+	options := buildModelPickerOptions(catalog, authState, modelState, false, nil)
+
+	wantIDs := []string{
+		"__header__Recent",
+		"openai:gpt-4.1",
+		"openai:gpt-4.1-mini",
+		"openai:gpt-4o",
+		"openai:gpt-4o-mini",
+		"openai:o3",
+		"__separator__provider:openai",
+		"__provider__openai",
+	}
+	if len(options) < len(wantIDs) {
+		t.Fatalf("len(options) = %d, want at least %d", len(options), len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if got := options[i].ID; got != want {
+			t.Fatalf("options[%d].ID = %q, want %q", i, got, want)
+		}
+	}
+	if got, want := options[1].Label, "GPT-4.1"; got != want {
+		t.Fatalf("options[1].Label = %q, want %q", got, want)
+	}
+	if got, want := options[1].Desc, "· OpenAI"; got != want {
+		t.Fatalf("options[1].Desc = %q, want %q", got, want)
+	}
+	if got := options[7].Desc; got != "" {
+		t.Fatalf("options[7].Desc = %q, want empty provider-group entry desc", got)
+	}
+	if !options[7].ProviderRow {
+		t.Fatal("expected provider group entry to be selectable provider row")
+	}
+	if got, want := options[7].DeleteProviderID, "openai"; got != want {
+		t.Fatalf("options[7].DeleteProviderID = %q, want %q", got, want)
+	}
+}
+
+func TestBuildModelPickerOptionsDisablesFreeProviderRowInModelsList(t *testing.T) {
+	catalog := &providerCatalog{
+		Providers: []providerCatalogEntry{
+			{
+				ID:       mindsporeCLIFreeProviderID,
+				Label:    "MindSpore CLI Free",
+				Protocol: "mindspore-cli-free",
+				Models: []modelCatalogEntry{
+					{ProviderID: mindsporeCLIFreeProviderID, ID: "kimi-k2.5", Label: "Kimi K2.5"},
+				},
+			},
+		},
+	}
+
+	options := buildModelPickerOptions(catalog, emptyProviderAuthState(), &modelSelectionState{}, true, nil)
+	if len(options) < 2 {
+		t.Fatalf("len(options) = %d, want at least 2", len(options))
+	}
+	if got, want := options[0].ID, "__provider__"+mindsporeCLIFreeProviderID; got != want {
+		t.Fatalf("options[0].ID = %q, want %q", got, want)
+	}
+	if !options[0].ProviderRow {
+		t.Fatal("expected free provider row marker")
+	}
+	if !options[0].Disabled {
+		t.Fatal("expected free provider row to be non-selectable")
+	}
+	if got := options[0].DeleteProviderID; got != "" {
+		t.Fatalf("options[0].DeleteProviderID = %q, want empty", got)
+	}
+}
+
+func TestPartitionConnectProvidersUsesConfiguredPopularOrder(t *testing.T) {
+	providers := []providerCatalogEntry{
+		{ID: "openrouter", Label: "OpenRouter"},
+		{ID: "deepseek", Label: "DeepSeek"},
+		{ID: "openai", Label: "OpenAI"},
+		{ID: "kimi-for-coding", Label: "Kimi for Coding"},
+		{ID: "anthropic", Label: "Anthropic"},
+	}
+
+	popular, other := partitionConnectProviders(providers, false)
+
+	wantPopularIDs := []string{"anthropic", "openai", "kimi-for-coding", "deepseek"}
+	if len(popular) != len(wantPopularIDs) {
+		t.Fatalf("len(popular) = %d, want %d", len(popular), len(wantPopularIDs))
+	}
+	for i, want := range wantPopularIDs {
+		if got := popular[i].ID; got != want {
+			t.Fatalf("popular[%d].ID = %q, want %q", i, got, want)
+		}
+	}
+	if len(other) != 1 || other[0].ID != "openrouter" {
+		t.Fatalf("other = %#v, want only openrouter", other)
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mindspore-lab/mindspore-cli/ui/theme"
 )
 
-const provideAPIKeyFirstMsg = "LLM unavailable: provide api key first, or /login and switch to free model."
+const provideAPIKeyFirstMsg = "LLM unavailable: run /model to configure a provider."
 const interruptActiveTaskToken = "__interrupt_active_task__"
 const internalPermissionsActionPrefix = "\x00permissions:"
 const historyReplayReadyToken = "__history_replay_ready__"
@@ -90,10 +90,11 @@ func (a *Application) runReal() error {
 	render.InitStyles()
 	ui.InitStyles()
 
+	providerDisplay := a.initialProviderDisplayLabel()
 	userCh := make(chan string, 8)
-	tui := ui.New(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window)
+	tui := ui.New(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window, providerDisplay)
 	if a.replayOnly {
-		tui = ui.NewReplay(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window)
+		tui = ui.NewReplay(a.EventCh, userCh, Version, a.WorkDir, a.RepoURL, a.Config.Model.Model, a.Config.Context.Window, providerDisplay)
 	} else {
 		if history, err := loadInputHistoryForWorkdir(a.WorkDir); err == nil {
 			tui = tui.SeedInputHistory(history)
@@ -123,6 +124,26 @@ func (a *Application) runReal() error {
 	_, err := p.Run()
 	close(userCh)
 	return err
+}
+
+func (a *Application) initialProviderDisplayLabel() string {
+	if strings.TrimSpace(a.Config.Model.Model) == "" {
+		return ""
+	}
+	modelState, err := loadModelSelectionState()
+	if err == nil && modelState != nil && modelState.Active != nil {
+		if strings.TrimSpace(modelState.Active.ModelID) == strings.TrimSpace(a.Config.Model.Model) {
+			if appCfg, cfgErr := loadAppConfig(); cfgErr == nil {
+				for _, extra := range appCfg.ExtraProviders {
+					if normalizedProviderID(extra.ID) == normalizedProviderID(modelState.Active.ProviderID) && strings.TrimSpace(extra.Label) != "" {
+						return strings.TrimSpace(extra.Label)
+					}
+				}
+			}
+			return runtimeProviderDisplayLabel(modelState.Active.ProviderID)
+		}
+	}
+	return runtimeProviderDisplayLabel(a.Config.Model.Provider)
 }
 
 func tuiProgramOptions(extra ...tea.ProgramOption) []tea.ProgramOption {
@@ -190,6 +211,21 @@ func (a *Application) processInput(input string) {
 	if strings.HasPrefix(trimmed, modelSetupToken+" ") {
 		parts := strings.Fields(trimmed)
 		a.cmdModelSetup(parts[1:])
+		return
+	}
+	if strings.HasPrefix(trimmed, connectProviderToken+" ") {
+		parts := strings.Fields(trimmed)
+		a.cmdConnect(parts[1:])
+		return
+	}
+	if strings.HasPrefix(trimmed, selectModelToken+" ") {
+		parts := strings.Fields(trimmed)
+		a.cmdSelectModel(parts[1:])
+		return
+	}
+	if strings.HasPrefix(trimmed, deleteProviderToken+" ") {
+		parts := strings.Fields(trimmed)
+		a.cmdDeleteProvider(parts[1:])
 		return
 	}
 

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -163,41 +163,26 @@ func Wire(cfg BootstrapConfig) (*Application, error) {
 		}
 	}
 
-	// If LLM is not ready (missing API key), try detecting saved model config.
+	// If LLM is not ready (missing API key), try restoring the new persistent
+	// provider/model selection, then deprecated preset compatibility, then
+	// logged-in default free provider.
 	var needsSetupPopup bool
 	var activePresetID string
 	var savedModelToken string
 	if !llmReady {
-		mode, appCfg := detectModelMode()
-		switch mode {
-		case modelModeMSCLIProvided:
-			savedModelToken = appCfg.ModelToken
-			if preset, ok := resolveBuiltinModelPreset(appCfg.ModelPresetID); ok {
-				config.Model.URL = preset.BaseURL
-				config.Model.Provider = preset.Provider
-				config.Model.Model = preset.Model
-				// Always re-fetch the API key from the server instead of
-				// reusing the cached one — it may have been rotated.
-				apiKey := appCfg.ModelToken
-				if freshKey, fetchErr := fetchPresetAPIKey(preset); fetchErr == nil {
-					apiKey = freshKey
-					// Update the saved config with the fresh key.
-					appCfg.ModelToken = freshKey
-					_ = saveAppConfig(appCfg)
-				}
-				config.Model.Key = apiKey
-				savedModelToken = apiKey
-				configs.RefreshModelTokenDefaults(config, previousModel)
-				provider, err = initProvider(config.Model, llm.ResolveOptions{PreferConfigAPIKey: true})
-				if err == nil {
-					llmReady = true
-					activePresetID = preset.ID
-				}
+		restoreResult, restoreErr := restoreProviderSelection(config)
+		if restoreErr != nil {
+			return nil, fmt.Errorf("restore provider selection: %w", restoreErr)
+		}
+		if restoreResult.Restored {
+			provider, err = initProvider(config.Model, llm.ResolveOptions{
+				PreferConfigAPIKey:  true,
+				PreferConfigBaseURL: true,
+			})
+			if err == nil {
+				llmReady = true
+				activePresetID = restoreResult.ActivePresetID
 			}
-		case modelModeOwnEnv:
-			// Env vars were applied but init still failed for another reason.
-		default:
-			needsSetupPopup = true
 		}
 	}
 

--- a/ui/app.go
+++ b/ui/app.go
@@ -46,6 +46,9 @@ const (
 	interruptActiveTaskToken        = "__interrupt_active_task__"
 	internalPermissionsActionPrefix = "\x00permissions:"
 	modelSetupToken                 = "__model_setup"
+	connectProviderInputToken       = "__connect_provider__"
+	selectModelInputToken           = "__select_model__"
+	deleteProviderInputToken        = "__delete_provider__"
 )
 
 // Style vars are populated by InitStyles() below.
@@ -74,6 +77,27 @@ func agentMsg(source, msg string, done bool) string {
 		return fmt.Sprintf("%s %-12s: %s", marker, source, msg)
 	}
 	return fmt.Sprintf("%s %s", marker, msg)
+}
+
+func moveSelectionIndex(current, delta int, options []model.SelectionOption) int {
+	n := len(options)
+	if n == 0 {
+		return 0
+	}
+	if delta == 0 {
+		return current
+	}
+	if current < 0 || current >= n {
+		current = 0
+	}
+	next := current
+	for range n {
+		next = (next + delta%n + n) % n
+		if !options[next].Disabled {
+			return next
+		}
+	}
+	return current
 }
 
 var (
@@ -136,6 +160,9 @@ func evSource(data *model.TrainEventData, fallback string) string {
 
 type bootDoneMsg struct{}
 type bootTickMsg struct{}
+type modelBrowserAnimTickMsg struct{}
+
+const modelBrowserAnimStep = 30 * time.Millisecond
 
 type permissionPromptState struct {
 	title    string
@@ -208,6 +235,7 @@ type App struct {
 	permissionPrompt *permissionPromptState
 	permissionsView  *permissionsViewState
 	toolsExpanded    *bool
+	modelBrowser     *model.ModelBrowserPopup
 	modelPicker      *model.SelectionPopup
 	setupPopup       *model.SetupPopup
 	appendHistoryFn  func(string)
@@ -225,9 +253,9 @@ type toolOutputViewState struct {
 
 // New creates a new App driven by the given event channel.
 // userCh may be nil — user input won't be forwarded.
-func New(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int) App {
+func New(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) App {
 	return App{
-		state:            model.NewState(version, workDir, repoURL, modelName, ctxMax),
+		state:            model.NewState(version, workDir, repoURL, modelName, ctxMax, providerName...),
 		input:            components.NewTextInput().WithFileSuggestions(workDir),
 		thinking:         components.NewThinkingSpinner(),
 		eventCh:          ch,
@@ -245,8 +273,8 @@ func New(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL,
 }
 
 // NewReplay creates a TUI instance that starts directly in chat view for playback.
-func NewReplay(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int) App {
-	app := New(ch, userCh, version, workDir, repoURL, modelName, ctxMax)
+func NewReplay(ch <-chan model.Event, userCh chan<- string, version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) App {
+	app := New(ch, userCh, version, workDir, repoURL, modelName, ctxMax, providerName...)
 	app.bootActive = false
 	return app
 }
@@ -379,6 +407,22 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.bootActive = false
 		return a, a.maybePrintBanner()
 
+	case modelBrowserAnimTickMsg:
+		if a.modelBrowser == nil || a.modelBrowser.AnimationOffset == 0 {
+			return a, nil
+		}
+		if a.modelBrowser.AnimationOffset > 0 {
+			a.modelBrowser.AnimationOffset--
+		} else {
+			a.modelBrowser.AnimationOffset++
+		}
+		if a.modelBrowser.AnimationOffset == 0 {
+			return a, nil
+		}
+		return a, tea.Tick(modelBrowserAnimStep, func(time.Time) tea.Msg {
+			return modelBrowserAnimTickMsg{}
+		})
+
 	case model.Event:
 		return a.handleEvent(msg)
 
@@ -450,7 +494,7 @@ func (a *App) wantsModalAltScreen() bool {
 	if a == nil {
 		return false
 	}
-	return a.modelPicker != nil || a.setupPopup != nil || a.toolOutputView != nil
+	return a.modelBrowser != nil || a.modelPicker != nil || a.setupPopup != nil || a.toolOutputView != nil
 }
 
 func (a *App) syncModalAltScreen() tea.Cmd {
@@ -774,6 +818,174 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if a.modelBrowser != nil {
+		p := a.modelBrowser
+		if p.ProviderInput != nil {
+			switch msg.String() {
+			case "enter":
+				if a.userCh != nil {
+					token := strings.TrimSpace(p.ProviderInput.Value)
+					if token == "" {
+						p.ProviderInput.Error = "api key required"
+						return a, nil
+					}
+					cmd := connectProviderInputToken + " " + p.ProviderInput.Option.ID + " " + token
+					select {
+					case a.userCh <- cmd:
+					default:
+					}
+				}
+				return a, nil
+			case "esc":
+				p.ProviderInput = nil
+				return a, nil
+			case "backspace":
+				runes := []rune(p.ProviderInput.Value)
+				if len(runes) > 0 {
+					p.ProviderInput.Value = string(runes[:len(runes)-1])
+				}
+				p.ProviderInput.Error = ""
+				return a, nil
+			default:
+				if msg.Type == tea.KeyRunes {
+					p.ProviderInput.Value += string(msg.Runes)
+					p.ProviderInput.Error = ""
+				}
+				return a, nil
+			}
+		}
+
+		target := &p.Models
+		if p.Focus == model.ModelBrowserFocusProvider {
+			target = &p.Providers
+		}
+		selectedDeleteProviderID := ""
+		if len(target.Options) > 0 && target.Selected >= 0 && target.Selected < len(target.Options) {
+			selectedDeleteProviderID = strings.TrimSpace(target.Options[target.Selected].DeleteProviderID)
+		}
+		clearPendingDelete := func() {
+			if p.PendingDeleteProviderID != "" && p.PendingDeleteProviderID != selectedDeleteProviderID {
+				p.PendingDeleteProviderID = ""
+			}
+		}
+		clearPendingDelete()
+		switch msg.String() {
+		case "left":
+			p.PendingDeleteProviderID = ""
+			if p.Focus == model.ModelBrowserFocusModel && len(p.Providers.Options) > 0 {
+				p.ProvidersVisible = true
+				p.Focus = model.ModelBrowserFocusProvider
+				p.AnimationOffset = 2
+				return a, tea.Tick(modelBrowserAnimStep, func(time.Time) tea.Msg {
+					return modelBrowserAnimTickMsg{}
+				})
+			}
+			return a, nil
+		case "right":
+			p.PendingDeleteProviderID = ""
+			if p.Focus == model.ModelBrowserFocusProvider && p.HasModels() {
+				p.ProvidersVisible = false
+				p.Focus = model.ModelBrowserFocusModel
+				p.AnimationOffset = -2
+				return a, tea.Tick(modelBrowserAnimStep, func(time.Time) tea.Msg {
+					return modelBrowserAnimTickMsg{}
+				})
+			}
+			return a, nil
+		case "up":
+			p.PendingDeleteProviderID = ""
+			target.MoveSelection(-1)
+			return a, nil
+		case "down":
+			p.PendingDeleteProviderID = ""
+			target.MoveSelection(1)
+			return a, nil
+		case "enter":
+			p.PendingDeleteProviderID = ""
+			if len(target.Options) == 0 {
+				return a, nil
+			}
+			selected := target.Options[target.Selected]
+			if !selected.Selectable() {
+				return a, nil
+			}
+			if p.Focus == model.ModelBrowserFocusProvider {
+				if selected.RequiresInput {
+					p.ProviderInput = &model.ModelBrowserProviderInput{
+						Option: selected,
+						Label:  "API key",
+					}
+					return a, nil
+				}
+				if a.userCh != nil {
+					select {
+					case a.userCh <- connectProviderInputToken + " " + selected.ID:
+					default:
+					}
+				}
+				return a, nil
+			}
+			if a.userCh != nil {
+				select {
+				case a.userCh <- selectModelInputToken + " " + selected.ID:
+				default:
+				}
+			}
+			return a, nil
+		case "esc":
+			p.PendingDeleteProviderID = ""
+			a.modelBrowser = nil
+			a.state = a.clearThinking()
+			exitAlt := a.syncModalAltScreen()
+			banner := a.maybePrintBanner()
+			if exitAlt != nil && banner != nil {
+				return a, tea.Sequence(exitAlt, banner)
+			}
+			return a, combineCmds(exitAlt, banner)
+		case "backspace":
+			p.PendingDeleteProviderID = ""
+			runes := []rune(target.SearchQuery)
+			if len(runes) > 0 {
+				target.SearchQuery = string(runes[:len(runes)-1])
+				if strings.TrimSpace(target.SearchQuery) == "" {
+					target.RestoreSearchBaseIfNeeded()
+				} else {
+					target.EnsureSelectableSelection()
+				}
+			}
+			return a, nil
+		default:
+			if p.Focus == model.ModelBrowserFocusModel && selectedDeleteProviderID != "" && msg.Type == tea.KeyRunes && string(msg.Runes) == "d" {
+				if p.PendingDeleteProviderID == selectedDeleteProviderID {
+					p.PendingDeleteProviderID = ""
+					if a.userCh != nil {
+						select {
+						case a.userCh <- deleteProviderInputToken + " " + selectedDeleteProviderID:
+						default:
+						}
+					}
+				} else {
+					p.PendingDeleteProviderID = selectedDeleteProviderID
+				}
+				return a, nil
+			}
+			p.PendingDeleteProviderID = ""
+			if msg.Type == tea.KeyRunes {
+				target.BeginSearchIfNeeded()
+				target.SearchQuery += string(msg.Runes)
+				target.EnsureSelectableSelection()
+				return a, nil
+			}
+			if msg.Type == tea.KeySpace {
+				target.BeginSearchIfNeeded()
+				target.SearchQuery += " "
+				target.EnsureSelectableSelection()
+				return a, nil
+			}
+		}
+		return a, nil
+	}
+
 	// Multi-step model setup popup navigation
 	if a.setupPopup != nil {
 		switch a.setupPopup.Screen {
@@ -810,19 +1022,58 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				opt := a.setupPopup.PresetOptions[a.setupPopup.PresetSelected]
 				if !opt.Disabled {
 					a.setupPopup.SelectedPreset = opt
-					a.setupPopup.Screen = model.SetupScreenTokenInput
-					a.setupPopup.TokenError = ""
+					if opt.RequiresInput {
+						a.setupPopup.Screen = model.SetupScreenTokenInput
+						a.setupPopup.TokenError = ""
+					} else if a.userCh != nil {
+						select {
+						case a.userCh <- connectProviderInputToken + " " + a.setupPopup.SelectedPreset.ID:
+						default:
+						}
+					}
 				}
 				return a, nil
 			case "esc":
+				if a.setupPopup.BackCloses {
+					a.setupPopup = nil
+					return a, a.syncModalAltScreen()
+				}
 				a.setupPopup.Screen = model.SetupScreenModeSelect
 				return a, nil
+			case "backspace":
+				runes := []rune(a.setupPopup.SearchQuery)
+				if len(runes) > 0 {
+					a.setupPopup.SearchQuery = string(runes[:len(runes)-1])
+					if strings.TrimSpace(a.setupPopup.SearchQuery) == "" {
+						a.setupPopup.RestoreSearchBaseIfNeeded()
+					} else {
+						a.setupPopup.EnsureSelectablePreset()
+					}
+				}
+				return a, nil
+			default:
+				if msg.Type == tea.KeyRunes {
+					a.setupPopup.BeginSearchIfNeeded()
+					a.setupPopup.SearchQuery += string(msg.Runes)
+					a.setupPopup.EnsureSelectablePreset()
+					return a, nil
+				}
+				if msg.Type == tea.KeySpace {
+					a.setupPopup.BeginSearchIfNeeded()
+					a.setupPopup.SearchQuery += " "
+					a.setupPopup.EnsureSelectablePreset()
+					return a, nil
+				}
 			}
 		case model.SetupScreenTokenInput:
 			switch msg.String() {
 			case "enter":
 				if a.userCh != nil && strings.TrimSpace(a.setupPopup.TokenValue) != "" {
-					cmd := fmt.Sprintf("%s %s %s", modelSetupToken,
+					token := modelSetupToken
+					if a.setupPopup.InputLabel == "API key" {
+						token = connectProviderInputToken
+					}
+					cmd := fmt.Sprintf("%s %s %s", token,
 						a.setupPopup.SelectedPreset.ID,
 						strings.TrimSpace(a.setupPopup.TokenValue))
 					select {
@@ -869,16 +1120,16 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		switch msg.String() {
 		case "up", "left":
-			p.Selected--
-			if p.Selected < 0 {
-				p.Selected = len(p.Options) - 1
-			}
+			p.MoveSelection(-1)
 			return a, nil
 		case "down", "right":
-			p.Selected = (p.Selected + 1) % len(p.Options)
+			p.MoveSelection(1)
 			return a, nil
 		case "enter":
 			selected := p.Options[p.Selected]
+			if !selected.Selectable() {
+				return a, nil
+			}
 			a.trainView.SelectionPopup = nil
 			a.modelPicker = nil
 			var input string
@@ -889,6 +1140,10 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				input = "/train add perf-feature " + selected.ID
 			case "model_picker":
 				input = "/model " + selected.ID
+			default:
+				if strings.HasPrefix(p.ActionID, "connect_provider_model_picker:") {
+					input = "/model " + selected.ID
+				}
 			}
 			if input != "" && a.userCh != nil {
 				select {
@@ -906,6 +1161,43 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return a, tea.Sequence(exitAlt, banner)
 			}
 			return a, combineCmds(exitAlt, banner)
+		case "ctrl+a":
+			if p.ActionID != "model_picker" {
+				return a, nil
+			}
+			a.trainView.SelectionPopup = nil
+			a.modelPicker = nil
+			if a.userCh != nil {
+				select {
+				case a.userCh <- "/connect":
+				default:
+				}
+			}
+			return a, a.syncModalAltScreen()
+		case "backspace":
+			runes := []rune(p.SearchQuery)
+			if len(runes) > 0 {
+				p.SearchQuery = string(runes[:len(runes)-1])
+				if strings.TrimSpace(p.SearchQuery) == "" {
+					p.RestoreSearchBaseIfNeeded()
+				} else {
+					p.EnsureSelectableSelection()
+				}
+			}
+			return a, nil
+		default:
+			if msg.Type == tea.KeyRunes {
+				p.BeginSearchIfNeeded()
+				p.SearchQuery += string(msg.Runes)
+				p.EnsureSelectableSelection()
+				return a, nil
+			}
+			if msg.Type == tea.KeySpace {
+				p.BeginSearchIfNeeded()
+				p.SearchQuery += " "
+				p.EnsureSelectableSelection()
+				return a, nil
+			}
 		}
 		return a, nil
 	}
@@ -1317,10 +1609,44 @@ func (a App) handleEvent(ev model.Event) (tea.Model, tea.Cmd) {
 	case model.ModelUpdate:
 		mi := a.state.Model
 		mi.Name = ev.Message
+		mi.Provider = ev.Provider
 		if ev.CtxMax > 0 {
 			mi.CtxMax = ev.CtxMax
 		}
 		a.state = a.state.WithModel(mi)
+
+	case model.ModelBrowserOpen:
+		if ev.ModelBrowser != nil {
+			cp := *ev.ModelBrowser
+			cp.Providers.Options = append([]model.SelectionOption(nil), ev.ModelBrowser.Providers.Options...)
+			cp.Models.Options = append([]model.SelectionOption(nil), ev.ModelBrowser.Models.Options...)
+			if ev.ModelBrowser.ProviderInput != nil {
+				input := *ev.ModelBrowser.ProviderInput
+				cp.ProviderInput = &input
+			}
+			if a.modelBrowser != nil && a.modelBrowser.Focus != cp.Focus && cp.AnimationOffset == 0 {
+				if cp.Focus == model.ModelBrowserFocusProvider {
+					cp.AnimationOffset = 2
+				} else {
+					cp.AnimationOffset = -2
+				}
+				eventCmd = combineCmds(eventCmd, tea.Tick(modelBrowserAnimStep, func(time.Time) tea.Msg {
+					return modelBrowserAnimTickMsg{}
+				}))
+			}
+			a.modelBrowser = &cp
+			eventCmd = combineCmds(eventCmd, a.syncModalAltScreen())
+		}
+
+	case model.ModelBrowserClose:
+		a.modelBrowser = nil
+		exitAlt := a.syncModalAltScreen()
+		banner := a.maybePrintBanner()
+		if exitAlt != nil && banner != nil {
+			eventCmd = combineCmds(eventCmd, tea.Sequence(exitAlt, banner))
+		} else {
+			eventCmd = combineCmds(eventCmd, exitAlt, banner)
+		}
 
 	case model.ModelPickerOpen:
 		if ev.Popup != nil {
@@ -3282,6 +3608,9 @@ func (a App) View() string {
 	blank := strings.Repeat("\n", a.height-1)
 	if a.trainView.Active && a.trainView.SelectionPopup != nil {
 		return overlayPopup(blank, panels.RenderSelectionPopup(a.trainView.SelectionPopup), a.width, a.height)
+	}
+	if a.modelBrowser != nil {
+		return overlayPopup(blank, panels.RenderModelBrowserPopup(a.modelBrowser), a.width, a.height)
 	}
 	if a.modelPicker != nil {
 		return overlayPopup(blank, panels.RenderSelectionPopup(a.modelPicker), a.width, a.height)

--- a/ui/app_model_browser_test.go
+++ b/ui/app_model_browser_test.go
@@ -1,0 +1,287 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+func TestModelBrowserDefaultsToModelPaneAndExpandsProvidersOnLeft(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelBrowserOpen,
+		ModelBrowser: &model.ModelBrowserPopup{
+			Providers: model.SelectionPopup{
+				Title: "Providers",
+				Options: []model.SelectionOption{
+					{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
+				},
+				Selected: 0,
+			},
+			Models: model.SelectionPopup{
+				Title: "Models",
+				Options: []model.SelectionOption{
+					{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+				Selected: 0,
+			},
+			Focus:            model.ModelBrowserFocusModel,
+			ProvidersVisible: false,
+		},
+	})
+	app = next.(App)
+
+	if app.modelBrowser == nil {
+		t.Fatal("expected model browser to open")
+	}
+	if view := app.View(); !strings.Contains(view, "Providers") {
+		t.Fatalf("expected provider hint in view, got:\n%s", view)
+	}
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
+	app = next.(App)
+
+	if !app.modelBrowser.ProvidersVisible {
+		t.Fatal("expected left key to expand providers pane")
+	}
+	if got, want := app.modelBrowser.Focus, model.ModelBrowserFocusProvider; got != want {
+		t.Fatalf("focus = %v, want %v", got, want)
+	}
+}
+
+func TestModelBrowserProviderInputAndModelSelectionSendInternalTokens(t *testing.T) {
+	userCh := make(chan string, 2)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelBrowserOpen,
+		ModelBrowser: &model.ModelBrowserPopup{
+			Providers: model.SelectionPopup{
+				Title: "Providers",
+				Options: []model.SelectionOption{
+					{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
+				},
+				Selected: 0,
+			},
+			Models: model.SelectionPopup{
+				Title: "Models",
+				Options: []model.SelectionOption{
+					{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+				Selected: 0,
+			},
+			Focus:            model.ModelBrowserFocusProvider,
+			ProvidersVisible: true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = next.(App)
+	if app.modelBrowser.ProviderInput == nil {
+		t.Fatal("expected provider input to open")
+	}
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("sk-test")})
+	app = next.(App)
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = next.(App)
+
+	select {
+	case got := <-userCh:
+		if got != connectProviderInputToken+" openrouter sk-test" {
+			t.Fatalf("provider input token = %q", got)
+		}
+	default:
+		t.Fatal("expected provider connect token")
+	}
+
+	app.modelBrowser.ProviderInput = nil
+	app.modelBrowser.Focus = model.ModelBrowserFocusModel
+	app.modelBrowser.ProvidersVisible = false
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = next.(App)
+
+	select {
+	case got := <-userCh:
+		if got != selectModelInputToken+" openrouter:openai/gpt-4o-mini" {
+			t.Fatalf("model select token = %q", got)
+		}
+	default:
+		t.Fatal("expected model select token")
+	}
+}
+
+func TestModelBrowserFocusSwitchStartsAndSettlesAnimation(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelBrowserOpen,
+		ModelBrowser: &model.ModelBrowserPopup{
+			Providers: model.SelectionPopup{
+				Options: []model.SelectionOption{
+					{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
+				},
+				Selected: 0,
+			},
+			Models: model.SelectionPopup{
+				Options: []model.SelectionOption{
+					{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+				Selected: 0,
+			},
+			Focus:            model.ModelBrowserFocusModel,
+			ProvidersVisible: false,
+		},
+	})
+	app = next.(App)
+
+	next, cmd := app.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
+	app = next.(App)
+	if cmd == nil {
+		t.Fatal("expected animation tick command on focus switch")
+	}
+	if got := app.modelBrowser.AnimationOffset; got == 0 {
+		t.Fatal("expected non-zero animation offset after focus switch")
+	}
+
+	next, _ = app.Update(modelBrowserAnimTickMsg{})
+	app = next.(App)
+	next, _ = app.Update(modelBrowserAnimTickMsg{})
+	app = next.(App)
+
+	if got, want := app.modelBrowser.AnimationOffset, 0; got != want {
+		t.Fatalf("animation offset = %d, want %d", got, want)
+	}
+}
+
+func TestModelBrowserDoublePressDDeletesSelectedProviderRow(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelBrowserOpen,
+		ModelBrowser: &model.ModelBrowserPopup{
+			Models: model.SelectionPopup{
+				Title: "Models",
+				Options: []model.SelectionOption{
+					{ID: "__provider__openrouter", Label: "OpenRouter", ProviderRow: true, DeleteProviderID: "openrouter"},
+					{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+				Selected: 0,
+			},
+			Focus:            model.ModelBrowserFocusModel,
+			ProvidersVisible: false,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	app = next.(App)
+	if got, want := app.modelBrowser.PendingDeleteProviderID, "openrouter"; got != want {
+		t.Fatalf("pending delete provider = %q, want %q", got, want)
+	}
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	app = next.(App)
+
+	select {
+	case got := <-userCh:
+		if got != deleteProviderInputToken+" openrouter" {
+			t.Fatalf("delete provider token = %q", got)
+		}
+	default:
+		t.Fatal("expected delete provider token")
+	}
+}
+
+func TestModelBrowserMovingSelectionClearsPendingDelete(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelBrowserOpen,
+		ModelBrowser: &model.ModelBrowserPopup{
+			Models: model.SelectionPopup{
+				Title: "Models",
+				Options: []model.SelectionOption{
+					{ID: "__provider__openrouter", Label: "OpenRouter", ProviderRow: true, DeleteProviderID: "openrouter"},
+					{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+				Selected: 0,
+			},
+			Focus:            model.ModelBrowserFocusModel,
+			ProvidersVisible: false,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	app = next.(App)
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = next.(App)
+
+	if got, want := app.modelBrowser.PendingDeleteProviderID, ""; got != want {
+		t.Fatalf("pending delete provider = %q, want empty", got)
+	}
+}
+
+func TestModelBrowserEscapeClearsWorkingIndicator(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{Type: model.AgentThinking})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelBrowserOpen,
+		ModelBrowser: &model.ModelBrowserPopup{
+			Models: model.SelectionPopup{
+				Title: "Models",
+				Options: []model.SelectionOption{
+					{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+				},
+				Selected: 0,
+			},
+			Focus:            model.ModelBrowserFocusModel,
+			ProvidersVisible: false,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEscape})
+	app = next.(App)
+
+	if app.modelBrowser != nil {
+		t.Fatal("expected model browser to close on esc")
+	}
+	if app.state.IsThinking {
+		t.Fatal("expected esc close to clear thinking state")
+	}
+	if got, want := app.state.WaitKind, model.WaitNone; got != want {
+		t.Fatalf("wait kind = %v, want %v", got, want)
+	}
+	if view := app.View(); strings.Contains(view, "Working...") {
+		t.Fatalf("expected working indicator to stay cleared after esc, got:\n%s", view)
+	}
+}

--- a/ui/app_model_browser_test.go
+++ b/ui/app_model_browser_test.go
@@ -122,6 +122,49 @@ func TestModelBrowserProviderInputAndModelSelectionSendInternalTokens(t *testing
 	}
 }
 
+func TestModelBrowserProviderSelectionWithoutInputSendsConnectToken(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelBrowserOpen,
+		ModelBrowser: &model.ModelBrowserPopup{
+			Providers: model.SelectionPopup{
+				Title: "Providers",
+				Options: []model.SelectionOption{
+					{ID: "__header__detected", Label: "Import", Header: true, Disabled: true},
+					{ID: "__import_provider__:kimi-for-coding", Label: "Kimi For Coding"},
+					{ID: "__detail__kimi-for-coding__source", Label: "from Claude Code environment detected:", Disabled: true, DetailRow: true},
+				},
+				Selected: 1,
+			},
+			Models: model.SelectionPopup{
+				Title:    "Models",
+				Options:  []model.SelectionOption{},
+				Selected: 0,
+			},
+			Focus:            model.ModelBrowserFocusProvider,
+			ProvidersVisible: true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = next.(App)
+
+	select {
+	case got := <-userCh:
+		if got != connectProviderInputToken+" __import_provider__:kimi-for-coding" {
+			t.Fatalf("provider connect token = %q", got)
+		}
+	default:
+		t.Fatal("expected provider connect token")
+	}
+}
+
 func TestModelBrowserFocusSwitchStartsAndSettlesAnimation(t *testing.T) {
 	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
 	app.bootActive = false

--- a/ui/app_model_picker_test.go
+++ b/ui/app_model_picker_test.go
@@ -176,3 +176,261 @@ func TestModelSetupPopupSuppressesThinkingIndicatorWithoutClearingState(t *testi
 		t.Fatalf("expected thinking indicator to return after popup close, got:\n%s", view)
 	}
 }
+
+func TestSetupPopupPresetPickerSupportsSearch(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:  "Connect Provider",
+			Screen: model.SetupScreenPresetPicker,
+			PresetOptions: []model.SelectionOption{
+				{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true},
+				{ID: "anthropic", Label: "Anthropic"},
+				{ID: "openai", Label: "OpenAI"},
+			},
+			PresetSelected: 1,
+			CanEscape:      true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("open")})
+	app = next.(App)
+
+	if got, want := app.setupPopup.SearchQuery, "open"; got != want {
+		t.Fatalf("SearchQuery = %q, want %q", got, want)
+	}
+	view := app.View()
+	if !strings.Contains(view, "OpenAI") {
+		t.Fatalf("expected filtered match in view, got:\n%s", view)
+	}
+	if strings.Contains(view, "Anthropic") {
+		t.Fatalf("expected non-matching option filtered out, got:\n%s", view)
+	}
+}
+
+func TestSetupPopupSearchClearRestoresPreviousSelection(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:  "Connect Provider",
+			Screen: model.SetupScreenPresetPicker,
+			PresetOptions: []model.SelectionOption{
+				{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true},
+				{ID: "anthropic", Label: "Anthropic"},
+				{ID: "openai", Label: "OpenAI"},
+			},
+			PresetSelected: 1,
+			CanEscape:      true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("open")})
+	app = next.(App)
+	if got, want := app.setupPopup.PresetSelected, 2; got != want {
+		t.Fatalf("PresetSelected after search = %d, want %d", got, want)
+	}
+
+	for range 4 {
+		next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		app = next.(App)
+	}
+
+	if got, want := app.setupPopup.SearchQuery, ""; got != want {
+		t.Fatalf("SearchQuery after clear = %q, want %q", got, want)
+	}
+	if got, want := app.setupPopup.PresetSelected, 1; got != want {
+		t.Fatalf("PresetSelected after clear = %d, want %d", got, want)
+	}
+}
+
+func TestConnectPopupEscapeClosesInsteadOfShowingModeSelect(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelSetupOpen,
+		SetupPopup: &model.SetupPopup{
+			Title:  "Connect Provider",
+			Screen: model.SetupScreenPresetPicker,
+			PresetOptions: []model.SelectionOption{
+				{ID: "__header__popular", Label: "Popular", Header: true, Disabled: true},
+				{ID: "anthropic", Label: "Anthropic"},
+			},
+			PresetSelected: 1,
+			BackCloses:     true,
+			CanEscape:      true,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEscape})
+	app = next.(App)
+
+	if app.setupPopup != nil {
+		t.Fatal("expected connect popup to close on esc")
+	}
+	if view := app.View(); strings.Contains(view, "mscli-provided model") {
+		t.Fatalf("expected old mode-select screen not to appear, got:\n%s", view)
+	}
+}
+
+func TestModelPickerSupportsSearch(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title: "Select model",
+			Options: []model.SelectionOption{
+				{ID: "__header__provider:free", Label: "MindSpore CLI Free", Header: true, Disabled: true},
+				{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+				{ID: "mindspore-cli-free:deepseek-chat", Label: "DeepSeek V3"},
+			},
+			Selected: 1,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("deep")})
+	app = next.(App)
+
+	if got, want := app.modelPicker.SearchQuery, "deep"; got != want {
+		t.Fatalf("SearchQuery = %q, want %q", got, want)
+	}
+	view := app.View()
+	if !strings.Contains(view, "DeepSeek V3") {
+		t.Fatalf("expected filtered match in view, got:\n%s", view)
+	}
+	if strings.Contains(view, "Kimi K2.5") {
+		t.Fatalf("expected non-matching option filtered out, got:\n%s", view)
+	}
+}
+
+func TestModelPickerSearchClearRestoresPreviousSelection(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title: "Select model",
+			Options: []model.SelectionOption{
+				{ID: "__header__provider:free", Label: "MindSpore CLI Free", Header: true, Disabled: true},
+				{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+				{ID: "mindspore-cli-free:deepseek-chat", Label: "DeepSeek V3"},
+			},
+			Selected: 1,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("deep")})
+	app = next.(App)
+	if got, want := app.modelPicker.Selected, 2; got != want {
+		t.Fatalf("Selected after search = %d, want %d", got, want)
+	}
+
+	for range 4 {
+		next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		app = next.(App)
+	}
+
+	if got, want := app.modelPicker.SearchQuery, ""; got != want {
+		t.Fatalf("SearchQuery after clear = %q, want %q", got, want)
+	}
+	if got, want := app.modelPicker.Selected, 1; got != want {
+		t.Fatalf("Selected after clear = %d, want %d", got, want)
+	}
+}
+
+func TestModelPickerCtrlAOpensConnect(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title:    "Select model",
+			ActionID: "model_picker",
+			Options: []model.SelectionOption{
+				{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+				{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+			},
+			Selected: 1,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyCtrlA})
+	app = next.(App)
+
+	if app.modelPicker != nil {
+		t.Fatal("expected model picker to close on ctrl+a")
+	}
+	select {
+	case got := <-userCh:
+		if got != "/connect" {
+			t.Fatalf("user input = %q, want %q", got, "/connect")
+		}
+	default:
+		t.Fatal("expected /connect shortcut to be sent")
+	}
+}
+
+func TestProviderScopedModelPickerEnterSelectsModel(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+	next, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = next.(App)
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.ModelPickerOpen,
+		Popup: &model.SelectionPopup{
+			Title:    "Select model",
+			ActionID: "connect_provider_model_picker:openrouter",
+			Options: []model.SelectionOption{
+				{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+			},
+			Selected: 0,
+		},
+	})
+	app = next.(App)
+
+	next, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = next.(App)
+
+	if app.modelPicker != nil {
+		t.Fatal("expected provider-scoped model picker to close on enter")
+	}
+	select {
+	case got := <-userCh:
+		if got != "/model openrouter:openai/gpt-4o-mini" {
+			t.Fatalf("user input = %q, want %q", got, "/model openrouter:openai/gpt-4o-mini")
+		}
+	default:
+		t.Fatal("expected selected model command to be sent")
+	}
+}

--- a/ui/inline.go
+++ b/ui/inline.go
@@ -31,6 +31,9 @@ var (
 	bannerValueStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("252"))
 
+	bannerProviderStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("248"))
+
 	cmdOutputStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("245"))
 
@@ -52,13 +55,13 @@ func (a *App) maybePrintBanner() tea.Cmd {
 	}
 	a.bannerPrinted = true
 	return tea.Sequence(
-		tea.Println(RenderBanner(a.state.Version, a.state.WorkDir, a.state.RepoURL, a.state.Model.Name, a.state.Model.CtxMax)),
+		tea.Println(RenderBanner(a.state.Version, a.state.WorkDir, a.state.RepoURL, a.state.Model.Name, a.state.Model.CtxMax, a.state.Model.Provider)),
 		a.signalHistoryReplayReady(),
 	)
 }
 
 // RenderBanner renders the one-shot banner shown after boot in inline mode.
-func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int) string {
+func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) string {
 	ver := strings.TrimSpace(version)
 	// Strip product name prefix (e.g. "MindSpore CLI. v0.5.0" → "v0.5.0")
 	for _, prefix := range []string{"MindSpore CLI. ", "MindSpore CLI. "} {
@@ -69,8 +72,13 @@ func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int) strin
 	}
 	title := bannerTitleStyle.Render("MindSpore CLI") + " " + bannerValueStyle.Render("("+ver+")")
 
+	provider := ""
+	if len(providerName) > 0 {
+		provider = strings.TrimSpace(providerName[0])
+	}
+
 	rows := []string{
-		bannerRow("model", valueOrString(strings.TrimSpace(modelName), "unknown")),
+		bannerModelRow(strings.TrimSpace(modelName), provider),
 		bannerRow("directory", valueOrString(shortenPath(strings.TrimSpace(workDir)), ".")),
 	}
 
@@ -80,6 +88,14 @@ func RenderBanner(version, workDir, repoURL, modelName string, ctxMax int) strin
 
 func bannerRow(label, value string) string {
 	return bannerLabelStyle.Render(label+":") + " " + bannerValueStyle.Render(value)
+}
+
+func bannerModelRow(modelName, providerName string) string {
+	row := bannerLabelStyle.Render("model:") + " " + bannerValueStyle.Render(valueOrString(strings.TrimSpace(modelName), "unknown"))
+	if strings.TrimSpace(providerName) != "" {
+		row += " " + bannerProviderStyle.Render(strings.TrimSpace(providerName))
+	}
+	return row
 }
 
 func (a *App) signalHistoryReplayReady() tea.Cmd {

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -17,6 +17,7 @@ type TaskInfo struct {
 // ModelInfo holds LLM model metadata for the top bar.
 type ModelInfo struct {
 	Name       string
+	Provider   string
 	CtxUsed    int
 	CtxMax     int
 	TokensUsed int
@@ -97,6 +98,8 @@ const (
 	ToolError            EventType = "ToolError"
 	ClearScreen          EventType = "ClearScreen"
 	ModelUpdate          EventType = "ModelUpdate"
+	ModelBrowserOpen     EventType = "ModelBrowserOpen"
+	ModelBrowserClose    EventType = "ModelBrowserClose"
 	ModelPickerOpen      EventType = "ModelPickerOpen"
 	ModelSetupOpen       EventType = "ModelSetupOpen"
 	ModelSetupClose      EventType = "ModelSetupClose"
@@ -111,28 +114,30 @@ const (
 // Event is sent from the agent loop to the TUI.
 // Implements tea.Msg so Bubble Tea can route it.
 type Event struct {
-	Type        EventType
-	Task        string
-	Message     string
-	RawANSI     bool
-	ToolName    string
-	ToolCallID  string
-	Summary     string
-	Meta        map[string]any
-	ReplayWait  *ReplayWaitData
-	CtxUsed     int
-	CtxMax      int
-	TokensUsed  int
-	Train       *TrainEventData // non-nil for train events only
-	Project     *ProjectStatusView
-	Permission  *PermissionPromptData
-	Permissions *PermissionsViewData
-	Popup       *SelectionPopup // non-nil for popup events only
-	SetupPopup  *SetupPopup     // non-nil for model setup popup events
-	BugView     *BugEventData   // non-nil for bug view events only
-	IssueView   *IssueEventData // non-nil for issue view events only
-	Bug         *bugs.Bug       // reserved for lightweight bug payloads
-	Issue       *issuepkg.Issue // reserved for lightweight issue payloads
+	Type         EventType
+	Task         string
+	Message      string
+	Provider     string
+	RawANSI      bool
+	ToolName     string
+	ToolCallID   string
+	Summary      string
+	Meta         map[string]any
+	ReplayWait   *ReplayWaitData
+	CtxUsed      int
+	CtxMax       int
+	TokensUsed   int
+	Train        *TrainEventData // non-nil for train events only
+	Project      *ProjectStatusView
+	Permission   *PermissionPromptData
+	Permissions  *PermissionsViewData
+	ModelBrowser *ModelBrowserPopup
+	Popup        *SelectionPopup // non-nil for popup events only
+	SetupPopup   *SetupPopup     // non-nil for model setup popup events
+	BugView      *BugEventData   // non-nil for bug view events only
+	IssueView    *IssueEventData // non-nil for issue view events only
+	Bug          *bugs.Bug       // reserved for lightweight bug payloads
+	Issue        *issuepkg.Issue // reserved for lightweight issue payloads
 }
 
 // ReplayWaitData lets replay fast-forward the UI timer while using shorter real delays.
@@ -193,19 +198,24 @@ type State struct {
 }
 
 // NewState returns an initial empty state.
-func NewState(version, workDir, repoURL, modelName string, ctxMax int) State {
+func NewState(version, workDir, repoURL, modelName string, ctxMax int, providerName ...string) State {
 	if modelName == "" {
 		modelName = "No model (/model to configure)"
 	}
 	if ctxMax == 0 {
 		ctxMax = 128000 // Default for models like gpt-4o
 	}
+	currentProvider := ""
+	if len(providerName) > 0 {
+		currentProvider = providerName[0]
+	}
 	return State{
 		Version: version,
 		Tasks:   []TaskInfo{},
 		Model: ModelInfo{
-			Name:   modelName,
-			CtxMax: ctxMax,
+			Name:     modelName,
+			Provider: currentProvider,
+			CtxMax:   ctxMax,
 		},
 		WorkDir:      workDir,
 		RepoURL:      repoURL,

--- a/ui/model/popup_test.go
+++ b/ui/model/popup_test.go
@@ -14,14 +14,14 @@ func TestSetupPopupPresetNavigatesAllItems(t *testing.T) {
 		PresetSelected: 0,
 	}
 
-	// Cursor moves to disabled items (they are visually navigable)
+	// Cursor skips disabled items.
 	popup.MovePresetSelection(1)
 	if popup.PresetSelected != 1 {
 		t.Errorf("expected 1, got %d", popup.PresetSelected)
 	}
 	popup.MovePresetSelection(1)
-	if popup.PresetSelected != 2 {
-		t.Errorf("expected 2, got %d", popup.PresetSelected)
+	if popup.PresetSelected != 0 {
+		t.Errorf("expected wrap to 0, got %d", popup.PresetSelected)
 	}
 	// Wraps around
 	popup.MovePresetSelection(1)

--- a/ui/model/train.go
+++ b/ui/model/train.go
@@ -1,5 +1,7 @@
 package model
 
+import "strings"
+
 // Train-specific UI event types.
 const (
 	TrainModeOpen      EventType = "TrainModeOpen"
@@ -224,17 +226,61 @@ type TrainActionsState struct {
 
 // SelectionPopup is a popup menu shown when an action needs user input.
 type SelectionPopup struct {
-	Title    string
-	Options  []SelectionOption
-	Selected int
-	ActionID string // which action triggered the popup
+	Title       string
+	SearchQuery string
+	Options     []SelectionOption
+	Selected    int
+	SearchBase  int
+	ActionID    string // which action triggered the popup
+}
+
+type ModelBrowserFocus int
+
+const (
+	ModelBrowserFocusProvider ModelBrowserFocus = iota
+	ModelBrowserFocusModel
+)
+
+type ModelBrowserProviderInput struct {
+	Option SelectionOption
+	Label  string
+	Value  string
+	Error  string
+}
+
+type ProviderImportSuggestion struct {
+	ProviderID    string
+	ProviderLabel string
+	Source        string
+	SourceLabel   string
+	Protocol      string
+	BaseURL       string
+	APIKeyEnvVar  string
+	BaseURLEnvVar string
+}
+
+type ModelBrowserPopup struct {
+	Title                   string
+	Providers               SelectionPopup
+	Models                  SelectionPopup
+	Focus                   ModelBrowserFocus
+	ProvidersVisible        bool
+	ProviderInput           *ModelBrowserProviderInput
+	ImportSuggestions       []ProviderImportSuggestion
+	AnimationOffset         int
+	PendingDeleteProviderID string
 }
 
 type SelectionOption struct {
-	ID       string
-	Label    string
-	Desc     string
-	Disabled bool // grayed out, not selectable (e.g. coming soon)
+	ID               string
+	Label            string
+	Desc             string
+	Header           bool
+	Separator        bool
+	Disabled         bool // grayed out, not selectable (e.g. coming soon)
+	RequiresInput    bool
+	ProviderRow      bool
+	DeleteProviderID string
 }
 
 // SetupScreen identifies which screen of the model setup popup is shown.
@@ -242,23 +288,28 @@ type SetupScreen int
 
 const (
 	SetupScreenModeSelect   SetupScreen = iota // "mscli-provided" vs "your own model"
-	SetupScreenPresetPicker                     // pick from preset list
-	SetupScreenTokenInput                       // enter token for selected preset
-	SetupScreenEnvInfo                          // show env var examples
+	SetupScreenPresetPicker                    // pick from preset list
+	SetupScreenTokenInput                      // enter token for selected preset
+	SetupScreenEnvInfo                         // show env var examples
 )
 
 // SetupPopup holds the full state of the multi-step model setup popup.
 type SetupPopup struct {
+	Title          string
+	InputLabel     string
+	SearchQuery    string
 	Screen         SetupScreen
-	ModeSelected   int    // 0 = mscli-provided, 1 = your own model
+	ModeSelected   int // 0 = mscli-provided, 1 = your own model
 	PresetOptions  []SelectionOption
 	PresetSelected int
+	SearchBase     int
 	SelectedPreset SelectionOption // set when user picks a preset
 	TokenValue     string
 	TokenError     string // inline error message
 	CurrentMode    string // "mscli-provided", "own", or "" — for (current) badge
 	CurrentPreset  string // preset ID currently active — for (current) badge
 	CanEscape      bool   // false on first boot (no config to fall back to)
+	BackCloses     bool
 }
 
 // MoveModeSelection moves the mode cursor by delta, wrapping around 2 options.
@@ -267,13 +318,174 @@ func (p *SetupPopup) MoveModeSelection(delta int) {
 }
 
 // MovePresetSelection moves the preset cursor by delta, wrapping around all options.
-// Disabled options are visually navigable but cannot be confirmed with enter.
+// Disabled options are skipped.
 func (p *SetupPopup) MovePresetSelection(delta int) {
-	n := len(p.PresetOptions)
-	if n == 0 {
-		return
+	p.PresetSelected = moveFilteredSelection(p.PresetSelected, delta, p.PresetOptions, p.SearchQuery)
+}
+
+func (p *SetupPopup) FirstSelectablePreset() int {
+	return firstSelectableFilteredOption(p.PresetOptions, p.SearchQuery)
+}
+
+func (p *SetupPopup) EnsureSelectablePreset() {
+	p.PresetSelected = ensureFilteredSelection(p.PresetSelected, p.PresetOptions, p.SearchQuery)
+}
+
+func (p *SetupPopup) BeginSearchIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" {
+		p.SearchBase = p.PresetSelected
 	}
-	p.PresetSelected = (p.PresetSelected + delta%n + n) % n
+}
+
+func (p *SetupPopup) RestoreSearchBaseIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" && p.SearchBase >= 0 && p.SearchBase < len(p.PresetOptions) {
+		p.PresetSelected = p.SearchBase
+	}
+}
+
+func (p *SelectionPopup) MoveSelection(delta int) {
+	p.Selected = moveFilteredSelection(p.Selected, delta, p.Options, p.SearchQuery)
+}
+
+func (p *SelectionPopup) EnsureSelectableSelection() {
+	p.Selected = ensureFilteredSelection(p.Selected, p.Options, p.SearchQuery)
+}
+
+func (p *SelectionPopup) BeginSearchIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" {
+		p.SearchBase = p.Selected
+	}
+}
+
+func (p *SelectionPopup) RestoreSearchBaseIfNeeded() {
+	if strings.TrimSpace(p.SearchQuery) == "" && p.SearchBase >= 0 && p.SearchBase < len(p.Options) {
+		p.Selected = p.SearchBase
+	}
+}
+
+func (p *ModelBrowserPopup) HasModels() bool {
+	if p == nil {
+		return false
+	}
+	for _, opt := range p.Models.Options {
+		if opt.Selectable() {
+			return true
+		}
+	}
+	return false
+}
+
+func (o SelectionOption) Selectable() bool {
+	return !o.Disabled && !o.Header && !o.Separator
+}
+
+func filteredOptionIndices(options []SelectionOption, query string) []int {
+	if len(options) == 0 {
+		return nil
+	}
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		idxs := make([]int, 0, len(options))
+		for i := range options {
+			idxs = append(idxs, i)
+		}
+		return idxs
+	}
+
+	type group struct {
+		header int
+		items  []int
+	}
+	var (
+		groups        []group
+		currentHeader = -1
+		currentItems  []int
+	)
+	flush := func() {
+		if len(currentItems) == 0 {
+			return
+		}
+		items := make([]int, len(currentItems))
+		copy(items, currentItems)
+		groups = append(groups, group{header: currentHeader, items: items})
+		currentItems = nil
+	}
+
+	for i, opt := range options {
+		if opt.Separator {
+			continue
+		}
+		if opt.Header {
+			flush()
+			currentHeader = i
+			continue
+		}
+		if !opt.Selectable() {
+			continue
+		}
+		text := strings.ToLower(strings.TrimSpace(opt.Label + " " + opt.Desc))
+		if strings.Contains(text, query) {
+			currentItems = append(currentItems, i)
+		}
+	}
+	flush()
+
+	result := make([]int, 0)
+	for gi, group := range groups {
+		if gi > 0 {
+			result = append(result, -1)
+		}
+		if group.header >= 0 {
+			result = append(result, group.header)
+		}
+		result = append(result, group.items...)
+	}
+	return result
+}
+
+func FilteredOptionIndicesForRender(options []SelectionOption, query string) []int {
+	return filteredOptionIndices(options, query)
+}
+
+func firstSelectableFilteredOption(options []SelectionOption, query string) int {
+	for _, idx := range filteredOptionIndices(options, query) {
+		if idx >= 0 && options[idx].Selectable() {
+			return idx
+		}
+	}
+	return 0
+}
+
+func ensureFilteredSelection(current int, options []SelectionOption, query string) int {
+	for _, idx := range filteredOptionIndices(options, query) {
+		if idx >= 0 && idx == current && options[idx].Selectable() {
+			return current
+		}
+	}
+	return firstSelectableFilteredOption(options, query)
+}
+
+func moveFilteredSelection(current, delta int, options []SelectionOption, query string) int {
+	if delta == 0 {
+		return current
+	}
+	selectable := make([]int, 0)
+	for _, idx := range filteredOptionIndices(options, query) {
+		if idx >= 0 && options[idx].Selectable() {
+			selectable = append(selectable, idx)
+		}
+	}
+	if len(selectable) == 0 {
+		return 0
+	}
+	pos := 0
+	for i, idx := range selectable {
+		if idx == current {
+			pos = i
+			break
+		}
+	}
+	return selectable[(pos+delta%len(selectable)+len(selectable))%len(selectable)]
 }
 
 type TrainMetricsView struct {

--- a/ui/model/train.go
+++ b/ui/model/train.go
@@ -279,6 +279,8 @@ type SelectionOption struct {
 	Separator        bool
 	Disabled         bool // grayed out, not selectable (e.g. coming soon)
 	RequiresInput    bool
+	Featured         bool
+	DetailRow        bool
 	ProviderRow      bool
 	DeleteProviderID string
 }

--- a/ui/panels/hintbar.go
+++ b/ui/panels/hintbar.go
@@ -34,7 +34,12 @@ var hints = []hint{
 // RenderHintBar renders the bottom status bar with model, context, and workdir.
 func RenderHintBar(s model.State, width int) string {
 	sep := hintSepStyle.Render("  ")
-	left := hintKeyStyle.Render(s.Model.Name) + sep +
+	modelDisplay := hintKeyStyle.Render(s.Model.Name)
+	if strings.TrimSpace(s.Model.Provider) != "" {
+		providerStyle := hintKeyStyle.Foreground(lipgloss.Color("245"))
+		modelDisplay += " " + providerStyle.Render(strings.TrimSpace(s.Model.Provider))
+	}
+	left := modelDisplay + sep +
 		hintDescStyle.Render(formatCtxHint(s.Model.CtxUsed, s.Model.CtxMax)) + sep +
 		hintDescStyle.Render(shortenHintPath(s.WorkDir))
 

--- a/ui/panels/hintbar_test.go
+++ b/ui/panels/hintbar_test.go
@@ -1,0 +1,19 @@
+package panels
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+func TestRenderHintBarIncludesModelAndProvider(t *testing.T) {
+	state := model.NewState("test", "/tmp/project", "", "Kimi K2.5", 262144, "MindSpore CLI Free")
+
+	result := RenderHintBar(state, 120)
+	for _, want := range []string{"Kimi K2.5", "MindSpore CLI Free", "/tmp/project"} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("expected hint bar to include %q, got:\n%s", want, result)
+		}
+	}
+}

--- a/ui/panels/model_browser.go
+++ b/ui/panels/model_browser.go
@@ -1,0 +1,253 @@
+package panels
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+	"github.com/mindspore-lab/mindspore-cli/ui/theme"
+)
+
+const (
+	modelBrowserCardHeight  = 19
+	modelBrowserRearWidth   = 4
+	modelBrowserRearDrop    = 2
+	modelBrowserFocusPad    = 2
+	modelBrowserLeftBiasPad = 1
+	modelBrowserFooterHint  = "↑/↓ select · enter choose · esc"
+)
+
+func RenderModelBrowserPopup(popup *model.ModelBrowserPopup) string {
+	if popup == nil {
+		return ""
+	}
+	if popup.Focus == model.ModelBrowserFocusProvider {
+		return renderProviderBrowserCard(popup)
+	}
+	return renderModelBrowserCard(popup)
+}
+
+func renderProviderBrowserCard(popup *model.ModelBrowserPopup) string {
+	if popup.ProviderInput != nil {
+		lines := renderCardHeader(model.ModelBrowserFocusProvider)
+		lines = append(lines, "")
+		lines = append(lines, setupLabelStyle.Render(popup.ProviderInput.Option.Label))
+		lines = append(lines, "")
+		lines = append(lines, setupLabelStyle.Render(popup.ProviderInput.Label+": ")+renderTokenField(popup.ProviderInput.Value))
+		if popup.ProviderInput.Error != "" {
+			lines = append(lines, "")
+			lines = append(lines, setupErrorStyle.Render(popup.ProviderInput.Error))
+		}
+		lines = append(lines, "")
+		lines = append(lines, setupHintStyle.Render(modelBrowserFooterHint))
+		return renderFixedBrowserCard(lines)
+	}
+
+	return renderBrowserSelectionCard(model.ModelBrowserFocusProvider, &popup.Providers)
+}
+
+func renderModelBrowserCard(popup *model.ModelBrowserPopup) string {
+	if popup.HasModels() {
+		return renderBrowserSelectionCard(model.ModelBrowserFocusModel, &popup.Models)
+	}
+
+	lines := renderCardHeader(model.ModelBrowserFocusModel)
+	lines = append(lines, "")
+	lines = append(lines, setupLabelStyle.Render("Search"))
+	lines = append(lines, renderSearchField("", popupContentWidth))
+	lines = append(lines, "")
+	lines = append(lines, setupHintStyle.Render("No models yet. Add a provider first."))
+	lines = append(lines, "")
+	lines = append(lines, setupHintStyle.Render(modelBrowserFooterHint))
+	return renderFixedBrowserCard(lines)
+}
+
+func renderBrowserSelectionCard(focus model.ModelBrowserFocus, popup *model.SelectionPopup) string {
+	filtered := filteredPopupOptions(popup.Options, popup.SearchQuery)
+	visible, _, _ := popupOptionWindow(filtered, popup.Selected, popupVisibleOptions)
+	maxW := popupContentWidth
+
+	t := theme.Current
+	normalStyle := lipgloss.NewStyle().Foreground(t.TextSecondary)
+	selectedStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true)
+	disabledStyle := lipgloss.NewStyle().Foreground(t.TextMuted)
+
+	lines := renderCardHeader(focus)
+	lines = append(lines, "")
+	lines = append(lines, setupLabelStyle.Render("Search"))
+	lines = append(lines, renderSearchField(popup.SearchQuery, maxW))
+	lines = append(lines, "")
+	for _, row := range visible {
+		if row.Separator {
+			lines = append(lines, "")
+			continue
+		}
+		opt := row.Option
+		marker := "  "
+		style := normalStyle
+		if opt.Disabled {
+			style = disabledStyle
+		}
+		if row.Index == popup.Selected {
+			marker = "❯ "
+			if !opt.Disabled {
+				style = selectedStyle
+			}
+		}
+		if opt.ProviderRow {
+			style = setupLabelStyle
+			if row.Index == popup.Selected {
+				style = selectedStyle
+			}
+		}
+		label := opt.Label
+		if opt.Desc != "" {
+			label += " " + modelPickerDescStyle.Render(opt.Desc)
+		}
+		if opt.ProviderRow && row.Index == popup.Selected && strings.TrimSpace(opt.DeleteProviderID) != "" {
+			lines = append(lines, renderBrowserProviderRow(label, "double-press d to delete", marker, style, maxW))
+			continue
+		}
+		lines = append(lines, renderWrappedPopupOption(label, marker, style, maxW))
+	}
+	lines = append(lines, "")
+	lines = append(lines, setupHintStyle.Render(modelBrowserFooterHint))
+	return renderFixedBrowserCard(lines)
+}
+
+func renderBrowserProviderRow(label, hint, marker string, style lipgloss.Style, width int) string {
+	if width < 4 {
+		width = 4
+	}
+	contentWidth := width - len([]rune(marker))
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	hintRendered := setupHintStyle.Render(hint)
+	hintWidth := lipgloss.Width(hintRendered)
+	labelWidth := contentWidth - hintWidth
+	if labelWidth < 1 {
+		labelWidth = 1
+	}
+	left := style.Width(labelWidth).MaxWidth(labelWidth).Render(label)
+	return marker + lipgloss.JoinHorizontal(lipgloss.Top, left, hintRendered)
+}
+
+func renderCardHeader(focus model.ModelBrowserFocus) []string {
+	headerWidth := popupContentWidth
+	leftText := "Select Providers"
+	leftStyle := setupTitleStyle.Copy().Align(lipgloss.Left)
+	rightText := "Select Models"
+	rightStyle := setupTitleStyle.Copy().Align(lipgloss.Right)
+	if focus == model.ModelBrowserFocusProvider {
+		rightText = "→ Select Models"
+		rightStyle = setupHintStyle.Copy().Align(lipgloss.Right)
+	} else {
+		leftText = "Select Providers ←"
+		leftStyle = setupHintStyle.Copy().Align(lipgloss.Left)
+	}
+	left := leftStyle.Render(leftText)
+	right := rightStyle.Render(rightText)
+	line := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		lipgloss.NewStyle().Width(headerWidth-lipgloss.Width(right)).Render(left),
+		right,
+	)
+	return []string{line}
+}
+
+func renderFixedBrowserCard(lines []string) string {
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+	footer := lines[len(lines)-1]
+	bodyLines := append([]string(nil), lines[:len(lines)-1]...)
+	for len(bodyLines) < modelBrowserCardHeight-1 {
+		bodyLines = append(bodyLines, "")
+	}
+	if len(bodyLines) > modelBrowserCardHeight-1 {
+		bodyLines = bodyLines[:modelBrowserCardHeight-1]
+	}
+	bodyLines = append(bodyLines, footer)
+	body := make([]string, 0, len(lines))
+	for _, line := range bodyLines {
+		body = append(body, lipgloss.NewStyle().Width(popupContentWidth).MaxWidth(popupContentWidth).Render(line))
+	}
+	return setupBorderStyle.Render(strings.Join(body, "\n"))
+}
+
+func renderRearBrowserCard(leftSide bool) string {
+	fullCard := renderBlankBrowserCardLines()
+	lines := make([]string, 0, len(fullCard)+modelBrowserRearDrop)
+	for i := 0; i < modelBrowserRearDrop; i++ {
+		lines = append(lines, strings.Repeat(" ", modelBrowserRearWidth))
+	}
+	for _, line := range fullCard {
+		if leftSide {
+			lines = append(lines, trimLinePrefix(line, modelBrowserRearWidth))
+			continue
+		}
+		lines = append(lines, trimLineSuffix(line, modelBrowserRearWidth))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderBlankBrowserCardLines() []string {
+	border := lipgloss.RoundedBorder()
+	innerWidth := popupContentWidth + 4
+	lines := make([]string, 0, modelBrowserCardHeight+2)
+	lines = append(lines, border.TopLeft+strings.Repeat(border.Top, innerWidth)+border.TopRight)
+	for i := 0; i < modelBrowserCardHeight; i++ {
+		lines = append(lines, border.Left+strings.Repeat(" ", innerWidth)+border.Right)
+	}
+	lines = append(lines, border.BottomLeft+strings.Repeat(border.Bottom, innerWidth)+border.BottomRight)
+	return lines
+}
+
+func trimLinePrefix(line string, width int) string {
+	runes := []rune(line)
+	if width <= 0 {
+		return ""
+	}
+	if len(runes) <= width {
+		return line
+	}
+	return string(runes[:width])
+}
+
+func trimLineSuffix(line string, width int) string {
+	runes := []rune(line)
+	if width <= 0 {
+		return ""
+	}
+	if len(runes) <= width {
+		return line
+	}
+	return string(runes[len(runes)-width:])
+}
+
+func overlayRearCard(mainCard, rearCard string, leftSide bool) string {
+	mainLines := strings.Split(mainCard, "\n")
+	rearLines := strings.Split(rearCard, "\n")
+	mainWidth := 0
+	if len(mainLines) > 0 {
+		mainWidth = lipgloss.Width(mainLines[0])
+	}
+	out := make([]string, 0, maxInt(len(mainLines), len(rearLines)))
+	for i := 0; i < maxInt(len(mainLines), len(rearLines)); i++ {
+		mainLine := ""
+		if i < len(mainLines) {
+			mainLine = mainLines[i]
+		}
+		rearLine := ""
+		if i < len(rearLines) {
+			rearLine = rearLines[i]
+		}
+		if leftSide {
+			out = append(out, rearLine+mainLine)
+			continue
+		}
+		out = append(out, mainLine+strings.Repeat(" ", maxInt(0, mainWidth-lipgloss.Width(mainLine)))+rearLine)
+	}
+	return strings.Join(out, "\n")
+}

--- a/ui/panels/model_browser.go
+++ b/ui/panels/model_browser.go
@@ -100,6 +100,10 @@ func renderBrowserSelectionCard(focus model.ModelBrowserFocus, popup *model.Sele
 				style = selectedStyle
 			}
 		}
+		if opt.DetailRow {
+			lines = append(lines, renderWrappedPopupOption(opt.Label, "  ", setupHintStyle, maxW))
+			continue
+		}
 		label := opt.Label
 		if opt.Desc != "" {
 			label += " " + modelPickerDescStyle.Render(opt.Desc)

--- a/ui/panels/model_setup.go
+++ b/ui/panels/model_setup.go
@@ -9,16 +9,19 @@ import (
 
 // Style vars are populated by InitStyles() in styles.go.
 var (
-	setupTitleStyle    lipgloss.Style
-	setupNormalStyle   lipgloss.Style
-	setupSelectedStyle lipgloss.Style
-	setupDisabledStyle lipgloss.Style
-	setupHintStyle     lipgloss.Style
-	setupErrorStyle    lipgloss.Style
-	setupLabelStyle    lipgloss.Style
-	setupBadgeStyle    lipgloss.Style
-	setupBorderStyle   lipgloss.Style
+	setupTitleStyle      lipgloss.Style
+	setupNormalStyle     lipgloss.Style
+	setupSelectedStyle   lipgloss.Style
+	setupDisabledStyle   lipgloss.Style
+	setupHintStyle       lipgloss.Style
+	setupErrorStyle      lipgloss.Style
+	setupLabelStyle      lipgloss.Style
+	setupBadgeStyle      lipgloss.Style
+	modelPickerDescStyle lipgloss.Style
+	setupBorderStyle     lipgloss.Style
 )
+
+const popupVisibleOptions = 12
 
 // RenderSetupPopup renders the multi-step model setup popup.
 func RenderSetupPopup(popup *model.SetupPopup) string {
@@ -38,10 +41,15 @@ func RenderSetupPopup(popup *model.SetupPopup) string {
 
 const (
 	modeMSCLIProvided = "mscli-provided"
-	modeModeOwn        = "own"
+	modeModeOwn       = "own"
+	popupContentWidth = 56
 )
 
 func renderModeSelect(popup *model.SetupPopup) string {
+	title := popup.Title
+	if title == "" {
+		title = "Model Setup"
+	}
 	modes := []struct {
 		label string
 		mode  string
@@ -50,7 +58,7 @@ func renderModeSelect(popup *model.SetupPopup) string {
 		{"your own model", modeModeOwn},
 	}
 
-	maxW := len("Model Setup")
+	maxW := len(title)
 	for _, m := range modes {
 		if w := 2 + len(m.label) + 12; w > maxW {
 			maxW = w
@@ -58,7 +66,7 @@ func renderModeSelect(popup *model.SetupPopup) string {
 	}
 
 	var lines []string
-	lines = append(lines, setupTitleStyle.Width(maxW).Render("Model Setup"))
+	lines = append(lines, setupTitleStyle.Width(maxW).Render(title))
 	lines = append(lines, "")
 	for i, m := range modes {
 		marker := "  "
@@ -84,36 +92,52 @@ func renderModeSelect(popup *model.SetupPopup) string {
 }
 
 func renderPresetPicker(popup *model.SetupPopup) string {
-	maxW := len("mscli-provided")
-	for _, opt := range popup.PresetOptions {
-		if w := 2 + len(opt.Label) + 12; w > maxW {
-			maxW = w
-		}
+	title := popup.Title
+	if title == "" {
+		title = "mscli-provided"
 	}
+	filtered := filteredPopupOptions(popup.PresetOptions, popup.SearchQuery)
+	visible, start, end := popupOptionWindow(filtered, popup.PresetSelected, popupVisibleOptions)
+	maxW := popupContentWidth
 
 	var lines []string
-	lines = append(lines, setupTitleStyle.Width(maxW).Render("mscli-provided"))
+	lines = append(lines, setupTitleStyle.Width(maxW).Render(title))
 	lines = append(lines, "")
-	for i, opt := range popup.PresetOptions {
+	lines = append(lines, setupLabelStyle.Render("Search"))
+	lines = append(lines, renderSearchField(popup.SearchQuery, maxW))
+	lines = append(lines, "")
+	for _, row := range visible {
+		if row.Separator {
+			lines = append(lines, "")
+			continue
+		}
+		opt := row.Option
 		marker := "  "
 		style := setupNormalStyle
 		if opt.Disabled {
 			style = setupDisabledStyle
 		}
-		if i == popup.PresetSelected {
+		if row.Index == popup.PresetSelected {
 			marker = "❯ "
 			if !opt.Disabled {
 				style = setupSelectedStyle
 			}
 		}
 		label := opt.Label
+		if opt.Desc != "" {
+			label += " " + opt.Desc
+		}
 		if opt.ID == popup.CurrentPreset {
 			label += setupBadgeStyle.Render("  (current)")
 		}
-		lines = append(lines, marker+style.Render(label))
+		lines = append(lines, renderWrappedPopupOption(label, marker, style, maxW))
 	}
 	lines = append(lines, "")
-	lines = append(lines, setupHintStyle.Render("↑/↓ select · enter · esc back"))
+	scrollHint := "↑/↓ select · enter · esc back"
+	if start > 0 || end < len(filtered) {
+		scrollHint = "↑/↓ scroll · enter · esc back"
+	}
+	lines = append(lines, setupHintStyle.Render(scrollHint))
 
 	return setupBorderStyle.Render(strings.Join(lines, "\n"))
 }
@@ -123,11 +147,15 @@ func renderTokenInput(popup *model.SetupPopup) string {
 	if title == "" {
 		title = "Enter Token"
 	}
+	inputLabel := popup.InputLabel
+	if inputLabel == "" {
+		inputLabel = "Token"
+	}
 
 	var lines []string
 	lines = append(lines, setupTitleStyle.Width(40).Render(title))
 	lines = append(lines, "")
-	lines = append(lines, setupLabelStyle.Render("Token: ")+renderTokenField(popup.TokenValue))
+	lines = append(lines, setupLabelStyle.Render(inputLabel+": ")+renderTokenField(popup.TokenValue))
 	if popup.TokenError != "" {
 		lines = append(lines, "")
 		lines = append(lines, setupErrorStyle.Render(popup.TokenError))
@@ -176,4 +204,82 @@ func renderEnvInfo(popup *model.SetupPopup) string {
 	lines = append(lines, setupHintStyle.Render("esc back"))
 
 	return setupBorderStyle.Render(strings.Join(lines, "\n"))
+}
+
+func popupOptionWindow[T any](options []T, selected, maxVisible int) ([]T, int, int) {
+	total := len(options)
+	if total == 0 || maxVisible <= 0 || total <= maxVisible {
+		return options, 0, total
+	}
+	if selected < 0 {
+		selected = 0
+	}
+	if selected >= total {
+		selected = total - 1
+	}
+	start := selected - maxVisible/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxVisible
+	if end > total {
+		end = total
+		start = end - maxVisible
+	}
+	return options[start:end], start, end
+}
+
+type popupOptionRow struct {
+	Index     int
+	Option    model.SelectionOption
+	Separator bool
+}
+
+func filteredPopupOptions(options []model.SelectionOption, query string) []popupOptionRow {
+	rows := make([]popupOptionRow, 0)
+	indices := model.FilteredOptionIndicesForRender(options, query)
+	for _, idx := range indices {
+		if idx < 0 {
+			rows = append(rows, popupOptionRow{Separator: true})
+			continue
+		}
+		rows = append(rows, popupOptionRow{
+			Index:  idx,
+			Option: options[idx],
+		})
+	}
+	return rows
+}
+
+func renderWrappedPopupOption(text, marker string, style lipgloss.Style, width int) string {
+	if width < 4 {
+		width = 4
+	}
+	contentWidth := width - 2
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	wrapped := lipgloss.NewStyle().Width(contentWidth).Render(text)
+	lines := strings.Split(wrapped, "\n")
+	for i, line := range lines {
+		prefix := "  "
+		if i == 0 {
+			prefix = marker
+		}
+		lines[i] = prefix + style.Render(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderSearchField(query string, width int) string {
+	if width < 4 {
+		width = 4
+	}
+	text := query
+	style := setupNormalStyle
+	if strings.TrimSpace(text) == "" {
+		text = "Type to filter"
+		style = setupHintStyle
+	}
+	return style.Width(width).Render(text)
 }

--- a/ui/panels/model_setup_test.go
+++ b/ui/panels/model_setup_test.go
@@ -1,11 +1,15 @@
 package panels
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/mindspore-lab/mindspore-cli/ui/model"
 )
+
+var selectionPopupANSIPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func TestRenderSetupPopupModeSelect(t *testing.T) {
 	popup := &model.SetupPopup{
@@ -72,5 +76,246 @@ func TestRenderSetupPopupEnvInfo(t *testing.T) {
 	}
 	if !strings.Contains(result, "MSCLI_API_KEY") {
 		t.Error("expected MSCLI_API_KEY in output")
+	}
+}
+
+func TestRenderSetupPopupPresetPickerUsesWindowedOptions(t *testing.T) {
+	options := make([]model.SelectionOption, 0, 20)
+	for i := 0; i < 20; i++ {
+		options = append(options, model.SelectionOption{
+			ID:    "provider-" + strings.Repeat("x", i%3+1),
+			Label: fmt.Sprintf("provider option item-%02d", i),
+		})
+	}
+	popup := &model.SetupPopup{
+		Screen:         model.SetupScreenPresetPicker,
+		PresetOptions:  options,
+		PresetSelected: 15,
+		CanEscape:      true,
+	}
+	result := RenderSetupPopup(popup)
+	if !strings.Contains(result, "provider option item-15") {
+		t.Fatalf("expected selected window item in output, got:\n%s", result)
+	}
+	if strings.Contains(result, "provider option item-00") {
+		t.Fatalf("expected earliest option to be clipped from output, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupUsesWindowedOptions(t *testing.T) {
+	options := make([]model.SelectionOption, 0, 20)
+	for i := 0; i < 20; i++ {
+		options = append(options, model.SelectionOption{
+			ID:    "model-id",
+			Label: fmt.Sprintf("model option item-%02d", i),
+		})
+	}
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		Options:  options,
+		Selected: 14,
+	})
+	if !strings.Contains(result, "model option item-14") {
+		t.Fatalf("expected selected window item in output, got:\n%s", result)
+	}
+	if strings.Contains(result, "model option item-00") {
+		t.Fatalf("expected earliest option to be clipped from output, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupIncludesConnectProviderShortcut(t *testing.T) {
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		ActionID: "model_picker",
+		Options: []model.SelectionOption{
+			{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+			{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+		},
+		Selected: 1,
+	})
+	if !strings.Contains(result, "Connect Provider ctrl+a") {
+		t.Fatalf("expected connect provider shortcut in output, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupModelPickerFooterOnlyShowsConnectShortcut(t *testing.T) {
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		ActionID: "model_picker",
+		Options: []model.SelectionOption{
+			{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+			{ID: "mindspore-cli-free:kimi-k2.5", Label: "Kimi K2.5"},
+		},
+		Selected: 1,
+	})
+	if strings.Contains(result, "↑/↓ select · enter confirm · esc cancel") {
+		t.Fatalf("expected model picker footer to omit nav hint, got:\n%s", result)
+	}
+	if strings.Contains(result, "↑/↓ scroll · enter confirm · esc cancel") {
+		t.Fatalf("expected model picker footer to omit scroll hint, got:\n%s", result)
+	}
+	if !strings.Contains(result, "Connect Provider ctrl+a") {
+		t.Fatalf("expected model picker footer to keep connect shortcut, got:\n%s", result)
+	}
+}
+
+func TestRenderSelectionPopupModelPickerShowsProviderAfterRecentModel(t *testing.T) {
+	result := RenderSelectionPopup(&model.SelectionPopup{
+		Title:    "Select model",
+		ActionID: "model_picker",
+		Options: []model.SelectionOption{
+			{ID: "__header__Recent", Label: "Recent", Header: true, Disabled: true},
+			{ID: "openai:gpt-4.1", Label: "GPT-4.1", Desc: "· OpenAI"},
+		},
+		Selected: 1,
+	})
+
+	plain := selectionPopupANSIPattern.ReplaceAllString(result, "")
+	if !strings.Contains(plain, "GPT-4.1 · OpenAI") {
+		t.Fatalf("expected recent model to render provider suffix, got:\n%s", plain)
+	}
+}
+
+func TestRenderModelBrowserPopupFocusProviderShowsOnlyProviderCardContent(t *testing.T) {
+	result := RenderModelBrowserPopup(&model.ModelBrowserPopup{
+		Providers: model.SelectionPopup{
+			Title: "Providers",
+			Options: []model.SelectionOption{
+				{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
+			},
+			Selected: 0,
+		},
+		Models: model.SelectionPopup{
+			Title: "Models",
+			Options: []model.SelectionOption{
+				{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+			},
+			Selected: 0,
+		},
+		Focus:            model.ModelBrowserFocusProvider,
+		ProvidersVisible: true,
+	})
+
+	plain := selectionPopupANSIPattern.ReplaceAllString(result, "")
+	if !strings.Contains(plain, "Select Providers") {
+		t.Fatalf("expected provider header, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Select Models") {
+		t.Fatalf("expected unified header to include models label, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "→ Select Models") {
+		t.Fatalf("expected provider switch hint in header, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "↑/↓ select") {
+		t.Fatalf("expected navigation hint in footer, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "GPT-4o mini") {
+		t.Fatalf("expected rear models card to hide content, got:\n%s", plain)
+	}
+	if strings.Contains(result, "───╮") || strings.Contains(result, "───╯") {
+		t.Fatalf("expected provider focus to hide rear card edge fragments, got:\n%s", result)
+	}
+	lines := strings.Split(plain, "\n")
+	if got := strings.TrimSpace(lines[len(lines)-1]); !strings.Contains(got, "↑/↓ select · enter choose · esc") {
+		t.Fatalf("expected footer on final line, got last line %q in:\n%s", got, plain)
+	}
+}
+
+func TestRenderModelBrowserPopupFocusModelsShowsOnlyModelCardContent(t *testing.T) {
+	result := RenderModelBrowserPopup(&model.ModelBrowserPopup{
+		Providers: model.SelectionPopup{
+			Title: "Providers",
+			Options: []model.SelectionOption{
+				{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
+			},
+			Selected: 0,
+		},
+		Models: model.SelectionPopup{
+			Title: "Models",
+			Options: []model.SelectionOption{
+				{ID: "__provider__openrouter", Label: "OpenRouter", ProviderRow: true, DeleteProviderID: "openrouter"},
+				{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+			},
+			Selected: 0,
+		},
+		Focus:            model.ModelBrowserFocusModel,
+		ProvidersVisible: false,
+	})
+
+	plain := selectionPopupANSIPattern.ReplaceAllString(result, "")
+	if !strings.Contains(plain, "Select Providers") {
+		t.Fatalf("expected unified header to include providers label, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Select Models") {
+		t.Fatalf("expected model header, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Select Providers ←") {
+		t.Fatalf("expected model switch hint in header, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "OpenRouter") {
+		t.Fatalf("expected selectable provider row in model card, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "double-press d to delete") {
+		t.Fatalf("expected provider delete hint, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "↑/↓ select") {
+		t.Fatalf("expected navigation hint in footer, got:\n%s", plain)
+	}
+	if strings.Contains(result, "╭───") || strings.Contains(result, "╰───") {
+		t.Fatalf("expected model focus to hide rear card edge fragments, got:\n%s", result)
+	}
+	lines := strings.Split(plain, "\n")
+	if got := strings.TrimSpace(lines[len(lines)-1]); !strings.Contains(got, "↑/↓ select · enter choose · esc") {
+		t.Fatalf("expected footer on final line, got last line %q in:\n%s", got, plain)
+	}
+}
+
+func TestRenderModelBrowserPopupProviderInputKeepsCardChromeAndHidesSearch(t *testing.T) {
+	result := RenderModelBrowserPopup(&model.ModelBrowserPopup{
+		Providers: model.SelectionPopup{
+			Title: "Providers",
+			Options: []model.SelectionOption{
+				{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
+			},
+			Selected: 0,
+		},
+		Models: model.SelectionPopup{
+			Title: "Models",
+			Options: []model.SelectionOption{
+				{ID: "openrouter:openai/gpt-4o-mini", Label: "GPT-4o mini"},
+			},
+			Selected: 0,
+		},
+		Focus:            model.ModelBrowserFocusProvider,
+		ProvidersVisible: true,
+		ProviderInput: &model.ModelBrowserProviderInput{
+			Option: model.SelectionOption{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
+			Label:  "API key",
+			Value:  "sk-demo",
+		},
+	})
+
+	plain := selectionPopupANSIPattern.ReplaceAllString(result, "")
+	if !strings.Contains(plain, "Select Providers") {
+		t.Fatalf("expected provider header, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Select Models") {
+		t.Fatalf("expected unified header to include models label, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "API key") {
+		t.Fatalf("expected input label, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "→ Select Models") {
+		t.Fatalf("expected switch hint retained in input mode, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "↑/↓ select") {
+		t.Fatalf("expected navigation hint retained in input mode, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "Search") {
+		t.Fatalf("expected search hidden in input mode, got:\n%s", plain)
+	}
+	lines := strings.Split(plain, "\n")
+	if got := strings.TrimSpace(lines[len(lines)-1]); !strings.Contains(got, "↑/↓ select · enter choose · esc") {
+		t.Fatalf("expected footer on final line, got last line %q in:\n%s", got, plain)
 	}
 }

--- a/ui/panels/model_setup_test.go
+++ b/ui/panels/model_setup_test.go
@@ -181,9 +181,17 @@ func TestRenderModelBrowserPopupFocusProviderShowsOnlyProviderCardContent(t *tes
 		Providers: model.SelectionPopup{
 			Title: "Providers",
 			Options: []model.SelectionOption{
+				{ID: "__header__detected", Label: "Import", Header: true, Disabled: true},
+				{
+					ID:    "kimi-for-coding",
+					Label: "Kimi For Coding",
+				},
+				{ID: "__detail__kimi-for-coding__source", Label: "from Claude Code environment detected:", Disabled: true, DetailRow: true},
+				{ID: "__detail__kimi-for-coding__base_url", Label: "- ANTHROPIC_BASE_URL=https://api.kimi.com/coding/", Disabled: true, DetailRow: true},
+				{ID: "__detail__kimi-for-coding__api_key", Label: "- ANTHROPIC_API_KEY=sk-kimi-xxxx****xxxx", Disabled: true, DetailRow: true},
 				{ID: "openrouter", Label: "OpenRouter", RequiresInput: true},
 			},
-			Selected: 0,
+			Selected: 1,
 		},
 		Models: model.SelectionPopup{
 			Title: "Models",
@@ -199,6 +207,18 @@ func TestRenderModelBrowserPopupFocusProviderShowsOnlyProviderCardContent(t *tes
 	plain := selectionPopupANSIPattern.ReplaceAllString(result, "")
 	if !strings.Contains(plain, "Select Providers") {
 		t.Fatalf("expected provider header, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Import") {
+		t.Fatalf("expected import section header in provider list, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Kimi For Coding") {
+		t.Fatalf("expected import candidate in provider list, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "from Claude Code environment detected:") {
+		t.Fatalf("expected muted import hint in provider list, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "ANTHROPIC_BASE_URL=https://api.kimi.com/coding/") {
+		t.Fatalf("expected base url hint in provider list, got:\n%s", plain)
 	}
 	if !strings.Contains(plain, "Select Models") {
 		t.Fatalf("expected unified header to include models label, got:\n%s", plain)

--- a/ui/panels/styles.go
+++ b/ui/panels/styles.go
@@ -75,6 +75,7 @@ func InitStyles() {
 	setupErrorStyle = lipgloss.NewStyle().Foreground(t.Error)
 	setupLabelStyle = lipgloss.NewStyle().Foreground(t.TextPrimary)
 	setupBadgeStyle = lipgloss.NewStyle().Foreground(t.TextSecondary)
+	modelPickerDescStyle = lipgloss.NewStyle().Foreground(t.TextMuted)
 	setupBorderStyle = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.TextPrimary).

--- a/ui/panels/styles_test.go
+++ b/ui/panels/styles_test.go
@@ -1,0 +1,21 @@
+package panels
+
+import (
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/ui/theme"
+)
+
+func TestInitStyles_ModelPickerDescUsesMutedColor(t *testing.T) {
+	original := theme.Current
+	t.Cleanup(func() { theme.Current = original })
+
+	theme.Current = theme.Dark
+	InitStyles()
+
+	got := modelPickerDescStyle.GetForeground()
+	want := theme.Current.TextMuted
+	if got != want {
+		t.Fatalf("modelPickerDescStyle.GetForeground() = %v, want %v", got, want)
+	}
+}

--- a/ui/panels/train_workspace.go
+++ b/ui/panels/train_workspace.go
@@ -361,34 +361,54 @@ func RenderSelectionPopup(popup *model.SelectionPopup) string {
 	titleStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true).Align(lipgloss.Center)
 	normalStyle := lipgloss.NewStyle().Foreground(t.TextSecondary)
 	selectedStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true)
+	disabledStyle := lipgloss.NewStyle().Foreground(t.TextMuted)
 	hintStyle := lipgloss.NewStyle().Foreground(t.TextMuted).Italic(true)
 
-	// Find the widest option line to size the title
-	maxW := lipgloss.Width(popup.Title)
-	for _, opt := range popup.Options {
-		w := 2 + lipgloss.Width(opt.Label)
-		if opt.Desc != "" {
-			w += 1 + lipgloss.Width(opt.Desc)
-		}
-		if w > maxW {
-			maxW = w
-		}
-	}
+	filtered := filteredPopupOptions(popup.Options, popup.SearchQuery)
+	visible, start, end := popupOptionWindow(filtered, popup.Selected, popupVisibleOptions)
+	maxW := popupContentWidth
 
 	var lines []string
 	lines = append(lines, titleStyle.Width(maxW).Render(popup.Title))
 	lines = append(lines, "")
-	for i, opt := range popup.Options {
+	lines = append(lines, setupLabelStyle.Render("Search"))
+	lines = append(lines, renderSearchField(popup.SearchQuery, maxW))
+	lines = append(lines, "")
+	for _, row := range visible {
+		if row.Separator {
+			lines = append(lines, "")
+			continue
+		}
+		opt := row.Option
 		marker := "  "
 		style := normalStyle
-		if i == popup.Selected {
-			marker = "❯ "
-			style = selectedStyle
+		if opt.Disabled {
+			style = disabledStyle
 		}
-		lines = append(lines, marker+style.Render(opt.Label))
+		if row.Index == popup.Selected {
+			marker = "❯ "
+			if !opt.Disabled {
+				style = selectedStyle
+			}
+		}
+		label := opt.Label
+		if popup.ActionID == "model_picker" && opt.Desc != "" {
+			label += " " + modelPickerDescStyle.Render(opt.Desc)
+		} else if opt.Desc != "" {
+			label += " " + opt.Desc
+		}
+		lines = append(lines, renderWrappedPopupOption(label, marker, style, maxW))
 	}
 	lines = append(lines, "")
-	lines = append(lines, hintStyle.Render("↑/↓ select · enter confirm · esc cancel"))
+	if popup.ActionID == "model_picker" {
+		lines = append(lines, hintStyle.Render("Connect Provider ctrl+a"))
+	} else {
+		scrollHint := "↑/↓ select · enter confirm · esc cancel"
+		if start > 0 || end < len(filtered) {
+			scrollHint = "↑/↓ scroll · enter confirm · esc cancel"
+		}
+		lines = append(lines, hintStyle.Render(scrollHint))
+	}
 
 	content := strings.Join(lines, "\n")
 	return lipgloss.NewStyle().

--- a/ui/slash/commands.go
+++ b/ui/slash/commands.go
@@ -149,8 +149,8 @@ func Parse(input string) (string, []string) {
 func (r *Registry) registerDefaults() {
 	r.Register(Command{
 		Name:        "/model",
-		Description: "Open model setup or switch model",
-		Usage:       "/model [preset-id|provider:model|model]",
+		Description: "Open provider and model browser",
+		Usage:       "/model",
 	})
 
 	r.Register(Command{
@@ -225,7 +225,6 @@ func (r *Registry) registerDefaults() {
 		Description: "List issues",
 		Usage:       "/issues [status]",
 	})
-
 
 	r.Register(Command{
 		Name:        "/diagnose",

--- a/ui/topbar_test.go
+++ b/ui/topbar_test.go
@@ -29,10 +29,11 @@ func TestViewOmitsPersistentTopBarAndViewportFill(t *testing.T) {
 }
 
 func TestRenderBannerIncludesMetadata(t *testing.T) {
-	banner := RenderBanner("MindSpore CLI. test", "/tmp/project", "github.com/mindspore-lab/mindspore-cli", "demo-model", 4096)
+	banner := RenderBanner("MindSpore CLI. test", "/tmp/project", "github.com/mindspore-lab/mindspore-cli", "demo-model", 4096, "MindSpore CLI Free")
 	for _, want := range []string{
 		"MindSpore CLI",
 		"demo-model",
+		"MindSpore CLI Free",
 		"/tmp/project",
 	} {
 		if !strings.Contains(banner, want) {
@@ -41,5 +42,28 @@ func TestRenderBannerIncludesMetadata(t *testing.T) {
 	}
 	if !strings.Contains(banner, "model: demo-model") {
 		t.Fatalf("expected banner rows to stay left aligned, got:\n%s", banner)
+	}
+	if strings.Contains(banner, "provider:") {
+		t.Fatalf("expected provider to render inline with model instead of its own row, got:\n%s", banner)
+	}
+}
+
+func TestModelUpdateSetsProviderDisplay(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type:     model.ModelUpdate,
+		Message:  "Kimi K2.5",
+		Provider: "MindSpore CLI Free",
+		CtxMax:   262144,
+	})
+	app = next.(App)
+
+	if got, want := app.state.Model.Name, "Kimi K2.5"; got != want {
+		t.Fatalf("state.Model.Name = %q, want %q", got, want)
+	}
+	if got, want := app.state.Model.Provider, "MindSpore CLI Free"; got != want {
+		t.Fatalf("state.Model.Provider = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Add a guided provider and model selection workflow to `/model`, including provider browsing, model browsing, setup, and restore.
- Support importing provider credentials from environment-backed local configs to reduce manual key entry during onboarding.
- Keep provider/model state aligned with recent upstream UI event and tool-output updates after rebasing onto the latest `main`.

## Release Highlights
- Guided setup flow for choosing a provider, browsing its available models, and applying the selection in-app.
- Environment-backed provider import suggestions that help users bring existing local credentials into the app with less friction.
- Persistent provider state restoration so previously selected providers and models can be resumed more reliably.
- UI updates across the model setup popup, browser panels, top bar, and hint bar to support the new workflow end to end.

## Test Plan
- [x] `go test ./internal/app`
- [x] `go test ./ui/...`