### PR TITLE
feat(tools): improve guidance and readonly exploration

### DIFF
--- a/agent/loop/engine.go
+++ b/agent/loop/engine.go
@@ -442,8 +442,8 @@ func (ex *executor) executeToolCall(ctx context.Context, tc llm.ToolCall) error 
 		return err
 	}
 	if !granted {
-		errMsg := fmt.Sprintf("Permission denied for tool: %s", toolName)
-		notice, err := ex.addToolResultWithFallback(tc.ID, errMsg)
+		toolResultMsg := "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and ask the user how to proceed."
+		notice, err := ex.addToolResultWithFallback(tc.ID, toolResultMsg)
 		if err != nil {
 			return err
 		}
@@ -451,7 +451,10 @@ func (ex *executor) executeToolCall(ctx context.Context, tc llm.ToolCall) error 
 			return err
 		}
 		ex.emitContextCompactionNotice(notice)
-		ex.addEvent(NewEvent(EventToolError, errMsg))
+		errEv := NewEvent(EventToolError, "rejected by user")
+		errEv.ToolName = toolName
+		errEv.ToolCallID = tc.ID
+		ex.addEvent(errEv)
 		return nil
 	}
 
@@ -574,6 +577,7 @@ func interruptedToolResultContent(partialOutput string) string {
 var toolEventMap = map[string]string{
 	"read":       EventToolRead,
 	"grep":       EventToolGrep,
+	"list_dir":   EventToolListDir,
 	"glob":       EventToolGlob,
 	"edit":       EventToolEdit,
 	"write":      EventToolWrite,
@@ -785,6 +789,8 @@ func describeToolCall(toolName string, raw json.RawMessage) string {
 		return getString("command")
 	case "read", "edit", "write":
 		return getString("path", "file_path")
+	case "list_dir":
+		return getString("path")
 	case "grep":
 		pattern := getString("pattern")
 		path := getString("path")
@@ -825,6 +831,7 @@ You help ML engineers and AI infra developers get training jobs running, diagnos
 
 You have access to the following tools:
 - read: Read file contents
+- list_dir: List directory contents and structure
 - write: Create or overwrite files
 - edit: Edit files by replacing text
 - grep: Search for patterns in files
@@ -836,12 +843,13 @@ Guidelines:
 1. Use tools to gather information before making changes
 2. Always read files before editing them
 3. Make minimal, focused changes
-4. Use grep and glob to explore the codebase
+4. Prefer dedicated tools over shell whenever a dedicated tool can do the job
 5. Run tests with shell to verify changes
-6. Before any write call, verify arguments contain BOTH "path" and "content"; if either is missing, do not call write yet.
-7. Never call write with empty JSON arguments ({}).
-8. When a user describes a training problem (failure, accuracy, performance), load the appropriate diagnosis skill.
-9. When a user asks to migrate or port a model, load migrate-agent.
+6. If the user rejects a tool permission request, do not try to bypass that denial with another tool or shell pattern. Stop and ask the user how to proceed.
+7. Before any write call, verify arguments contain BOTH "path" and "content"; if either is missing, do not call write yet.
+8. Never call write with empty JSON arguments ({}).
+9. When a user describes a training problem (failure, accuracy, performance), load the appropriate diagnosis skill.
+10. When a user asks to migrate or port a model, load migrate-agent.
 
 IMPORTANT: When you have gathered enough information to answer the user's question, you MUST provide your final answer directly WITHOUT using any more tools. Do not keep calling tools indefinitely - provide a clear, concise response once you have the information needed.
 

--- a/agent/loop/engine_persistence_test.go
+++ b/agent/loop/engine_persistence_test.go
@@ -10,6 +10,7 @@ import (
 
 	ctxmanager "github.com/mindspore-lab/mindspore-cli/agent/context"
 	"github.com/mindspore-lab/mindspore-cli/integrations/llm"
+	"github.com/mindspore-lab/mindspore-cli/permission"
 	"github.com/mindspore-lab/mindspore-cli/tools"
 )
 
@@ -128,6 +129,36 @@ func (t cancelAwareStreamingStubTool) ExecuteStream(ctx context.Context, raw jso
 	<-ctx.Done()
 	return tools.StringResultWithSummary(t.content, "interrupted"), nil
 }
+
+type rejectingPermissionService struct{}
+
+func (rejectingPermissionService) Request(context.Context, string, string, string) (bool, error) {
+	return false, nil
+}
+
+func (rejectingPermissionService) Check(string, string) permission.PermissionLevel {
+	return permission.PermissionAsk
+}
+
+func (rejectingPermissionService) CheckCommand(string) permission.PermissionLevel {
+	return permission.PermissionAsk
+}
+
+func (rejectingPermissionService) CheckPath(string) permission.PermissionLevel {
+	return permission.PermissionAsk
+}
+
+func (rejectingPermissionService) Grant(string, permission.PermissionLevel) {}
+
+func (rejectingPermissionService) GrantCommand(string, permission.PermissionLevel) {}
+
+func (rejectingPermissionService) GrantPath(string, permission.PermissionLevel) {}
+
+func (rejectingPermissionService) Revoke(string) {}
+
+func (rejectingPermissionService) RevokeCommand(string) {}
+
+func (rejectingPermissionService) RevokePath(string) {}
 
 func newPersistenceRecorder(log *[]string) *TrajectoryRecorder {
 	last := ""
@@ -265,6 +296,83 @@ func TestRunPersistsToolResultBeforeToolRender(t *testing.T) {
 
 	requireOrder(t, log, "tool_call:read", "snapshot:tool_call:read", "ui:ToolCallStart")
 	requireOrder(t, log, "tool_result:read", "snapshot:tool_result:read", "ui:ToolRead")
+}
+
+func TestRunUsesClaudeStyleRejectMessageForDeniedWriteTool(t *testing.T) {
+	args, err := json.Marshal(map[string]string{
+		"path":    "note.md",
+		"content": "# note\n",
+	})
+	if err != nil {
+		t.Fatalf("marshal tool args: %v", err)
+	}
+
+	provider := &scriptedStreamProvider{
+		responses: []*llm.CompletionResponse{
+			{
+				ToolCalls: []llm.ToolCall{{
+					ID:   "call-write-1",
+					Type: "function",
+					Function: llm.ToolCallFunc{
+						Name:      "write",
+						Arguments: args,
+					},
+				}},
+				FinishReason: llm.FinishToolCalls,
+			},
+			{
+				Content:      "waiting for user direction",
+				FinishReason: llm.FinishStop,
+			},
+		},
+	}
+
+	registry := tools.NewRegistry()
+	registry.MustRegister(stubTool{name: "write", content: "should not execute", summary: "unused"})
+
+	engine := NewEngine(EngineConfig{
+		MaxIterations: 2,
+		ContextWindow: 4096,
+	}, provider, registry)
+	engine.SetPermissionService(rejectingPermissionService{})
+
+	var toolResult string
+	engine.SetTrajectoryRecorder(&TrajectoryRecorder{
+		RecordUserInput:  func(string) error { return nil },
+		RecordAssistant:  func(string) error { return nil },
+		RecordToolCall:   func(llm.ToolCall) error { return nil },
+		RecordToolResult: func(_ llm.ToolCall, content string) error { toolResult = content; return nil },
+		PersistSnapshot:  func() error { return nil },
+	})
+
+	events, err := engine.Run(Task{
+		ID:          "write-rejected",
+		Description: "write a markdown note",
+	})
+	if err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
+
+	if !strings.Contains(toolResult, "The user doesn't want to proceed with this tool use") {
+		t.Fatalf("tool result missing reject guidance, got %q", toolResult)
+	}
+	if !strings.Contains(toolResult, "STOP what you are doing and ask the user how to proceed") {
+		t.Fatalf("tool result missing ask-user guidance, got %q", toolResult)
+	}
+
+	var sawWriteReject bool
+	for _, ev := range events {
+		if ev.Type != EventToolError {
+			continue
+		}
+		if ev.ToolName == "write" && strings.Contains(ev.Message, "rejected by user") {
+			sawWriteReject = true
+			break
+		}
+	}
+	if !sawWriteReject {
+		t.Fatalf("expected ToolError event for denied write, got %#v", events)
+	}
 }
 
 func TestRunShellStreamingEmitsLiveCommandEvents(t *testing.T) {

--- a/agent/loop/engine_prompt_test.go
+++ b/agent/loop/engine_prompt_test.go
@@ -14,4 +14,27 @@ func TestDefaultSystemPromptIncludesWriteArgumentValidationRules(t *testing.T) {
 	if !strings.Contains(prompt, "Never call write with empty JSON arguments ({})") {
 		t.Fatalf("DefaultSystemPrompt() missing empty-args guard: %q", prompt)
 	}
+	if !strings.Contains(prompt, "Prefer dedicated tools over shell whenever a dedicated tool can do the job") {
+		t.Fatalf("DefaultSystemPrompt() missing dedicated-tool preference: %q", prompt)
+	}
+	if !strings.Contains(prompt, "If the user rejects a tool permission request, do not try to bypass that denial with another tool or shell pattern") {
+		t.Fatalf("DefaultSystemPrompt() missing rejection bypass guardrail: %q", prompt)
+	}
+	if !strings.Contains(prompt, "ask the user how to proceed") {
+		t.Fatalf("DefaultSystemPrompt() missing ask-user follow-up guidance after rejection: %q", prompt)
+	}
+
+	for _, phrase := range []string{
+		"To read files use read instead of cat, head, tail, or sed",
+		"To edit files use edit instead of sed or awk",
+		"To create files use write instead of cat with heredoc or echo redirection",
+		"To search for files use glob instead of find or ls",
+		"To search the content of files, use grep instead of grep or rg",
+		"Reserve using the shell exclusively for system commands and terminal operations that require shell execution",
+		"Do not use shell redirection, heredoc, tee, or similar shell patterns to create or edit files",
+	} {
+		if strings.Contains(prompt, phrase) {
+			t.Fatalf("DefaultSystemPrompt() should keep tool-selection guidance in tool descriptions, found %q in prompt: %q", phrase, prompt)
+		}
+	}
 }

--- a/agent/loop/types.go
+++ b/agent/loop/types.go
@@ -68,6 +68,7 @@ const (
 	EventTokenUpdate         = "TokenUpdate"
 	EventToolRead            = "ToolRead"
 	EventToolGrep            = "ToolGrep"
+	EventToolListDir         = "ToolListDir"
 	EventToolGlob            = "ToolGlob"
 	EventToolEdit            = "ToolEdit"
 	EventToolWrite           = "ToolWrite"

--- a/docs/design/claude-code-technical-route.md
+++ b/docs/design/claude-code-technical-route.md
@@ -1,0 +1,151 @@
+# Claude Code Technical Route (Source-Validated)
+
+## Purpose
+
+This note records the Claude Code terminal UI architecture after comparing prior behavior-based guesses with source under `claude-code-full/package/src`.
+
+It replaces the earlier inference-only model.
+
+## What Was Confirmed
+
+### 1. `ctrl+o` toggles transcript mode, not a tool-only viewer
+
+Claude Code has an explicit screen state:
+
+```text
+'prompt' | 'transcript'
+```
+
+`ctrl+o` flips between those two screens. This is implemented in:
+
+- `src/hooks/useGlobalKeybindings.tsx`
+- `src/screens/REPL.tsx`
+
+This means the earlier description of `ctrl+o` as "open historical tool output" was too narrow. Tool results are included, but the feature is a full transcript screen.
+
+### 2. Claude Code keeps structured message history in app state
+
+Transcript mode renders from in-memory message/tool state rather than from terminal scrollback.
+
+Evidence:
+
+- `src/screens/REPL.tsx` builds `transcriptMessagesElement` from `transcriptMessages`, `tools`, `commands`, `transcriptStreamingToolUses`
+- `src/components/Messages.tsx` applies transcript-mode-specific filtering/grouping/collapse rules over normalized message state
+
+This part of the earlier document was correct in spirit: old tool results are recoverable because the app retains structured history.
+
+### 3. Transcript mode is a full-app rendering mode
+
+Transcript mode is not just "expand one tool result". It changes how the whole conversation is rendered.
+
+Evidence:
+
+- `src/components/Messages.tsx`
+- `src/components/MessageRow.tsx`
+- `src/components/CompactSummary.tsx`
+- `src/components/messages/*`
+
+Examples of transcript-specific behavior:
+
+- transcript mode can bypass some normal filtering
+- transcript mode can hide past thinking blocks except the latest one
+- transcript mode can show extra metadata such as timestamps/models
+- transcript mode has its own footer/search/scroll behavior
+
+### 4. Claude Code does have a real alternate-screen fullscreen path
+
+Claude Code includes an `AlternateScreen` component that explicitly enters DEC 1049 alt screen and exits it on unmount.
+
+Evidence:
+
+- `src/ink/components/AlternateScreen.tsx`
+- `src/utils/fullscreen.ts`
+
+Key facts:
+
+- it writes `ENTER_ALT_SCREEN` / `EXIT_ALT_SCREEN`
+- it optionally enables mouse tracking
+- it constrains rendering to terminal height
+- comments explicitly say alt screen has no native scrollback
+
+### 5. Fullscreen/alt-screen is environment-gated, not always on
+
+Claude Code does not always run in fullscreen for every user.
+
+From `src/utils/fullscreen.ts` and `src/components/FullscreenLayout.tsx`:
+
+- fullscreen defaults on for internal `ant` users
+- fullscreen defaults off for external users
+- env vars can force opt-in/opt-out
+- tmux `-CC` disables fullscreen automatically
+
+So whether a user can still access pre-`claude` shell scrollback depends on which branch they are on.
+
+### 6. There are two transcript-mode branches
+
+Transcript mode itself has two rendering strategies:
+
+1. Fullscreen + virtual scroll:
+   - wrapped in `AlternateScreen`
+   - uses `FullscreenLayout`
+   - app owns scrolling
+   - no native terminal scrollback for transcript content
+
+2. Legacy non-fullscreen dump path:
+   - no alt screen
+   - dumps transcript into terminal scrollback
+   - keeps a render cap plus `Ctrl+E`
+
+This split is documented directly in comments in `src/screens/REPL.tsx`.
+
+## What The Earlier Version Got Right
+
+- Claude Code is not a pure "all history only lives in terminal scrollback" app.
+- Claude Code retains structured history in memory and can reconstruct older tool results.
+- There is a hybrid architecture rather than one single rendering model.
+- The loss of pre-app shell history after entering the fullscreen transcript path is consistent with a buffer switch.
+
+## What Needed Correction
+
+- `ctrl+o` is not a dedicated tool-output viewer. It is a prompt/transcript screen toggle.
+- The architecture is not simply "normal inline mode" plus "tool output view mode".
+- Alt-screen is real in the codebase, but it is conditional, not universal.
+- Prompt mode can also run inside `AlternateScreen` when fullscreen is enabled; transcript mode is not the only alt-screen consumer.
+- Claude Code also supports a non-fullscreen transcript fallback, so user-observed behavior depends on runtime environment.
+
+## Working Model
+
+The best source-backed model is:
+
+```text
+REPL screen state
+  - prompt
+  - transcript
+
+rendering strategy
+  - fullscreen enabled:
+      use AlternateScreen + FullscreenLayout + app-managed scrolling
+  - fullscreen disabled:
+      stay on main terminal buffer and rely more on terminal scrollback
+
+ctrl+o
+  - toggles prompt <-> transcript
+  - transcript renders from structured message/tool state
+  - not limited to tool output
+```
+
+## Practical Takeaways For mscli
+
+If you want to learn from Claude Code, the important ideas are:
+
+1. Separate "screen mode" from "message expansion state".
+2. Keep a structured conversation/tool model in memory; do not depend on terminal scrollback as your source of truth.
+3. Support two rendering regimes:
+   - main-buffer / scrollback-friendly
+   - fullscreen / alt-screen / app-scrolled
+4. Treat transcript as a first-class screen, not just a temporary viewer for one block.
+5. Make transcript-mode rendering rules explicit instead of trying to mutate already-printed terminal history in place.
+
+## Status
+
+Current status: **source-validated against local Claude Code source**

--- a/docs/mscli-tool-hit-rate-readonly-plan.md
+++ b/docs/mscli-tool-hit-rate-readonly-plan.md
@@ -1,0 +1,322 @@
+# Tool Hit Rate And Read-Only Exploration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve first-try tool selection and parameter correctness for filesystem tasks, add a first-class read-only directory exploration tool, and stop shell-based file-writing fallbacks from bypassing `write`/`edit` permissions.
+
+**Architecture:** Keep the current lightweight `Tool` interface and centralized permission service, but make three focused improvements: move tool-choice guidance into tool descriptions, add a dedicated `list_dir` read-only primitive, and classify shell commands by intent so read-only exploration can be allowed without opening a write bypass. Avoid broad runtime rewrites in this cycle; only add seams that directly improve these two target workflows and the related shell-write guardrail.
+
+**Tech Stack:** Go, `agent/loop`, `tools/fs`, `tools/shell`, `permission`, Bubble Tea UI tests, current `llm.Provider` capture tests.
+
+---
+
+## Scope
+
+This plan is intentionally narrower than the broader tool-system refactor notes in `docs/mscli-tool-system-analysis.md` and `docs/mscli-tool-system-refactor-plan.md`.
+
+In scope for this cycle:
+
+- tool prompting and parameter-contract cleanup for existing filesystem tools
+- add `list_dir` as the default directory-structure exploration primitive
+- fix `glob("**/train.py")` so it also matches `./train.py`
+- reduce or remove permission prompts for read-only shell exploration commands
+- block shell-based file creation/editing fallbacks after `write`/`edit` denial
+- add deterministic and agent-level E2E coverage for the three known bad cases
+
+Explicitly out of scope for this cycle:
+
+- `multi_edit`
+- `web_fetch`
+- MCP/external tool adaptation
+- full schema-system rewrite
+- large runtime extraction or orchestration refactor
+
+## Success Criteria
+
+- The request “当前目录是否有 `train.py` 文件” succeeds in one tool call and returns `./train.py` when present.
+- The request “为我总结当前目录的代码结构” prefers `list_dir` over `shell(ls/find/tree)` in agent-level tests.
+- Read-only shell exploration commands no longer interrupt the user with avoidable permission prompts in the directory-summary flow.
+- After the user denies `write` or `edit`, the agent does not continue by attempting equivalent shell writes such as heredoc redirection, `tee`, or `echo >`.
+- Tool descriptions and system prompt no longer conflict about tool boundaries.
+
+## Design Decisions
+
+### 1. `list_dir` is the new primary tool for directory structure questions
+
+- Use `list_dir` for “what is in this directory”, “summarize the structure”, and first-pass tree inspection.
+- Keep `glob` for file-name/path-pattern lookup, not general directory summarization.
+- Keep `grep` for content search only.
+
+### 2. `glob` semantics must treat `**/name` as “zero or more directories”
+
+- `**/train.py` must match both `train.py` and `subdir/train.py`.
+- This is a correctness bug, not just a prompting issue.
+
+### 3. Shell permissions must distinguish read-only exploration from file authoring
+
+- Read-only exploration: `ls`, `find`, `tree`, `pwd`, `stat`, `rg --files` and similar commands that do not modify files.
+- File authoring via shell: output redirection, heredoc-to-file, `tee`, `sed -i`, `perl -pi`, and similar commands that create or modify files.
+- Read-only shell exploration can be separately allowlisted without letting shell impersonate `write` or `edit`.
+
+### 4. `write` and `edit` remain the exclusive file-authoring tools
+
+- If file creation or modification is required, the agent must use `write` or `edit`.
+- If those tools are denied, the agent must stop and report the restriction instead of routing through shell.
+
+## File Map
+
+### Existing files to modify
+
+- `agent/loop/engine.go`
+- `agent/loop/engine_prompt_test.go`
+- `internal/app/wire.go`
+- `tools/fs/glob.go`
+- `tools/fs/grep.go`
+- `tools/fs/read.go`
+- `tools/fs/edit.go`
+- `tools/fs/write.go`
+- `tools/shell/shell.go`
+- `permission/service.go`
+- `permission/rules.go`
+- `permission/service_test.go`
+- `permission/rules_test.go`
+
+### New files likely to add
+
+- `tools/fs/list_dir.go`
+- `tools/fs/list_dir_test.go`
+- `agent/loop/engine_tool_selection_test.go`
+- `internal/app/tool_system_e2e_test.go`
+
+## Task 1: Tighten Tool Guidance And Contract Signals
+
+**Files:**
+- Modify: `agent/loop/engine.go`
+- Modify: `agent/loop/engine_prompt_test.go`
+- Modify: `tools/fs/read.go`
+- Modify: `tools/fs/glob.go`
+- Modify: `tools/fs/grep.go`
+- Modify: `tools/fs/edit.go`
+- Modify: `tools/fs/write.go`
+- Modify: `tools/shell/shell.go`
+
+- [ ] **Step 1: Rewrite tool descriptions with explicit decision boundaries**
+
+Update each tool description so the model can answer:
+
+- what the tool does
+- when to use it
+- when not to use it
+- which sibling tool is preferred in nearby cases
+- which arguments must be exact
+
+Required message changes:
+
+- `glob`: use for file-path/name pattern lookup, not for summarizing a directory tree
+- `grep`: use for content search, not file discovery
+- `read`: use after the exact file path is known
+- `shell`: reserve for tests, build, git, process execution, or cases with no dedicated tool
+- `write` / `edit`: file-authoring only; do not simulate them with shell redirection or heredoc
+
+- [ ] **Step 2: Shrink the global system prompt to high-level policy**
+
+Revise `DefaultSystemPrompt()` so it keeps only:
+
+- gather information before editing
+- read before editing
+- prefer dedicated tools over shell
+- `write` requires exact `path` and `content`
+- shell must not be used to create or edit files when dedicated tools exist
+
+Move detailed tool-by-tool routing guidance into tool descriptions.
+
+- [ ] **Step 3: Clarify temporary compatibility for `write` arguments**
+
+Keep runtime compatibility for legacy aliases during this cycle if needed, but make the model-visible contract strict:
+
+- schema advertises only `path` and `content`
+- error text says aliases are compatibility-only, not preferred
+- new tests assert prompt and descriptions consistently reinforce the canonical fields
+
+- [ ] **Step 4: Add prompt-contract regression tests**
+
+Add or extend tests in `agent/loop/engine_prompt_test.go` to assert the prompt includes:
+
+- prefer dedicated tools over shell
+- do not use shell heredoc/redirection to create files
+- `write` requires `path` and `content`
+
+## Task 2: Add `list_dir` And Fix `glob` Root-Match Semantics
+
+**Files:**
+- Create: `tools/fs/list_dir.go`
+- Create: `tools/fs/list_dir_test.go`
+- Modify: `internal/app/wire.go`
+- Modify: `agent/loop/engine.go`
+- Modify: `tools/fs/glob.go`
+- Modify: `tools/fs/ignore_test.go` or add a dedicated `glob` regression test file
+
+- [ ] **Step 1: Implement `list_dir`**
+
+Suggested tool contract:
+
+```go
+{
+  "path": string,
+  "depth": integer,
+  "include_hidden": boolean,
+  "offset": integer,
+  "limit": integer
+}
+```
+
+Behavior requirements:
+
+- workspace-relative `path`
+- deterministic ordering
+- clear distinction between files and directories
+- bounded output with paging
+- concise summary including total visible entries
+
+- [ ] **Step 2: Register and surface `list_dir` cleanly**
+
+Wire the tool in `internal/app/wire.go`, and update tool call display logic in `agent/loop/engine.go` so transcripts show meaningful summaries for `list_dir`.
+
+If UI needs a dedicated event type, add it only if necessary; otherwise reuse the current generic tool event path to keep the diff small.
+
+- [ ] **Step 3: Fix `glob("**/train.py")` to match root files**
+
+Update `tools/fs/glob.go` so `**/foo` means zero-or-more directories, not one-or-more. Add a regression test that proves:
+
+- `train.py` is returned for `**/train.py`
+- nested matches are also returned
+
+- [ ] **Step 4: Add deterministic tool tests**
+
+Add tests covering:
+
+- `list_dir` basic listing
+- `list_dir` depth limiting
+- `list_dir` hidden-file filtering
+- `glob` root-match regression for `**/train.py`
+
+## Task 3: Classify Shell Commands By Intent And Block Shell Write Fallbacks
+
+**Files:**
+- Modify: `permission/service.go`
+- Modify: `permission/rules.go`
+- Modify: `tools/shell/shell.go`
+- Modify: `permission/service_test.go`
+- Modify: `permission/rules_test.go`
+
+- [ ] **Step 1: Introduce shell intent classification helpers**
+
+Add focused helpers that classify shell commands into at least:
+
+- read-only exploration
+- shell file authoring
+- general execution
+
+The first version only needs to cover commands that affect the known bad cases.
+
+- [ ] **Step 2: Allow read-only exploration without broadening shell writes**
+
+Update permission evaluation so read-only exploration commands can be auto-allowed or matched by read-only-style rules without turning on generic `shell(*)`.
+
+Examples to cover:
+
+- `ls`
+- `find`
+- `tree`
+- `pwd`
+- `stat`
+- `rg --files`
+
+- [ ] **Step 3: Treat shell authoring as equivalent to file write/edit**
+
+Commands with these patterns must not bypass denied file-authoring permissions:
+
+- `>`, `>>`
+- `tee`
+- `cat <<EOF > file`
+- `echo ... > file`
+- `sed -i`
+- `perl -pi`
+
+If `write`/`edit` is denied, the result should be deny-or-stop, not fallback shell execution.
+
+- [ ] **Step 4: Add permission regression tests**
+
+Add tests proving:
+
+- read-only shell exploration is recognized and does not require the same approval path as a write
+- shell commands with file-writing semantics are not treated as read-only
+- heredoc and redirection patterns are classified as authoring
+
+## Task 4: Lock The Behavior With Agent-Level E2E Tests
+
+**Files:**
+- Create: `agent/loop/engine_tool_selection_test.go`
+- Create: `internal/app/tool_system_e2e_test.go`
+- Modify: provider capture test helpers under `internal/app/wire_provider_test.go` only if needed
+
+- [ ] **Step 1: Add E2E for bad case 1**
+
+Fixture:
+
+- workspace root contains `train.py`
+- nested directory may also contain another `train.py`
+
+Expected behavior:
+
+- the agent can answer whether `train.py` exists from the current directory
+- the first tool used is `glob` or `list_dir`
+- `glob("**/train.py")` returns the root file on the first try
+
+- [ ] **Step 2: Add E2E for bad case 2**
+
+Prompt:
+
+- “为我总结当前目录的代码结构”
+
+Expected behavior:
+
+- the first tool used is `list_dir`
+- the flow does not rely on `shell(ls/find/tree)` as the primary path
+- if shell is used secondarily, read-only exploration does not interrupt the user with avoidable approval prompts
+
+- [ ] **Step 3: Add E2E for bad case 3**
+
+Prompt:
+
+- “帮我写一个 markdown 文档”
+
+Harness behavior:
+
+- deny `write` permission
+
+Expected behavior:
+
+- the agent does not attempt shell-based writes such as heredoc redirection
+- the flow stops with a permission-aware explanation or explicit request for file-authoring permission
+
+- [ ] **Step 4: Run narrow verification first**
+
+Run the smallest relevant Go commands before any broader sweep:
+
+```bash
+go test ./tools/fs ./permission ./agent/loop ./internal/app
+```
+
+If those pass and the touched test set is narrow enough, stop there. Only widen if a broader package interaction needs proof.
+
+## Implementation Order
+
+1. Task 1: tighten tool guidance first
+2. Task 2: add `list_dir` and fix `glob`
+3. Task 3: add shell intent classification and write-bypass guardrails
+4. Task 4: add the three E2E tests and run narrow verification
+
+## Review Notes
+
+This plan intentionally defers bigger architectural moves. The only architectural change justified in this cycle is introducing a small shell-intent seam inside the existing permission pipeline. That gives immediate benefit to the two target workflows and the write-bypass bad case without forcing a full runtime redesign.

--- a/docs/mscli-tool-system-analysis.md
+++ b/docs/mscli-tool-system-analysis.md
@@ -1,0 +1,727 @@
+# ms-cli Tool System Analysis
+
+## Scope
+
+This document analyzes the current `ms-cli` tool system from three angles:
+
+1. Current-state design of the tool system
+2. Key differences versus Claude Code
+3. Concrete improvements `ms-cli` can borrow from Claude Code
+
+The document is written in phases so the analysis can be refined incrementally.
+
+## Phase 1: Current-State Analysis
+
+### 1. Architectural Position
+
+`ms-cli` currently places the tool system directly inside the main agent loop. The overall path is:
+
+`Application wiring -> tool registry -> LLM tool schema export -> model tool call -> permission check -> tool execution -> tool result appended back into context`
+
+Relevant files:
+
+- `internal/app/wire.go`
+- `tools/types.go`
+- `tools/registry.go`
+- `agent/loop/engine.go`
+- `permission/service.go`
+
+This is a relatively direct architecture. There is no separate tool runtime layer, no separate tool exposure layer, and no separate tool orchestration layer.
+
+### 2. Tool Object Model
+
+The core abstraction is intentionally thin:
+
+```go
+type Tool interface {
+    Name() string
+    Description() string
+    Schema() llm.ToolSchema
+    Execute(ctx context.Context, params json.RawMessage) (*Result, error)
+}
+```
+
+Optional streaming support is added through a second interface:
+
+```go
+type StreamingTool interface {
+    ExecuteStream(ctx context.Context, params json.RawMessage, emit func(StreamEvent)) (*Result, error)
+}
+```
+
+Observations:
+
+- The abstraction is easy to understand and easy to implement.
+- Model-facing metadata and runtime behavior are partially unified, but only at a minimal level.
+- The interface does not encode permission hints, read-only/destructive classification, concurrency safety, input validation stages, result mapping policy, or UI rendering behavior.
+- As a result, responsibilities that Claude Code keeps inside a richer `Tool` contract are distributed across the engine, permission service, and individual tools.
+
+### 3. Tool Registry and Tool Pool
+
+`tools.Registry` is a simple ordered registry:
+
+- `Register`
+- `Get`
+- `List`
+- `Names`
+- `ToLLMTools`
+
+Current behavior:
+
+- Tools are statically registered during application wiring.
+- The exported tool set is effectively the full registry on every LLM request.
+- Tool order is preserved by registration order.
+- There is no request-scoped filtering, no delayed exposure, and no dynamic tool discovery step.
+
+Current built-in set assembled in `internal/app/wire.go`:
+
+- `read`
+- `write`
+- `edit`
+- `grep`
+- `glob`
+- `shell`
+- `load_skill`
+
+This is simple and stable, but it also means the system does not yet distinguish:
+
+- available tools vs exposed tools
+- built-in tools vs external tools
+- lightweight tools vs heavyweight tools
+- always-load tools vs defer-load tools
+
+### 4. Tool Schema Design
+
+`ms-cli` uses a small custom schema model in `integrations/llm/provider.go`:
+
+```go
+type ToolSchema struct {
+    Type       string
+    Properties map[string]Property
+    Required   []string
+}
+
+type Property struct {
+    Type        string
+    Description string
+    Enum        []string
+}
+```
+
+This is enough for simple object-shaped tools, but it is significantly less expressive than full JSON Schema.
+
+Current strengths:
+
+- easy to serialize
+- easy to reason about
+- provider-independent
+
+Current limits:
+
+- no nested object schema modeling
+- no array item schema
+- no unions / `oneOf`
+- no numeric or string constraints
+- no schema-level default/nullable/pattern controls
+- no separate protocol fields like `strict` or `defer_loading` at the tool-definition level
+
+There is also an important contract gap between schema and runtime behavior:
+
+- `write` advertises only `path` and `content`
+- runtime still accepts `file_path` and `filename` as fallback aliases
+
+That means the true accepted input contract is broader than the model-visible schema.
+
+### 5. Execution Flow
+
+The execution path in `agent/loop/engine.go` is:
+
+1. Build request with `ctxManager.GetMessages()` and `tools.ToLLMTools()`
+2. Send request to provider
+3. Persist assistant message and tool calls into context
+4. For each returned tool call, execute serially
+5. Append tool output as a tool message
+6. Continue the loop
+
+Important properties of the current design:
+
+- tool calls are executed serially
+- there is no tool batching or concurrency scheduler
+- there is no separate pre-hook / post-hook pipeline
+- there is no standardized `validateInput` stage before execution
+- tool result mapping is lightweight and mostly string-based
+
+The runtime is therefore straightforward, but thin:
+
+- tool lookup happens in the engine
+- permission checking happens in the engine
+- input parsing is delegated to each tool
+- semantic validation is delegated to each tool
+- output formatting is delegated to each tool
+
+### 6. Permission Design
+
+`ms-cli` already has a meaningful permission subsystem, and this is one of the stronger parts of the design.
+
+The decision chain in `permission/service.go` is broadly:
+
+1. check tool-level permission
+2. for `shell`, also check command-level permission
+3. check path-level permission
+4. if result is `ask`, optionally invoke interactive UI
+5. remember session or persisted decisions when applicable
+
+Notable strengths:
+
+- explicit levels: `deny`, `ask`, `allow_once`, `allow_session`, `allow_always`
+- shell command policy and path policy are both supported
+- rules support Claude-like forms such as `Bash(...)`, `Read(...)`, `Edit(...)`
+- dangerous shell commands are recognized separately
+- edit/write can be granted together as a session-level convenience
+
+Important limits versus Claude Code:
+
+- permission logic is centralized, but tools do not provide their own permission metadata or tool-specific `checkPermissions`
+- the permission pipeline is not integrated with hooks, classifiers, or sandbox-aware execution policy
+- permission and tool schema are mostly separate worlds
+- non-shell tools do not contribute rich action metadata beyond path extraction in the engine
+
+### 7. Tool Result Model
+
+The tool result shape is:
+
+```go
+type Result struct {
+    Content string
+    Summary string
+    Meta    map[string]any
+    Error   error
+}
+```
+
+This is a pragmatic format, but it still collapses most tool results into free-form text.
+
+Current implications:
+
+- the agent loop can easily append results back into context
+- the UI can render basic summaries
+- some tools can attach metadata, such as edit/write diff meta
+
+But compared with Claude Code:
+
+- result typing is much weaker
+- there is no dedicated result-to-transcript mapping layer
+- large-output persistence/truncation is owned by tool/runtime code, not by a dedicated tool-result subsystem
+
+### 8. Prompt Coupling
+
+The current system prompt in `agent/loop/engine.go` hardcodes the tool list and some tool-usage rules.
+
+This creates a duplication problem:
+
+- registry is the actual source of tool availability
+- system prompt separately lists tool names and rules
+
+Consequences:
+
+- adding a new tool requires both registry wiring and prompt maintenance
+- prompt drift is possible
+- the prompt cannot naturally reflect request-scoped tool visibility
+
+### 9. Strong Parts of the Current Design
+
+The current `ms-cli` design is not primitive; it is deliberately compact. Its strengths are:
+
+- easy-to-follow control flow
+- low conceptual overhead for contributors
+- centralized permission service
+- streaming support already exists for `shell`
+- session/context integration is direct
+- tools are small and easy to write
+
+For a focused CLI agent, this gives good implementation velocity.
+
+### 10. Main Structural Weaknesses
+
+The main design pressure points are:
+
+1. The `Tool` abstraction is too thin for future scale.
+2. Schema expressivity is too weak for richer tools.
+3. Runtime validation is fragmented inside individual tools.
+4. Tool exposure is static and all-tools-by-default.
+5. Prompt content duplicates tool registry knowledge.
+6. There is no orchestration layer for concurrency or scheduling.
+7. There is no native extension path equivalent to Claude Code's MCP adaptation layer.
+
+## Phase 2: Differences Versus Claude Code
+
+### 1. Tool Protocol Richness
+
+Claude Code uses a much richer tool object model. In addition to name, prompt, and schema, its tool objects carry execution behavior, permission-related behavior, schema conversion policy, concurrency hints, and UI/result-rendering behavior.
+
+`ms-cli` currently keeps only:
+
+- name
+- description
+- schema
+- execute
+
+Difference summary:
+
+- `ms-cli` optimizes for simplicity
+- Claude Code optimizes for a unified runtime contract
+
+### 2. Schema Pipeline
+
+Claude Code has a clear pipeline:
+
+`inputSchema -> input_schema -> safeParse -> validateInput -> permission -> call`
+
+`ms-cli` currently has:
+
+`Schema() -> provider export -> tool-specific ParseParams -> tool-specific semantic validation -> execute`
+
+Main consequences:
+
+- Claude Code has a shared validation frontier before tool logic runs
+- `ms-cli` repeats parsing and semantic checks inside each tool
+- `ms-cli` has a higher risk of schema/runtime drift
+
+### 3. Tool Exposure Strategy
+
+Claude Code separates:
+
+- tool definition
+- tool pool assembly
+- model exposure of tools
+
+It can also delay exposure of tools and use a `ToolSearch` step.
+
+`ms-cli` does not currently distinguish these layers. The engine just exports the registry as the full visible tool list every turn.
+
+### 4. Execution Runtime
+
+Claude Code has:
+
+- single-tool execution pipeline
+- multi-tool orchestration
+- streaming tool executor
+- hook points
+- standardized result mapping
+
+`ms-cli` has:
+
+- a single engine-owned execution path
+- serial tool execution
+- optional per-tool streaming
+- no hook system
+- direct string result injection into context
+
+### 5. Permission Architecture
+
+Claude Code integrates permissions as part of a broader policy system:
+
+- tool-level metadata
+- explicit permission rules
+- mode/policy layering
+- hook/classifier checks
+- UI approval flow
+- sandbox-aware decisions
+
+`ms-cli` has a solid rule-based permission service, but it is not yet a first-class part of the `Tool` contract.
+
+### 6. Extension Model
+
+Claude Code adapts MCP tools into the same unified tool runtime as built-in tools.
+
+`ms-cli` shows early conceptual awareness of external tools because permission rules already recognize `mcp__...`, but the runtime itself does not yet have an MCP-style external tool adaptation layer.
+
+### 7. Prompt and Tool Catalog Relationship
+
+Claude Code is closer to deriving model-visible tool data from tool objects and runtime policy.
+
+`ms-cli` still hardcodes tool descriptions and usage guidance in the system prompt, which makes the prompt partially act as a second tool catalog.
+
+## Phase 3: Improvements ms-cli Can Borrow from Claude Code
+
+### 1. Evolve the Tool Contract
+
+Recommended direction:
+
+- keep the current lightweight developer experience
+- add optional capabilities instead of one giant interface
+
+A practical next step would be to extend the contract with optional interfaces such as:
+
+- `ValidateInput`
+- `PermissionContext`
+- `ConcurrencyClass`
+- `ResultRenderer`
+
+This preserves simplicity while giving the runtime more structure.
+
+### 2. Introduce a Shared Validation Stage
+
+The highest-value improvement is to make validation a first-class runtime phase:
+
+`decode -> schema validate -> semantic validate -> permission -> execute`
+
+This would reduce duplicated parsing logic inside tools and make tool behavior more predictable.
+
+### 3. Replace the Minimal Schema Type
+
+`llm.ToolSchema` should eventually move toward a richer JSON Schema representation.
+
+Recommended options:
+
+- expand the existing struct to support nested schemas and constraints
+- or adopt a generic JSON-schema-shaped map model plus helper builders
+
+Without this, more advanced tools will be difficult to describe accurately across providers.
+
+### 4. Remove Prompt Duplication
+
+The hardcoded tool list in `DefaultSystemPrompt()` should be reduced or generated from registry metadata.
+
+Best direction:
+
+- system prompt provides stable behavioral guidance
+- tool registry provides actual tool catalog
+- per-tool descriptions stay with tool definitions
+
+This avoids drift and makes future tool filtering possible.
+
+### 5. Add a Tool Exposure Layer
+
+Before copying Claude Code's full deferred-loading design, `ms-cli` should first add a smaller abstraction:
+
+- available tools
+- exposed tools for this request
+
+Once that exists, later enhancements become possible:
+
+- request-scoped filtering
+- provider-specific filtering
+- defer heavy tools
+- future tool-search or skill-search flows
+
+### 6. Separate Execution from Orchestration
+
+The current engine execution logic is already understandable, so the refactor can be incremental:
+
+- keep single-tool execution as one unit
+- extract multi-tool scheduling into a separate orchestration unit
+
+This would allow future rules such as:
+
+- read-only tools may run concurrently
+- write tools stay serial
+- shell remains serial by default
+
+### 7. Formalize External Tool Adaptation
+
+If `ms-cli` wants to converge toward Claude Code-class extensibility, it should define an adapter path for external tools.
+
+Even before full MCP support, the architecture can prepare for:
+
+- externally supplied schema
+- externally supplied execution backend
+- shared runtime wrapping for permission, validation, and result mapping
+
+### 8. Make Schema and Runtime Contract Match Exactly
+
+This is a near-term cleanup item with low implementation risk and high conceptual value.
+
+Example:
+
+- if `write` accepts `file_path` or `filename`, either expose them formally
+- or remove them and keep `path` as the only contract
+
+Claude Code is strict about keeping model-visible schema and runtime validation on a clearer path. `ms-cli` should move in the same direction.
+
+## Interim Conclusion
+
+`ms-cli` already has a usable tool system, but it is still in an early-runtime form:
+
+- one thin tool interface
+- one simple registry
+- one engine-owned execution path
+- one strong centralized permission service
+
+This is a good base for a compact CLI agent.
+
+The main opportunity is not to copy Claude Code mechanically, but to selectively borrow the layers that reduce drift and increase extensibility:
+
+1. richer schema and validation pipeline
+2. clearer separation between tool definition, tool exposure, and execution
+3. optional tool metadata for permissions and concurrency
+4. less prompt duplication
+5. an eventual external-tool adaptation layer
+
+## Next Analysis Pass
+
+The next pass should focus on:
+
+1. A file-by-file mapping of the `ms-cli` tool runtime
+2. A proposed target architecture for `ms-cli`
+3. A staged refactor sequence with low-risk implementation order
+
+## Phase 4: Proposed Target Architecture for ms-cli
+
+The best path for `ms-cli` is not to clone Claude Code's full runtime. The better move is to introduce the missing layers one by one while preserving the current compact mental model.
+
+### 1. Recommended Layering
+
+Suggested target architecture:
+
+```text
+Tool Definition Layer
+  -> tool metadata, schema, validation hooks, execute
+
+Tool Registry Layer
+  -> all installed/available tools
+
+Tool Exposure Layer
+  -> request-scoped visible tools
+
+Permission & Policy Layer
+  -> tool/action/path checks, interactive approval
+
+Execution Runtime Layer
+  -> parse, validate, permission, execute, result mapping
+
+Orchestration Layer
+  -> serial vs concurrent scheduling for tool batches
+
+Transcript/UI Layer
+  -> how tool execution is summarized back to the model and UI
+```
+
+This keeps the current engine-centered flow, but removes the need for the engine to personally own every tool-related concern.
+
+### 2. Minimal Contract Evolution
+
+Instead of replacing `tools.Tool` with a huge interface, add optional interfaces around it.
+
+Base interface can remain:
+
+```go
+type Tool interface {
+    Name() string
+    Description() string
+    Schema() llm.ToolSchema
+    Execute(ctx context.Context, params json.RawMessage) (*Result, error)
+}
+```
+
+Optional extensions can then be layered on top:
+
+```go
+type ValidatingTool interface {
+    ValidateInput(ctx context.Context, params json.RawMessage) error
+}
+
+type PermissionAwareTool interface {
+    PermissionContext(params json.RawMessage) (action string, path string, err error)
+}
+
+type ConcurrencyAwareTool interface {
+    ConcurrencyMode() string
+}
+
+type ResultFormattingTool interface {
+    FormatToolMessage(result *Result) string
+}
+```
+
+This is a practical middle ground:
+
+- contributor ergonomics stay good
+- the runtime gains structured extension points
+- not every tool needs to implement every concern
+
+### 3. Recommended Execution Pipeline
+
+The current engine logic should eventually become:
+
+```text
+tool lookup
+  -> decode params
+  -> schema validation
+  -> semantic validation
+  -> derive permission context
+  -> permission request/check
+  -> execute
+  -> normalize result
+  -> append transcript message
+  -> emit UI event
+```
+
+Compared with today, the most important structural gain is that decode/validate/permission become explicit pipeline stages rather than ad hoc work split across engine and tool bodies.
+
+### 4. Recommended Exposure Model
+
+Before implementing deferred loading, `ms-cli` should first create a simple split between:
+
+- installed tools
+- exposed tools for this turn
+
+That unlocks several future directions without overbuilding:
+
+- hide tools unsupported by a provider
+- hide tools disabled by config or mode
+- later introduce skill-driven or request-driven tool subsets
+- later introduce deferred or searchable tools if the catalog grows
+
+### 5. Recommended Result Handling
+
+`Result.Content` should remain for compatibility, but the runtime should start owning transcript formatting instead of treating every result as raw free text.
+
+A good intermediate model would be:
+
+```go
+type Result struct {
+    Content string
+    Summary string
+    Meta    map[string]any
+    Error   error
+    Kind    string
+}
+```
+
+Then the execution runtime can decide:
+
+- what goes to context
+- what goes to UI
+- what should be truncated or summarized
+- what should be marked as error payload
+
+That moves `ms-cli` closer to Claude Code's clearer result pipeline without requiring a large rewrite.
+
+## Phase 5: Low-Risk Refactor Sequence
+
+The safest sequence is to refactor in six small steps.
+
+### Step 1. Remove Schema Drift
+
+Clean up the places where runtime input handling is broader than the published schema.
+
+Start with:
+
+- `tools/fs/write.go`
+- engine-side path extraction assumptions
+
+Goal:
+
+- model-visible schema and actual accepted arguments match exactly
+
+### Step 2. Add an Explicit Validation Hook
+
+Introduce `ValidatingTool` and teach the engine runtime to call it before execution.
+
+Goal:
+
+- move semantic validation out of the middle of `Execute`
+- make tool errors more uniform
+
+### Step 3. Add Permission Context Extraction to Tools
+
+Move action/path derivation away from generic engine heuristics where possible.
+
+Goal:
+
+- tools define their own permission-relevant action and target path
+- engine stops carrying tool-name-specific extraction logic
+
+### Step 4. Extract a Tool Runtime Module
+
+Move the execution logic out of `agent/loop/engine.go` into a dedicated tool runtime package.
+
+Good boundary:
+
+- `RunToolCall`
+- `AppendToolResult`
+- `EmitToolEvents`
+
+Goal:
+
+- reduce engine complexity
+- make future orchestration possible
+
+### Step 5. Add Tool Exposure as a Separate Decision
+
+Introduce something like:
+
+```go
+type VisibleToolSet interface {
+    ToLLMTools() []llm.Tool
+}
+```
+
+Goal:
+
+- separate registry from model-visible tool list
+- prepare for provider-specific or policy-specific tool filtering
+
+### Step 6. Add Basic Orchestration Metadata
+
+Once the runtime is extracted, add a minimal concurrency model:
+
+- read-like tools: concurrency-safe
+- write/edit/shell: serial
+
+Goal:
+
+- preserve correctness
+- gain performance where tool calls are independent
+
+## File-by-File Mapping
+
+This is the most useful current map of where tool-system responsibilities live today.
+
+### Definition and registration
+
+- `tools/types.go`: base tool protocol and result model
+- `tools/registry.go`: ordered registry and LLM export
+- `internal/app/wire.go`: concrete tool assembly and registration
+
+### Schema and provider adaptation
+
+- `integrations/llm/provider.go`: internal tool schema types
+- `integrations/llm/codec_anthropic.go`: Anthropic tool encoding and `tool_result` decoding
+- `integrations/llm/codec_openai_completion.go`: OpenAI chat-completions tool encoding
+- `integrations/llm/codec_openai_responses.go`: OpenAI responses tool encoding, currently with unconditional `strict: true`
+
+### Runtime execution
+
+- `agent/loop/engine.go`: request construction, tool execution, context updates, event emission
+
+### Permissions
+
+- `permission/service.go`: core policy evaluation and interactive approval
+- `permission/rules.go`: Claude-style rule parsing and matching
+- `permission/dangerous.go`: dangerous shell command detection
+- `internal/app/permission_ui.go`: TUI approval bridge
+
+### Concrete tools
+
+- `tools/fs/*.go`: read/write/edit/grep/glob tools
+- `tools/shell/shell.go`: LLM-callable shell wrapper
+- `runtime/shell/runner.go`: actual command execution runtime
+- `tools/skills/load_skill.go`: deferred skill-content loading
+
+## Updated Conclusion
+
+After a second pass, the most important judgment is this:
+
+`ms-cli` already has the right coarse-grained pieces, but they are still collapsed into too few layers.
+
+The project does not need a wholesale redesign. It needs targeted separation of concerns:
+
+1. richer validation and schema handling
+2. tool-owned permission context instead of engine heuristics
+3. a dedicated tool runtime module
+4. a distinction between registry and model-visible tool set
+5. gradual preparation for external-tool adaptation
+
+That is the shortest path toward Claude Code-level robustness without losing the simplicity that currently makes `ms-cli` fast to evolve.

--- a/docs/mscli-tool-system-refactor-plan.md
+++ b/docs/mscli-tool-system-refactor-plan.md
@@ -1,0 +1,517 @@
+# ms-cli Tool System Refactor Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve tool hit rate, reduce invalid tool arguments, add the most valuable missing tools, and evolve the tool runtime toward a clearer Claude Code-inspired architecture without overcomplicating `ms-cli`.
+
+**Architecture:** Keep the current lightweight `Tool` interface as the base, but add missing layers in order: better tool prompting and schema clarity first, then missing high-value tools, then execution/runtime refactors. The plan deliberately separates "better model behavior" improvements from "bigger architecture" work so `ms-cli` can gain quality quickly without taking on a full runtime rewrite.
+
+**Tech Stack:** Go, current `tools.Registry`, `agent/loop.Engine`, `integrations/llm` codecs, `permission` service, Bubble Tea UI.
+
+---
+
+## Direct Answers
+
+### 1. Which existing-vs-Claude gaps are worth filling?
+
+Not every Claude Code tool is worth copying. For `ms-cli`, the most useful additions are:
+
+- **`list_dir` / `ls`-style tool**
+  Current gap: `glob` can find files by pattern, but it is not a strong "show me what is here" tool.
+  Why it matters: improves exploration hit rate and reduces unnecessary `shell` calls.
+  Priority: **high**
+
+- **`multi_edit` or `apply_patch`-style editing tool**
+  Current gap: `edit` only supports one exact replacement per call, which is brittle and increases retry loops.
+  Why it matters: directly improves code-edit success rate and lowers tool-call count.
+  Priority: **high**
+
+- **`web_fetch` / `fetch_url` tool**
+  Current gap: external docs, release notes, and troubleshooting references currently depend on `shell` usage.
+  Why it matters: `ms-cli` targets ML infra and training workflows; external documentation lookup is common and should not require generic shell access.
+  Priority: **high**
+
+- **External tool adapter / MCP-compatible bridge**
+  Current gap: permissions already understand `mcp__...`, but runtime does not.
+  Why it matters: this is the natural long-term extension path.
+  Priority: **medium-long term**
+
+- **Subagent / task tool**
+  Current gap: no decomposition mechanism inside the tool runtime.
+  Why it matters: useful for larger workflows, but not necessary before the basics are fixed.
+  Priority: **low for now**
+
+### 2. Do current tool descriptions need optimization?
+
+Yes. This is the easiest high-leverage change.
+
+Current problems:
+
+- descriptions are correct, but too generic
+- they often describe what the tool does, but not when to prefer it over another tool
+- they do not consistently encode decision boundaries
+- parameter descriptions are sometimes weaker than runtime behavior
+- some constraints are split across tool descriptions and the global system prompt
+
+Highest-priority descriptions to improve:
+
+- `write`: must strongly reinforce exact field names and overwrite semantics
+- `edit`: must strongly reinforce exact-match behavior and when not to use it
+- `shell`: must explain when shell is the fallback instead of the default
+- `load_skill`: must better explain invocation boundary
+- `grep` / `glob`: should clarify selection boundary between "search content" and "find files"
+
+### 3. Does the current tool system architecture need optimization?
+
+Yes, but not all at once.
+
+Judgment:
+
+- **Prompting/tool-description quality:** optimize immediately
+- **Necessary missing tools:** add next
+- **Architecture refactor:** start only after the tool contract and tool catalog are cleaner
+
+The architecture is good enough for a compact agent, but it is already showing three pressure points:
+
+- too much tool-specific logic lives in `agent/loop/engine.go`
+- schema validation is too weak and too fragmented
+- registry and model-visible tool set are still the same thing
+
+So the right move is phased optimization, not a rewrite.
+
+## Current Tool Catalog Review
+
+### Existing tools
+
+- `read`
+- `write`
+- `edit`
+- `grep`
+- `glob`
+- `shell`
+- `load_skill`
+
+### Coverage assessment
+
+What this set already covers well:
+
+- basic code exploration
+- single-file read and write
+- exact string replacement edits
+- shell fallback for everything else
+- skill activation
+
+What it covers poorly compared with Claude Code:
+
+- directory structure inspection as a first-class action
+- multi-change editing
+- safe external information retrieval
+- external tool extensibility
+- richer tool-specific runtime behavior
+
+## Tool Description Optimization Plan
+
+This is the first and easiest phase because it improves tool hit rate without changing architecture.
+
+### Description design rules
+
+Each tool description should answer five things:
+
+1. What the tool does
+2. When to use it
+3. When not to use it
+4. Which sibling tool is preferable in nearby cases
+5. Which arguments must be exact
+
+### Recommended improvements by tool
+
+#### `read`
+
+Need to clarify:
+
+- use `read` when you already know the file path
+- use `glob` to find files first
+- use `grep` when searching by content
+- `path` is workspace-relative
+
+#### `write`
+
+Need to clarify:
+
+- this overwrites the full file content
+- prefer `edit` or `multi_edit` for targeted changes
+- arguments must include exact keys `path` and `content`
+- do not use aliases if aliases remain temporarily supported
+
+#### `edit`
+
+Need to clarify:
+
+- best for one targeted exact replacement
+- do not use when multiple distant changes are needed
+- `old_string` must match exactly including whitespace and newlines
+- if uniqueness is unclear, read the file first
+
+#### `grep`
+
+Need to clarify:
+
+- use to search file contents, not filenames
+- prefer `glob` for file discovery
+- prefer `read` after locating the exact file
+- `include` narrows file types
+
+#### `glob`
+
+Need to clarify:
+
+- use to find candidate files by filename or path pattern
+- not a replacement for content search
+- use `path` to scope the search root
+- use `offset`/`limit` when results are large
+
+#### `shell`
+
+Need to clarify:
+
+- use shell only when dedicated tools are insufficient
+- prefer `read`/`grep`/`glob`/`edit`/`write` for file operations
+- command should be one focused operation
+- destructive or high-risk commands may require confirmation
+
+#### `load_skill`
+
+Need to clarify:
+
+- use when the user's task clearly matches a listed skill
+- do not call it for ordinary coding actions that existing tools already support
+- load once when needed rather than repeatedly
+
+### Prompt cleanup rule
+
+After tool descriptions improve, the global system prompt should shrink.
+
+Keep in the system prompt:
+
+- high-level behavior policy
+- minimal workflow heuristics
+
+Remove from the system prompt over time:
+
+- duplicated per-tool contract details
+- exact argument warnings that belong in schema/description
+
+## Missing Tool Roadmap
+
+### Phase A: Add easy, high-value tools
+
+#### 1. `list_dir`
+
+Why first:
+
+- simple implementation
+- directly reduces `shell ls/find/tree`
+- gives the model a clearer exploration primitive than `glob`
+
+Suggested shape:
+
+- `path`
+- `depth`
+- `include_hidden`
+
+Expected behavior:
+
+- return files and directories distinctly
+- preserve stable ordering
+- optionally summarize counts
+
+#### 2. `multi_edit`
+
+Why next:
+
+- biggest quality win for coding tasks
+- directly addresses brittleness in current `edit`
+
+Suggested shape:
+
+- `path`
+- `edits[]` with `old_string` and `new_string`
+
+Expected behavior:
+
+- validate all edits before writing
+- fail safely if any edit is ambiguous
+- apply in a deterministic order
+
+### Phase B: Add medium-complexity capability tools
+
+#### 3. `web_fetch`
+
+Why:
+
+- recurring need for docs, release notes, dependency changes, training/runtime troubleshooting
+- safer and more structured than `shell` + `curl`
+
+Suggested shape:
+
+- `url`
+- `prompt` or `extract`
+
+Expected behavior:
+
+- fetch and return cleaned text
+- include source URL in the result
+- integrate with permission policy if external access is controlled
+
+### Phase C: Add extension-oriented tools
+
+#### 4. External tool adapter / MCP bridge
+
+Why:
+
+- aligns with the existing permission-rule vocabulary
+- creates a long-term extensibility path
+
+Suggested scope:
+
+- list external tools
+- adapt external schema into `ms-cli` tool definitions
+- run through shared permission and result handling
+
+#### 5. Subagent / task tool
+
+Why later:
+
+- only valuable once the core runtime is stable
+- high complexity and architecture surface area
+
+## Architecture Optimization Plan
+
+This section is ordered from easiest to hardest.
+
+### Phase 1: Contract cleanup
+
+#### 1. Make schema and runtime contract match exactly
+
+Current issue:
+
+- `write` accepts undocumented fallback keys
+- engine still contains tool-name-specific argument extraction logic
+
+Goal:
+
+- one published contract
+- one accepted contract
+
+#### 2. Add shared validation hooks
+
+Add optional interfaces:
+
+```go
+type ValidatingTool interface {
+    ValidateInput(ctx context.Context, params json.RawMessage) error
+}
+```
+
+Goal:
+
+- move semantic validation out of arbitrary `Execute` bodies
+- create a shared tool runtime frontier before side effects happen
+
+#### 3. Add tool-owned permission context
+
+Add optional interface:
+
+```go
+type PermissionAwareTool interface {
+    PermissionContext(params json.RawMessage) (action string, path string, err error)
+}
+```
+
+Goal:
+
+- stop forcing the engine to infer tool semantics from tool names
+
+### Phase 2: Runtime extraction
+
+#### 4. Extract tool execution out of `agent/loop/engine.go`
+
+Create a dedicated runtime path such as:
+
+- lookup tool
+- validate input
+- derive permission context
+- request permission
+- execute
+- normalize result
+- append tool result message
+- emit events
+
+Goal:
+
+- make the engine smaller
+- make tool behavior more testable
+- prepare for orchestration and hook points
+
+#### 5. Separate registry from visible tool set
+
+Current state:
+
+- registry equals exposed tools
+
+Target state:
+
+- registry stores available tools
+- a request-scoped selector decides visible tools
+
+Why this matters:
+
+- provider-specific filtering
+- mode-specific filtering
+- future deferred loading
+- future external tools
+
+### Phase 3: Capability scaling
+
+#### 6. Upgrade schema representation
+
+Current issue:
+
+- `llm.ToolSchema` is too small for future tools
+
+Target:
+
+- richer JSON Schema support
+
+Why:
+
+- arrays for `multi_edit`
+- nested objects for better contracts
+- more accurate provider encoding
+
+#### 7. Add orchestration metadata
+
+Introduce optional tool metadata such as:
+
+```go
+type ConcurrencyAwareTool interface {
+    ConcurrencyMode() string
+}
+```
+
+Initial policy:
+
+- `read`, `grep`, `glob`, `list_dir`, `web_fetch`: concurrency-safe
+- `write`, `edit`, `multi_edit`, `shell`: serial
+
+#### 8. Add extension/adaptation layer
+
+Only after the previous steps:
+
+- external tools
+- MCP-style schema adaptation
+- unified runtime wrapping
+
+## Recommended Execution Order
+
+This is the actual roadmap from easiest to hardest.
+
+### Stage 1: Prompt and description quality
+
+- Rewrite all tool descriptions with explicit decision boundaries
+- Strengthen parameter descriptions
+- Reduce duplicated tool guidance in `DefaultSystemPrompt()`
+- Keep only high-level workflow rules in the system prompt
+
+Expected outcome:
+
+- better tool selection
+- fewer malformed arguments
+- fewer unnecessary shell calls
+
+### Stage 2: Contract correctness
+
+- Remove schema/runtime drift, especially in `write`
+- Add validation hooks
+- Add tool-owned permission context
+
+Expected outcome:
+
+- fewer invalid executions
+- clearer runtime behavior
+- less engine heuristic logic
+
+### Stage 3: High-value tool additions
+
+- Add `list_dir`
+- Add `multi_edit`
+- Add `web_fetch`
+
+Expected outcome:
+
+- better repository navigation
+- better edit success rate
+- less misuse of shell for external lookup
+
+### Stage 4: Runtime refactor
+
+- Extract tool execution into a runtime module
+- Separate available tools from exposed tools
+
+Expected outcome:
+
+- cleaner architecture
+- easier testing
+- better future extensibility
+
+### Stage 5: Long-term architecture
+
+- Upgrade schema expressivity
+- Add concurrency/orchestration metadata
+- Add external tool adapter / MCP-like layer
+
+Expected outcome:
+
+- Claude Code-style evolution path without immediate overengineering
+
+## Files Most Likely To Change
+
+### Prompt and tool contract
+
+- `agent/loop/engine.go`
+- `tools/fs/read.go`
+- `tools/fs/write.go`
+- `tools/fs/edit.go`
+- `tools/fs/grep.go`
+- `tools/fs/glob.go`
+- `tools/shell/shell.go`
+- `tools/skills/load_skill.go`
+
+### Runtime and architecture
+
+- `tools/types.go`
+- `tools/registry.go`
+- `agent/loop/engine.go`
+- `integrations/llm/provider.go`
+- `integrations/llm/codec_anthropic.go`
+- `integrations/llm/codec_openai_completion.go`
+- `integrations/llm/codec_openai_responses.go`
+- `permission/service.go`
+
+### New tools
+
+- `tools/fs/list_dir.go` or similar
+- `tools/fs/multi_edit.go` or similar
+- `tools/webfetch/...` or similar
+- `runtime/webfetch/...` if runtime separation is desired
+
+## Final Recommendation
+
+The right order is:
+
+1. **Fix tool prompting and descriptions first**
+2. **Then fix contract correctness and validation**
+3. **Then add `list_dir`, `multi_edit`, and `web_fetch`**
+4. **Only then refactor the runtime architecture**
+
+This order gives `ms-cli` visible quality gains quickly, while keeping the architecture changes justified by real tool pressure instead of abstract design purity.

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -688,6 +688,7 @@ var loopEventTypeMap = map[string]model.EventType{
 	"ContextCompacted":    model.ContextNotice,
 	"ToolRead":            model.ToolRead,
 	"ToolGrep":            model.ToolGrep,
+	"ToolListDir":         model.ToolListDir,
 	"ToolGlob":            model.ToolGlob,
 	"ToolEdit":            model.ToolEdit,
 	"ToolWrite":           model.ToolWrite,

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -319,6 +319,26 @@ func TestConvertLoopEvent_PreservesMeta(t *testing.T) {
 	}
 }
 
+func TestConvertLoopEvent_MapsToolListDir(t *testing.T) {
+	ev := loop.Event{
+		Type:     "ToolListDir",
+		ToolName: "list_dir",
+		Message:  "showing 1-2 of 2 entries\ncmd/\nREADME.md",
+		Summary:  "showing 1-2 of 2 entries",
+	}
+
+	got := convertLoopEvent(ev)
+	if got == nil {
+		t.Fatal("convertLoopEvent(ToolListDir) = nil, want non-nil")
+	}
+	if got.Type != model.ToolListDir {
+		t.Fatalf("convertLoopEvent type = %v, want %v", got.Type, model.ToolListDir)
+	}
+	if got.Message != ev.Message {
+		t.Fatalf("convertLoopEvent message = %q, want %q", got.Message, ev.Message)
+	}
+}
+
 func TestConvertLoopEvent_MapsToolInterrupted(t *testing.T) {
 	ev := loop.Event{
 		Type:       loop.EventToolInterrupted,

--- a/internal/app/tool_system_e2e_test.go
+++ b/internal/app/tool_system_e2e_test.go
@@ -1,0 +1,199 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mindspore-lab/mindspore-cli/agent/loop"
+	"github.com/mindspore-lab/mindspore-cli/integrations/llm"
+	"github.com/mindspore-lab/mindspore-cli/permission"
+)
+
+func TestToolSystemE2E_GlobFindsRootTrainPyInSingleToolCall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MSCLI_PROVIDER", "openai-completion")
+	t.Setenv("MSCLI_API_KEY", "token")
+	t.Setenv("MSCLI_MODEL", "gpt-4o-mini")
+
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "train.py"), []byte("print('root')\n"), 0o644); err != nil {
+		t.Fatalf("write root train.py: %v", err)
+	}
+
+	provider := &scriptedAppStreamProvider{
+		responses: []*llm.CompletionResponse{
+			{
+				ToolCalls: []llm.ToolCall{{
+					ID:   "call-glob-train",
+					Type: "function",
+					Function: llm.ToolCallFunc{
+						Name:      "glob",
+						Arguments: json.RawMessage(`{"pattern":"**/train.py","path":"."}`),
+					},
+				}},
+				FinishReason: llm.FinishToolCalls,
+			},
+			{
+				Content:      "yes, train.py exists in the current directory",
+				FinishReason: llm.FinishStop,
+			},
+		},
+	}
+
+	origBuildProvider := buildProvider
+	buildProvider = func(resolved llm.ResolvedConfig) (llm.Provider, error) {
+		return provider, nil
+	}
+	defer func() { buildProvider = origBuildProvider }()
+
+	app, err := Wire(BootstrapConfig{})
+	if err != nil {
+		t.Fatalf("Wire() error = %v", err)
+	}
+
+	events, err := app.Engine.Run(loop.Task{
+		ID:          "tool-e2e-train-py",
+		Description: "当前目录是否有train.py文件",
+	})
+	if err != nil {
+		t.Fatalf("Engine.Run() error = %v", err)
+	}
+
+	var sawGlob bool
+	for _, ev := range events {
+		if ev.Type != loop.EventToolGlob {
+			continue
+		}
+		sawGlob = true
+		if !strings.Contains(ev.Message, "train.py") {
+			t.Fatalf("glob event message = %q, want train.py", ev.Message)
+		}
+	}
+	if !sawGlob {
+		t.Fatal("expected glob tool event, got none")
+	}
+}
+
+func TestToolSystemE2E_ExposesListDirAndShellGuardrailsToModel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MSCLI_PROVIDER", "openai-completion")
+	t.Setenv("MSCLI_API_KEY", "token")
+	t.Setenv("MSCLI_MODEL", "gpt-4o-mini")
+
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	provider := &captureStreamProvider{}
+	origBuildProvider := buildProvider
+	buildProvider = func(resolved llm.ResolvedConfig) (llm.Provider, error) {
+		return provider, nil
+	}
+	defer func() { buildProvider = origBuildProvider }()
+
+	app, err := Wire(BootstrapConfig{})
+	if err != nil {
+		t.Fatalf("Wire() error = %v", err)
+	}
+
+	_, err = app.Engine.Run(loop.Task{
+		ID:          "tool-e2e-structure-summary",
+		Description: "为我总结当前目录的代码结构",
+	})
+	if err != nil {
+		t.Fatalf("Engine.Run() error = %v", err)
+	}
+
+	if provider.lastReq == nil {
+		t.Fatal("expected provider to receive completion request")
+	}
+
+	var sawListDir bool
+	var shellDescription string
+	for _, tool := range provider.lastReq.Tools {
+		switch tool.Function.Name {
+		case "list_dir":
+			sawListDir = true
+		case "shell":
+			shellDescription = tool.Function.Description
+		}
+	}
+	if !sawListDir {
+		t.Fatal("expected list_dir to be exposed to the model")
+	}
+	if !strings.Contains(shellDescription, "Do not use shell redirection, heredoc, tee, sed -i, or similar patterns to create or edit files") {
+		t.Fatalf("shell description = %q, want file-authoring guardrail", shellDescription)
+	}
+}
+
+func TestToolSystemE2E_DenyWriteBlocksShellFileAuthoringFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MSCLI_PROVIDER", "openai-completion")
+	t.Setenv("MSCLI_API_KEY", "token")
+	t.Setenv("MSCLI_MODEL", "gpt-4o-mini")
+
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	provider := &scriptedAppStreamProvider{
+		responses: []*llm.CompletionResponse{
+			{
+				ToolCalls: []llm.ToolCall{{
+					ID:   "call-shell-write",
+					Type: "function",
+					Function: llm.ToolCallFunc{
+						Name:      "shell",
+						Arguments: json.RawMessage("{\"command\":\"cat <<'EOF' > note.md\\nhello\\nEOF\"}"),
+					},
+				}},
+				FinishReason: llm.FinishToolCalls,
+			},
+			{
+				Content:      "unable to proceed without file-authoring permission",
+				FinishReason: llm.FinishStop,
+			},
+		},
+	}
+
+	origBuildProvider := buildProvider
+	buildProvider = func(resolved llm.ResolvedConfig) (llm.Provider, error) {
+		return provider, nil
+	}
+	defer func() { buildProvider = origBuildProvider }()
+
+	app, err := Wire(BootstrapConfig{})
+	if err != nil {
+		t.Fatalf("Wire() error = %v", err)
+	}
+
+	if svc, ok := app.permService.(*permission.DefaultPermissionService); ok {
+		svc.Grant("write", permission.PermissionDeny)
+	}
+
+	events, err := app.Engine.Run(loop.Task{
+		ID:          "tool-e2e-write-denied",
+		Description: "帮我写一个markdown文档",
+	})
+	if err == nil {
+		t.Fatal("Engine.Run() error = nil, want shell file authoring denial")
+	}
+	if !strings.Contains(err.Error(), "shell file authoring is blocked") {
+		t.Fatalf("Engine.Run() error = %v, want shell file authoring blocked", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(workDir, "note.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("note.md should not be created after shell fallback denial, stat err = %v", statErr)
+	}
+
+	for _, ev := range events {
+		if ev.Type == loop.EventToolError && !strings.Contains(ev.Message, "shell file authoring is blocked") {
+			t.Fatalf("tool error = %q, want shell file authoring blocked", ev.Message)
+		}
+	}
+}

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -666,6 +666,7 @@ func initTools(cfg *configs.Config, workDir string) *tools.Registry {
 	registry := tools.NewRegistry()
 
 	registry.MustRegister(fs.NewReadTool(workDir))
+	registry.MustRegister(fs.NewListDirTool(workDir))
 	registry.MustRegister(fs.NewWriteTool(workDir))
 	registry.MustRegister(fs.NewEditTool(workDir))
 	registry.MustRegister(fs.NewGrepTool(workDir))

--- a/permission/rules.go
+++ b/permission/rules.go
@@ -68,6 +68,8 @@ func ruleFromToolLiteral(tool string) string {
 		return "Bash"
 	case "read", "grep", "glob":
 		return "Read"
+	case "list_dir":
+		return "Read"
 	case "edit":
 		return "Edit"
 	case "write":
@@ -133,7 +135,7 @@ func matchRule(rule PermissionRule, tool, action, path string) bool {
 
 func isReadTool(tool string) bool {
 	switch tool {
-	case "read", "glob", "grep":
+	case "read", "glob", "grep", "list_dir":
 		return true
 	default:
 		return false

--- a/permission/service.go
+++ b/permission/service.go
@@ -175,8 +175,19 @@ func (s *DefaultPermissionService) SetStore(store PermissionStore) {
 
 // Request requests permission.
 func (s *DefaultPermissionService) Request(ctx context.Context, tool, action, path string) (bool, error) {
+	shellIntent := shellIntentGeneral
+	if tool == "shell" {
+		shellIntent = classifyShellCommand(action)
+		if shellIntent == shellIntentFileAuthoring && (s.Check("write", "") == PermissionDeny || s.Check("edit", "") == PermissionDeny) {
+			return false, fmt.Errorf("shell file authoring is blocked; use write/edit tool permissions")
+		}
+	}
+
 	// 1. 检查工具级别权限
 	toolLevel := s.Check(tool, action)
+	if tool == "shell" && shellIntent == shellIntentReadOnlyExplore {
+		toolLevel = PermissionAllowAlways
+	}
 	level := toolLevel
 	cmdLevel := PermissionAllowAlways
 	pathLevel := PermissionAllowAlways
@@ -313,7 +324,7 @@ func (s *DefaultPermissionService) Check(tool, action string) PermissionLevel {
 	}
 
 	// Check read/write patterns
-	if tool == "read" || tool == "glob" {
+	if tool == "read" || tool == "glob" || tool == "grep" || tool == "list_dir" {
 		return PermissionAllowAlways
 	}
 
@@ -371,6 +382,90 @@ var safeReadOnlyCommands = map[string]bool{
 	"md5sum": true, "sha256sum": true, "sha1sum": true,
 	"tar": true, "gzip": true, "gunzip": true, "zcat": true,
 	"true": true, "false": true, "test": true,
+}
+
+type shellIntent string
+
+const (
+	shellIntentGeneral         shellIntent = "general"
+	shellIntentReadOnlyExplore shellIntent = "read_only_explore"
+	shellIntentFileAuthoring   shellIntent = "file_authoring"
+)
+
+var readOnlyExploreCommands = map[string]bool{
+	"ls": true, "ll": true, "la": true,
+	"find": true, "tree": true, "pwd": true,
+	"stat": true, "realpath": true, "basename": true, "dirname": true,
+	"rg": true,
+}
+
+func classifyShellCommand(command string) shellIntent {
+	command = normalizeCommandInput(command)
+	if strings.TrimSpace(command) == "" {
+		return shellIntentGeneral
+	}
+
+	parts := splitShellCommand(command)
+	if len(parts) == 0 {
+		parts = []string{command}
+	}
+
+	allReadOnly := true
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if isShellFileAuthoringCommand(part) {
+			return shellIntentFileAuthoring
+		}
+		if !isReadOnlyExploreCommand(part) {
+			allReadOnly = false
+		}
+	}
+	if allReadOnly {
+		return shellIntentReadOnlyExplore
+	}
+	return shellIntentGeneral
+}
+
+func isReadOnlyExploreCommand(command string) bool {
+	command = strings.TrimSpace(normalizeCommandInput(command))
+	if command == "" || isShellFileAuthoringCommand(command) {
+		return false
+	}
+	name := extractCommandName(command)
+	if !readOnlyExploreCommands[name] {
+		return false
+	}
+	if name == "rg" && !strings.Contains(command, "--files") {
+		return false
+	}
+	return true
+}
+
+func isShellFileAuthoringCommand(command string) bool {
+	command = strings.TrimSpace(normalizeCommandInput(command))
+	if command == "" {
+		return false
+	}
+	lower := strings.ToLower(command)
+	if strings.Contains(command, ">>") || strings.Contains(command, " >") || strings.Contains(command, "> ") {
+		return true
+	}
+	if strings.Contains(command, "<<") {
+		return true
+	}
+	if strings.Contains(lower, " tee ") || strings.HasPrefix(lower, "tee ") {
+		return true
+	}
+	if strings.HasPrefix(lower, "sed ") && strings.Contains(lower, " -i") {
+		return true
+	}
+	if strings.HasPrefix(lower, "perl ") && strings.Contains(lower, "-pi") {
+		return true
+	}
+	return false
 }
 
 func (s *DefaultPermissionService) checkShellCommandSingle(command string) PermissionLevel {

--- a/permission/service_test.go
+++ b/permission/service_test.go
@@ -150,6 +150,49 @@ func TestRuleConfig_BashOperatorAwareMatching(t *testing.T) {
 	}
 }
 
+func TestRequest_ReadOnlyShellCommandBypassesInteractivePrompt(t *testing.T) {
+	svc := NewDefaultPermissionService(configs.PermissionsConfig{
+		DefaultLevel: "ask",
+	})
+	svc.SetUI(stubPermissionUI{granted: false, remember: false})
+
+	granted, err := svc.Request(context.Background(), "shell", "ls -la", "")
+	if err != nil {
+		t.Fatalf("Request() err = %v", err)
+	}
+	if !granted {
+		t.Fatal("Request() granted = false, want true for read-only shell command")
+	}
+}
+
+func TestCheck_ShellFileAuthoringDoesNotInheritReadOnlyAllowance(t *testing.T) {
+	svc := NewDefaultPermissionService(configs.PermissionsConfig{
+		DefaultLevel: "ask",
+	})
+
+	if got := svc.Check("shell", "echo hi > note.md"); got != PermissionAsk {
+		t.Fatalf("Check(shell redirect write) = %v, want %v", got, PermissionAsk)
+	}
+	if got := svc.Check("shell", "cat <<'EOF' > note.md\nhello\nEOF"); got != PermissionAsk {
+		t.Fatalf("Check(shell heredoc write) = %v, want %v", got, PermissionAsk)
+	}
+}
+
+func TestRequest_ShellFileAuthoringRespectsWriteDeny(t *testing.T) {
+	svc := NewDefaultPermissionService(configs.PermissionsConfig{
+		DefaultLevel: "ask",
+	})
+	svc.Grant("write", PermissionDeny)
+
+	granted, err := svc.Request(context.Background(), "shell", "cat <<'EOF' > note.md\nhello\nEOF", "")
+	if err == nil {
+		t.Fatal("Request() err = nil, want denial error")
+	}
+	if granted {
+		t.Fatal("Request() granted = true, want false")
+	}
+}
+
 func TestRuleConfig_BashFindPatternMatchesQuoteAndGroupingVariants(t *testing.T) {
 	svc := NewDefaultPermissionService(configs.PermissionsConfig{
 		DefaultLevel: "ask",

--- a/tools/fs/description_test.go
+++ b/tools/fs/description_test.go
@@ -1,0 +1,59 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToolDescriptionsIncludeDedicatedToolGuidance(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		got   string
+		wants []string
+	}{
+		{
+			name:  "read",
+			got:   NewReadTool(".").Description(),
+			wants: []string{"To read files use read instead of cat, head, tail, or sed"},
+		},
+		{
+			name:  "edit",
+			got:   NewEditTool(".").Description(),
+			wants: []string{"To edit files use edit instead of sed or awk"},
+		},
+		{
+			name:  "write",
+			got:   NewWriteTool(".").Description(),
+			wants: []string{"To create files use write instead of cat with heredoc or echo redirection"},
+		},
+		{
+			name:  "glob",
+			got:   NewGlobTool(".").Description(),
+			wants: []string{"To search for files use glob instead of find or ls"},
+		},
+		{
+			name:  "grep",
+			got:   NewGrepTool(".").Description(),
+			wants: []string{"To search the content of files, use grep instead of grep or rg"},
+		},
+		{
+			name:  "list_dir",
+			got:   NewListDirTool(".").Description(),
+			wants: []string{"Prefer this over glob or shell ls/find/tree when exploring directory layout"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, want := range tc.wants {
+				if !strings.Contains(tc.got, want) {
+					t.Fatalf("%s description missing %q: %q", tc.name, want, tc.got)
+				}
+			}
+		})
+	}
+}

--- a/tools/fs/edit.go
+++ b/tools/fs/edit.go
@@ -28,7 +28,7 @@ func (t *EditTool) Name() string {
 
 // Description returns the tool description.
 func (t *EditTool) Description() string {
-	return "Edit a file by replacing specific text. Use this for making targeted changes. The old_string must match exactly including whitespace."
+	return "Edit a file by replacing one exact text block. To edit files use edit instead of sed or awk. Use this for targeted file changes after reading the file first. The old_string must match exactly, including whitespace and newlines. Do not use shell redirection, tee, sed -i, or heredoc as a substitute for edit."
 }
 
 // Schema returns the tool parameter schema.

--- a/tools/fs/glob.go
+++ b/tools/fs/glob.go
@@ -30,7 +30,7 @@ func (t *GlobTool) Name() string {
 
 // Description returns the tool description.
 func (t *GlobTool) Description() string {
-	return "Find files matching a glob pattern. Use this to explore project structure and find specific file types."
+	return "Find files by file name or path pattern. To search for files use glob instead of find or ls. Use this when you know the kind of path you want, such as '**/*.go' or '**/train.py'. Prefer list_dir for summarizing directory structure and grep for searching file contents."
 }
 
 // Schema returns the tool parameter schema.
@@ -208,6 +208,11 @@ func compileDoubleStarPattern(pattern string) (*regexp.Regexp, error) {
 		switch ch {
 		case '*':
 			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				if i+2 < len(pattern) && pattern[i+2] == '/' {
+					b.WriteString(`(?:.*/)?`)
+					i += 2
+					continue
+				}
 				b.WriteString(".*")
 				i++
 				continue

--- a/tools/fs/grep.go
+++ b/tools/fs/grep.go
@@ -30,7 +30,7 @@ func (t *GrepTool) Name() string {
 
 // Description returns the tool description.
 func (t *GrepTool) Description() string {
-	return "Search for patterns in files using regular expressions. Returns matching lines with file names and line numbers."
+	return "Search file contents using regular expressions and return matching lines with file names and line numbers. To search the content of files, use grep instead of grep or rg. Use this for content search only. Prefer glob for finding files by path pattern and read after you know the exact file to inspect."
 }
 
 // Schema returns the tool parameter schema.

--- a/tools/fs/ignore_test.go
+++ b/tools/fs/ignore_test.go
@@ -102,6 +102,34 @@ func TestGlobToolSupportsOffsetAndLimit(t *testing.T) {
 	}
 }
 
+func TestGlobToolDoubleStarMatchesRootAndNestedFiles(t *testing.T) {
+	workDir := t.TempDir()
+	mustWriteTestFile(t, filepath.Join(workDir, "train.py"), "print('root')\n")
+	mustWriteTestFile(t, filepath.Join(workDir, "nested", "train.py"), "print('nested')\n")
+
+	params, err := json.Marshal(map[string]any{
+		"pattern": "**/train.py",
+		"path":    ".",
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	result, err := NewGlobTool(workDir).Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute result error = %v, want nil", result.Error)
+	}
+	if !strings.Contains(result.Content, "train.py") {
+		t.Fatalf("glob content = %q, want root train.py match", result.Content)
+	}
+	if !strings.Contains(result.Content, filepath.Join("nested", "train.py")) {
+		t.Fatalf("glob content = %q, want nested train.py match", result.Content)
+	}
+}
+
 func TestGlobToolDefaultsLimitTo100(t *testing.T) {
 	workDir := t.TempDir()
 	for i := 0; i < 120; i++ {

--- a/tools/fs/list_dir.go
+++ b/tools/fs/list_dir.go
@@ -1,0 +1,187 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mindspore-lab/mindspore-cli/integrations/llm"
+	"github.com/mindspore-lab/mindspore-cli/tools"
+)
+
+// ListDirTool lists directory contents for structure exploration.
+type ListDirTool struct {
+	workDir string
+}
+
+// NewListDirTool creates a new list_dir tool.
+func NewListDirTool(workDir string) *ListDirTool {
+	return &ListDirTool{workDir: workDir}
+}
+
+// Name returns the tool name.
+func (t *ListDirTool) Name() string {
+	return "list_dir"
+}
+
+// Description returns the tool description.
+func (t *ListDirTool) Description() string {
+	return "List directory contents and shallow tree structure. Use this to answer questions like what is in the current directory or summarize the code structure. Prefer this over glob or shell ls/find/tree when exploring directory layout. Use glob to find files by path pattern, grep to search file contents, and read after you know the exact file path."
+}
+
+// Schema returns the tool parameter schema.
+func (t *ListDirTool) Schema() llm.ToolSchema {
+	return llm.ToolSchema{
+		Type: "object",
+		Properties: map[string]llm.Property{
+			"path": {
+				Type:        "string",
+				Description: "Relative directory path to list. Use '.' for the current directory.",
+			},
+			"depth": {
+				Type:        "integer",
+				Description: "Maximum directory depth to include (default: 2, minimum: 1).",
+			},
+			"include_hidden": {
+				Type:        "boolean",
+				Description: "Whether to include dotfiles and dot-directories. Default: false.",
+			},
+			"offset": {
+				Type:        "integer",
+				Description: "Entry number to start returning from (1-indexed, 0 means from start).",
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "Maximum number of entries to return (defaults to 100, maximum 100).",
+			},
+		},
+	}
+}
+
+type listDirParams struct {
+	Path          string `json:"path"`
+	Depth         int    `json:"depth"`
+	IncludeHidden bool   `json:"include_hidden"`
+	Offset        int    `json:"offset"`
+	Limit         int    `json:"limit"`
+}
+
+type listDirEntry struct {
+	display string
+	sortKey string
+}
+
+// Execute executes the list_dir tool.
+func (t *ListDirTool) Execute(ctx context.Context, params json.RawMessage) (*tools.Result, error) {
+	var p listDirParams
+	if err := tools.ParseParams(params, &p); err != nil {
+		return tools.ErrorResult(err), nil
+	}
+
+	basePath := "."
+	if strings.TrimSpace(p.Path) != "" {
+		basePath = strings.TrimSpace(p.Path)
+	}
+	fullPath, err := resolveSafePath(t.workDir, basePath)
+	if err != nil {
+		return tools.ErrorResult(err), nil
+	}
+
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return tools.ErrorResultf("path not found: %s", basePath), nil
+		}
+		return tools.ErrorResult(err), nil
+	}
+	if !info.IsDir() {
+		return tools.ErrorResultf("path is not a directory: %s", basePath), nil
+	}
+
+	depth := p.Depth
+	if depth <= 0 {
+		depth = 2
+	}
+
+	entries, err := t.collectEntries(fullPath, depth, p.IncludeHidden)
+	if err != nil {
+		return tools.ErrorResult(err), nil
+	}
+	if len(entries) == 0 {
+		return tools.StringResultWithSummary("No entries found", "0 entries"), nil
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].sortKey < entries[j].sortKey
+	})
+
+	lines := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		lines = append(lines, entry.display)
+	}
+
+	effectiveLimit := normalizeSearchResultLimit(p.Limit)
+	totalEntries := len(lines)
+	lines = sliceWithOffsetLimit(lines, p.Offset, effectiveLimit)
+
+	summary := pagedSearchSummary(totalEntries, p.Offset, len(lines), "entries")
+	result := buildSearchResultContent(summary, lines)
+	return tools.StringResultWithSummary(result, summary), nil
+}
+
+func (t *ListDirTool) collectEntries(root string, maxDepth int, includeHidden bool) ([]listDirEntry, error) {
+	var entries []listDirEntry
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+
+		name := d.Name()
+		if isIgnoredGitName(name) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !includeHidden && strings.HasPrefix(name, ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		relPath, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		depth := strings.Count(filepath.ToSlash(relPath), "/") + 1
+		if depth > maxDepth {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		display := filepath.ToSlash(relPath)
+		if d.IsDir() {
+			display += "/"
+		}
+		entries = append(entries, listDirEntry{
+			display: display,
+			sortKey: display,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}

--- a/tools/fs/list_dir_test.go
+++ b/tools/fs/list_dir_test.go
@@ -1,0 +1,94 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListDirToolListsFilesAndDirectories(t *testing.T) {
+	workDir := t.TempDir()
+	mustWriteTestFile(t, filepath.Join(workDir, "README.md"), "# readme\n")
+	mustWriteTestFile(t, filepath.Join(workDir, "cmd", "main.go"), "package main\n")
+
+	params, err := json.Marshal(map[string]any{
+		"path":  ".",
+		"depth": 2,
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	result, err := NewListDirTool(workDir).Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute result error = %v, want nil", result.Error)
+	}
+	if !strings.Contains(result.Content, "README.md") {
+		t.Fatalf("list_dir content = %q, want README.md", result.Content)
+	}
+	if !strings.Contains(result.Content, "cmd/") {
+		t.Fatalf("list_dir content = %q, want cmd/", result.Content)
+	}
+	if !strings.Contains(result.Content, "main.go") {
+		t.Fatalf("list_dir content = %q, want nested main.go", result.Content)
+	}
+}
+
+func TestListDirToolRespectsDepth(t *testing.T) {
+	workDir := t.TempDir()
+	mustWriteTestFile(t, filepath.Join(workDir, "pkg", "inner", "leaf.txt"), "x")
+
+	params, err := json.Marshal(map[string]any{
+		"path":  ".",
+		"depth": 1,
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	result, err := NewListDirTool(workDir).Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute result error = %v, want nil", result.Error)
+	}
+	if !strings.Contains(result.Content, "pkg/") {
+		t.Fatalf("list_dir content = %q, want pkg/", result.Content)
+	}
+	if strings.Contains(result.Content, "leaf.txt") {
+		t.Fatalf("list_dir content = %q, should not include depth-2 file", result.Content)
+	}
+}
+
+func TestListDirToolHidesDotEntriesByDefault(t *testing.T) {
+	workDir := t.TempDir()
+	mustWriteTestFile(t, filepath.Join(workDir, ".env"), "token=x\n")
+	mustWriteTestFile(t, filepath.Join(workDir, "visible.txt"), "x\n")
+
+	params, err := json.Marshal(map[string]any{
+		"path": ".",
+	})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	result, err := NewListDirTool(workDir).Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute result error = %v, want nil", result.Error)
+	}
+	if strings.Contains(result.Content, ".env") {
+		t.Fatalf("list_dir content = %q, should hide dotfiles by default", result.Content)
+	}
+	if !strings.Contains(result.Content, "visible.txt") {
+		t.Fatalf("list_dir content = %q, want visible.txt", result.Content)
+	}
+}

--- a/tools/fs/read.go
+++ b/tools/fs/read.go
@@ -29,7 +29,7 @@ func (t *ReadTool) Name() string {
 
 // Description returns the tool description.
 func (t *ReadTool) Description() string {
-	return "Read the contents of a file. Use this when you need to examine file contents."
+	return "Read the contents of a file when you already know the exact file path. To read files use read instead of cat, head, tail, or sed. Prefer list_dir to inspect directory structure, glob to find files by path pattern, and grep to search file contents across files."
 }
 
 // Schema returns the tool parameter schema.

--- a/tools/fs/write.go
+++ b/tools/fs/write.go
@@ -29,7 +29,7 @@ func (t *WriteTool) Name() string {
 
 // Description returns the tool description.
 func (t *WriteTool) Description() string {
-	return "Create a new file or overwrite an existing file with new content. Arguments must be a JSON object containing required fields path and content."
+	return "Create a new file or overwrite an existing file with full new content. To create files use write instead of cat with heredoc or echo redirection. Use this only for file authoring. Arguments must be a JSON object containing the exact required fields path and content. Do not use file_path or filename unless handling legacy compatibility, and do not use shell redirection, tee, or heredoc to create files instead of write."
 }
 
 // Schema returns the tool parameter schema.

--- a/tools/shell/description_test.go
+++ b/tools/shell/description_test.go
@@ -1,0 +1,21 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShellToolDescriptionIncludesDedicatedToolGuidance(t *testing.T) {
+	t.Parallel()
+
+	got := NewShellTool(nil).Description()
+
+	for _, want := range []string{
+		"Reserve using the shell exclusively for system commands and terminal operations that require shell execution",
+		"Do not use shell redirection, heredoc, tee, sed -i, or similar patterns to create or edit files",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("shell description missing %q: %q", want, got)
+		}
+	}
+}

--- a/tools/shell/shell.go
+++ b/tools/shell/shell.go
@@ -32,7 +32,7 @@ func (t *ShellTool) Name() string {
 
 // Description returns the tool description.
 func (t *ShellTool) Description() string {
-	return "Execute a shell command. Use this for running tests, building, git operations, etc. Commands have a timeout and destructive operations may require confirmation."
+	return "Execute a shell command for tasks that truly require a shell, such as running tests, builds, git commands, or launching programs. Reserve using the shell exclusively for system commands and terminal operations that require shell execution. If you are unsure and there is a relevant dedicated tool, default to using the dedicated tool and only fallback on using the shell if it is absolutely necessary. Prefer dedicated tools for file reading, file discovery, directory structure exploration, and file editing. Do not use shell redirection, heredoc, tee, sed -i, or similar patterns to create or edit files when write or edit can do the job."
 }
 
 // Schema returns the tool parameter schema.

--- a/ui/app.go
+++ b/ui/app.go
@@ -1196,6 +1196,18 @@ func (a App) handleEvent(ev model.Event) (tea.Model, tea.Cmd) {
 			Display: model.DisplayCollapsed, Content: ev.Message, Summary: ev.Summary,
 		})
 
+	case model.ToolListDir:
+		a.replayWait = nil
+		a.backgroundModelWork = false
+		a.state = a.clearThinking()
+		stats := a.state.Stats
+		stats.Searches++
+		a.state = a.state.WithStats(stats)
+		a.state = a.resolveToolEvent(ev, model.Message{
+			Kind: model.MsgTool, ToolName: "List", ToolArgs: ev.Message,
+			Display: model.DisplayCollapsed, Content: ev.Message, Summary: ev.Summary,
+		})
+
 	case model.ToolGlob:
 		a.replayWait = nil
 		a.backgroundModelWork = false
@@ -2618,7 +2630,7 @@ func finalizeToolMessage(pending model.Message, ev model.Event) model.Message {
 			Summary:    firstNonEmpty(ev.Summary, pending.Summary),
 			Meta:       firstNonNilMeta(ev.Meta, pending.Meta),
 		}
-	case model.ToolGrep, model.ToolGlob, model.ToolSkill:
+	case model.ToolGrep, model.ToolListDir, model.ToolGlob, model.ToolSkill:
 		return model.Message{
 			Kind:       model.MsgTool,
 			ToolName:   pending.ToolName,
@@ -2704,6 +2716,8 @@ func displayToolName(name string) string {
 		return "Read"
 	case "grep":
 		return "Grep"
+	case "list_dir":
+		return "List"
 	case "glob":
 		return "Glob"
 	case "edit":

--- a/ui/inline.go
+++ b/ui/inline.go
@@ -514,7 +514,7 @@ func (a App) eventPrintCmd(ev model.Event, prevMessages []model.Message) tea.Cmd
 		return nil
 	case model.CmdFinished:
 		return a.printResolvedTool(ev)
-	case model.ToolRead, model.ToolGrep, model.ToolGlob, model.ToolEdit, model.ToolWrite, model.ToolSkill, model.ToolInterrupted, model.ToolWarning, model.ToolError, model.ToolReplay:
+	case model.ToolRead, model.ToolGrep, model.ToolListDir, model.ToolGlob, model.ToolEdit, model.ToolWrite, model.ToolSkill, model.ToolInterrupted, model.ToolWarning, model.ToolError, model.ToolReplay:
 		return a.printResolvedTool(ev)
 	case model.ClearScreen:
 		return clearMessage()

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -87,6 +87,7 @@ const (
 	TokenUpdate          EventType = "TokenUpdate"
 	ToolRead             EventType = "ToolRead"
 	ToolGrep             EventType = "ToolGrep"
+	ToolListDir          EventType = "ToolListDir"
 	ToolGlob             EventType = "ToolGlob"
 	ToolEdit             EventType = "ToolEdit"
 	ToolWrite            EventType = "ToolWrite"


### PR DESCRIPTION
> [!dev-notes]
>
> **Explore功能的针对性体验优化**
> - (P1)工具调用参数不准确，相同工具需要多次调用才能返回结果：现有工具提示词优化。提升一次性命中率
> - (P1)只读权限的目录探索工具缺失，需多次向用户申请授权打断流程：Bash:ls/tree/find/...放权 | ListTool新增。降低read-only工作流中的权限申请

  这个 PR 优化了 agent 的工具使用体验，主要集中在三方面：

  - 提升常见文件与代码库任务的一次性命中率
  - 降低只读探索场景中的不必要权限打断
  - 让权限被拒绝后的行为更安全、更符合预期

  ## 改动
### 工具系统

  - 新增了 list_dir 工具，用于只读目录结构探索，避免“总结代码结构”时优先走 bash ls/find/tree。
  - 修复了 glob("**/train.py") 漏掉根目录 ./train.py 的问题，现在会正确匹配当前目录下的 train.py。
  - 在权限层增加了 shell 意图分类：
      - 只读探索命令单独识别
      - shell 写文件代理命令单独识别
  - 当 write/edit 被拒绝时，shell 的 cat <<EOF、重定向、tee 等写文件回退会被拦住，不能再绕过专用写工具。

  ### 提示词与工具描述

  - 把 Claude Code 风格的 dedicated-tool 指引迁进了 mscli：
      - read 替代 cat/head/tail/sed
      - edit 替代 sed/awk
      - write 替代 cat <<EOF / echo > file
      - glob 替代 find/ls
      - grep 用于内容搜索
      - shell 只保留给确实需要 shell 的场景
  - 这些具体指引后来从 system prompt 下沉到了各工具自己的 Description()，system prompt 只保留高层规则。
  - system prompt 额外补了一条高层约束：
      - 如果用户拒绝了某个工具权限，不要尝试用别的工具或 shell pattern 绕过。

  ### 拒绝权限后的行为

  - write 被用户拒绝后，写回给 LLM 的 tool result 不再是简单的 Permission denied for tool: write。
  - 现在改成 Claude Code 风格的拒绝引导，核心意思是：
      - 这次 tool use 被拒绝了
      - 不要继续当前动作
      - 要去问用户下一步怎么做

  ## 用户可感知的变化

  ### 1. 工具选择更准确，减少重复尝试

  agent 现在更容易在第一次就选对工具，而不是在相似工具之间来回切换，或者因为参数不准而多次重试。

  例如：

  - 询问“总结当前目录的代码结构”时，现在会优先使用专门的目录探索工具，而不是默认退回到 shell 命令
  - 询问当前目录是否存在 train.py 时，之前Glob(**/train.py)无法一次性命中，现在也能正确命中

  ### 2. 只读探索流程更顺畅，权限弹窗更少

  当用户只是想查看仓库结构、了解目录布局、做代码阅读时，流程中的权限申请会明显减少。

  例如：

  - “总结当前目录结构”
  - “当前目录有哪些文件”
  - “帮我看看这个代码库的大致布局”

  这些只读场景不再默认依赖 ls/find/tree 这类 shell 命令，因此减少了探索过程中的打断。

  ### 3. 写权限被拒绝后，agent 的行为更安全

  当用户拒绝文件写入权限后，agent 现在会更明确地停下来并询问下一步怎么做，而不是继续尝试通过 shell 写文件来绕过限制。

  这类不希望再出现的行为包括：

  - cat <<EOF > file
  - 各类重定向写文件
  - 在 write 被拒绝后继续寻找 shell 写入替代路径

  新的行为让 agent 能更清楚地尊重用户的权限决策，避免出现“明明拒绝了写权限，结果它还是继续尝试写”的体验。

  ## 已改善的典型场景

  - 为我总结当前目录的代码结构
  - 当前目录是否有 train.py 文件
  - 帮我写一个 markdown 文档，并且用户拒绝写权限

  ## 整体效果

  这次改动会让 agent 在体验上更接近下面这些预期：

  - 第一次就更容易做对
  - 只读场景下不再频繁打断用户
  - 当用户拒绝权限时，行为更可信、更可控

  ## 验证

  本次改动已经通过针对性的工具系统与回归测试覆盖，包括：

  - 根目录 train.py 的匹配问题
  - 只读目录结构探索场景
  - 拒绝 write 后阻止 shell 写文件回退
  - 权限拒绝后的后续引导行为