### PR TITLE
fix(preflight): support @file expansion in /preflight input

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -88,7 +88,12 @@ func (a *Application) handleCommand(input string) {
 		}
 		a.cmdIntegrate(expanded)
 	case "/preflight":
-		a.cmdPreflight(cmd.Remainder)
+		expanded, err := a.expandInputText(cmd.Remainder)
+		if err != nil {
+			a.emitInputExpansionError(err)
+			return
+		}
+		a.cmdPreflight(expanded)
 	case "/now":
 		a.cmdNow()
 	case "/skill":


### PR DESCRIPTION
## Summary

- `/preflight` was the only diagnostic command that did not expand `@file` references before passing input to the agent
- Consistent with `/fix`, `/diagnose`, `/migrate`, `/integrate` which all call `expandInputText` or `expandIssueCommandInput`

## Example

```
/preflight @train.py
```

Now resolves the file path before handing off to `readiness-agent`.

## Test plan

- [x] Run `/preflight @<some-file>` and verify the file path is expanded in the agent prompt
- [x] Run `/preflight` with plain text — behavior unchanged

<img width="590" height="365" alt="image" src="https://github.com/user-attachments/assets/558dba8d-971c-45e6-a94a-1b9d8e633097" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)