### PR TITLE
fix(preflight): support @file expansion in /preflight input

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -88,7 +88,12 @@ func (a *Application) handleCommand(input string) {
 		}
 		a.cmdIntegrate(expanded)
 	case "/preflight":
-		a.cmdPreflight(cmd.Remainder)
+		expanded, err := a.expandInputText(cmd.Remainder)
+		if err != nil {
+			a.emitInputExpansionError(err)
+			return
+		}
+		a.cmdPreflight(expanded)
 	case "/now":
 		a.cmdNow()
 	case "/skill":


### PR DESCRIPTION
/preflight was the only diagnostic command that did not expand @file references. Users can now pass @train.py or similar file references and have them resolved before the prompt reaches the agent.