### PR TITLE
feat: add AskUserQuestion tool flow

### DIFF
--- a/agent/loop/engine.go
+++ b/agent/loop/engine.go
@@ -579,6 +579,7 @@ var toolEventMap = map[string]string{
 	"write":      EventToolWrite,
 	"shell":      EventCmdFinished,
 	"load_skill": EventToolSkill,
+	"AskUserQuestion": EventToolAskUserQuestion,
 }
 
 func (ex *executor) addStreamingToolEvent(toolName, toolCallID string, update tools.StreamEvent) {
@@ -809,13 +810,47 @@ func describeToolCall(toolName string, raw json.RawMessage) string {
 		}
 	case "load_skill":
 		return getString("name")
-	default:
-		preview := strings.TrimSpace(string(raw))
-		if preview == "" {
-			return toolName
+	case "AskUserQuestion":
+		type questionArg struct {
+			Header   string `json:"header"`
+			Question string `json:"question"`
 		}
-		return preview
+		var args struct {
+			Questions []questionArg `json:"questions"`
+		}
+		if err := json.Unmarshal(raw, &args); err == nil {
+			parts := make([]string, 0, len(args.Questions))
+			for _, question := range args.Questions {
+				if header := strings.TrimSpace(question.Header); header != "" {
+					parts = append(parts, header)
+					continue
+				}
+				if text := strings.TrimSpace(question.Question); text != "" {
+					parts = append(parts, text)
+				}
+			}
+			switch len(parts) {
+			case 0:
+				switch count := len(args.Questions); count {
+				case 1:
+					return "1 question"
+				case 0:
+				default:
+					return fmt.Sprintf("%d questions", count)
+				}
+			case 1:
+				return parts[0]
+			default:
+				return fmt.Sprintf("%s (+%d more)", parts[0], len(parts)-1)
+			}
+		}
 	}
+
+	preview := strings.TrimSpace(string(raw))
+	if preview == "" {
+		return toolName
+	}
+	return preview
 }
 
 func DefaultSystemPrompt() string {
@@ -830,6 +865,7 @@ You have access to the following tools:
 - grep: Search for patterns in files
 - glob: Find files matching patterns
 - shell: Execute shell commands
+- AskUserQuestion: Ask the user clarifying multiple-choice questions
 - load_skill: Load a skill's detailed instructions. Call this when the user's task matches an available skill listed below.
 
 Guidelines:
@@ -842,6 +878,7 @@ Guidelines:
 7. Never call write with empty JSON arguments ({}).
 8. When a user describes a training problem (failure, accuracy, performance), load the appropriate diagnosis skill.
 9. When a user asks to migrate or port a model, load migrate-agent.
+10. If you are blocked on user preferences, ambiguous requirements, or implementation choices, use AskUserQuestion instead of guessing.
 
 IMPORTANT: When you have gathered enough information to answer the user's question, you MUST provide your final answer directly WITHOUT using any more tools. Do not keep calling tools indefinitely - provide a clear, concise response once you have the information needed.
 

--- a/agent/loop/engine.go
+++ b/agent/loop/engine.go
@@ -879,6 +879,7 @@ Guidelines:
 8. When a user describes a training problem (failure, accuracy, performance), load the appropriate diagnosis skill.
 9. When a user asks to migrate or port a model, load migrate-agent.
 10. If you are blocked on user preferences, ambiguous requirements, or implementation choices, use AskUserQuestion instead of guessing.
+11. When using AskUserQuestion, pass one to four concrete options and never add an explicit Other or manual-input option because the UI provides Other automatically.
 
 IMPORTANT: When you have gathered enough information to answer the user's question, you MUST provide your final answer directly WITHOUT using any more tools. Do not keep calling tools indefinitely - provide a clear, concise response once you have the information needed.
 

--- a/agent/loop/engine.go
+++ b/agent/loop/engine.go
@@ -879,7 +879,7 @@ Guidelines:
 8. When a user describes a training problem (failure, accuracy, performance), load the appropriate diagnosis skill.
 9. When a user asks to migrate or port a model, load migrate-agent.
 10. If you are blocked on user preferences, ambiguous requirements, or implementation choices, use AskUserQuestion instead of guessing.
-11. When using AskUserQuestion, pass one to four concrete options and never add an explicit Other or manual-input option because the UI provides Other automatically.
+11. When using AskUserQuestion, pass one to four concrete options and never add an explicit Other or manual-input option because the UI already provides a built-in custom-input path.
 
 IMPORTANT: When you have gathered enough information to answer the user's question, you MUST provide your final answer directly WITHOUT using any more tools. Do not keep calling tools indefinitely - provide a clear, concise response once you have the information needed.
 

--- a/agent/loop/types.go
+++ b/agent/loop/types.go
@@ -72,6 +72,7 @@ const (
 	EventToolEdit            = "ToolEdit"
 	EventToolWrite           = "ToolWrite"
 	EventToolSkill           = "ToolSkill"
+	EventToolAskUserQuestion = "ToolAskUserQuestion"
 	EventAnalysisReady       = "AnalysisReady"
 	EventDone                = "Done"
 )

--- a/integrations/llm/provider.go
+++ b/integrations/llm/provider.go
@@ -85,9 +85,12 @@ type ToolSchema struct {
 
 // Property represents a property in the tool schema.
 type Property struct {
-	Type        string   `json:"type"`
-	Description string   `json:"description"`
-	Enum        []string `json:"enum,omitempty"`
+	Type        string              `json:"type"`
+	Description string              `json:"description"`
+	Enum        []string            `json:"enum,omitempty"`
+	Properties  map[string]Property `json:"properties,omitempty"`
+	Required    []string            `json:"required,omitempty"`
+	Items       *Property           `json:"items,omitempty"`
 }
 
 // ToolCall represents a tool call request from the model.

--- a/internal/app/ask_user_question_ui.go
+++ b/internal/app/ask_user_question_ui.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	askuserquestion "github.com/mindspore-lab/mindspore-cli/tools/ask_user_question"
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+const askUserQuestionInputPrefix = "\x00ask_user_question:"
+
+// AskUserQuestionPromptUI bridges interactive question prompts into the TUI flow.
+type AskUserQuestionPromptUI struct {
+	mu      sync.Mutex
+	pending *pendingAskUserQuestionRequest
+	eventCh chan<- model.Event
+}
+
+type pendingAskUserQuestionRequest struct {
+	wait chan askuserquestion.PromptResponse
+}
+
+func NewAskUserQuestionPromptUI(eventCh chan<- model.Event) *AskUserQuestionPromptUI {
+	return &AskUserQuestionPromptUI{eventCh: eventCh}
+}
+
+func (p *AskUserQuestionPromptUI) Ask(ctx context.Context, req askuserquestion.PromptRequest) (askuserquestion.PromptResponse, error) {
+	p.mu.Lock()
+	if p.pending != nil {
+		p.mu.Unlock()
+		return askuserquestion.PromptResponse{}, fmt.Errorf("question prompt already pending")
+	}
+	pending := &pendingAskUserQuestionRequest{
+		wait: make(chan askuserquestion.PromptResponse, 1),
+	}
+	p.pending = pending
+	p.mu.Unlock()
+
+	p.eventCh <- model.Event{
+		Type:            model.AskUserQuestionPrompt,
+		AskUserQuestion: buildAskUserQuestionPromptData(req),
+	}
+
+	select {
+	case resp := <-pending.wait:
+		return resp, nil
+	case <-ctx.Done():
+		p.clearPending(pending)
+		p.eventCh <- model.Event{Type: model.AskUserQuestionClose}
+		return askuserquestion.PromptResponse{}, ctx.Err()
+	}
+}
+
+// HandleInput resolves the active prompt when the UI submits a serialized response.
+func (p *AskUserQuestionPromptUI) HandleInput(input string) bool {
+	if !strings.HasPrefix(input, askUserQuestionInputPrefix) {
+		return false
+	}
+
+	p.mu.Lock()
+	pending := p.pending
+	if pending != nil {
+		p.pending = nil
+	}
+	p.mu.Unlock()
+	if pending == nil {
+		return true
+	}
+
+	var resp askuserquestion.PromptResponse
+	raw := strings.TrimPrefix(input, askUserQuestionInputPrefix)
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		resp = askuserquestion.PromptResponse{Declined: true}
+	}
+	pending.wait <- resp
+	return true
+}
+
+func (p *AskUserQuestionPromptUI) clearPending(target *pendingAskUserQuestionRequest) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pending == target {
+		p.pending = nil
+	}
+}
+
+func buildAskUserQuestionPromptData(req askuserquestion.PromptRequest) *model.AskUserQuestionPromptData {
+	questions := make([]model.AskUserQuestionView, 0, len(req.Questions))
+	for _, question := range req.Questions {
+		options := make([]model.AskUserQuestionOption, 0, len(question.Options))
+		for _, option := range question.Options {
+			options = append(options, model.AskUserQuestionOption{
+				Label:       option.Label,
+				Description: option.Description,
+			})
+		}
+		questions = append(questions, model.AskUserQuestionView{
+			Header:      question.Header,
+			Question:    question.Question,
+			Options:     options,
+			MultiSelect: question.MultiSelect,
+		})
+	}
+
+	return &model.AskUserQuestionPromptData{
+		Title:        "Answer Questions",
+		SubmitPrefix: askUserQuestionInputPrefix,
+		Questions:    questions,
+	}
+}

--- a/internal/app/ask_user_question_ui_test.go
+++ b/internal/app/ask_user_question_ui_test.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	askuserquestion "github.com/mindspore-lab/mindspore-cli/tools/ask_user_question"
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+func TestAskUserQuestionPromptUI_AskAndHandleInput(t *testing.T) {
+	eventCh := make(chan model.Event, 2)
+	ui := NewAskUserQuestionPromptUI(eventCh)
+
+	req := askuserquestion.PromptRequest{
+		Questions: []askuserquestion.Question{{
+			Header:   "Scope",
+			Question: "Which scope should we optimize first?",
+			Options: []askuserquestion.QuestionOption{
+				{Label: "backend", Description: "Optimize backend first"},
+				{Label: "frontend", Description: "Optimize frontend first"},
+			},
+		}},
+	}
+
+	resultCh := make(chan struct {
+		resp askuserquestion.PromptResponse
+		err  error
+	}, 1)
+	go func() {
+		resp, err := ui.Ask(context.Background(), req)
+		resultCh <- struct {
+			resp askuserquestion.PromptResponse
+			err  error
+		}{resp: resp, err: err}
+	}()
+
+	select {
+	case ev := <-eventCh:
+		if ev.Type != model.AskUserQuestionPrompt {
+			t.Fatalf("event type = %s, want %s", ev.Type, model.AskUserQuestionPrompt)
+		}
+		if ev.AskUserQuestion == nil {
+			t.Fatal("event.AskUserQuestion = nil, want prompt payload")
+		}
+		if got := ev.AskUserQuestion.Title; got != "Answer Questions" {
+			t.Fatalf("prompt title = %q, want %q", got, "Answer Questions")
+		}
+		if got := len(ev.AskUserQuestion.Questions); got != 1 {
+			t.Fatalf("question count = %d, want 1", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ask-user-question prompt event")
+	}
+
+	if handled := ui.HandleInput(askUserQuestionInputPrefix + `{"answers":[{"question":"Which scope should we optimize first?","answer":"frontend"}]}`); !handled {
+		t.Fatal("HandleInput() = false, want true for serialized prompt response")
+	}
+
+	select {
+	case out := <-resultCh:
+		if out.err != nil {
+			t.Fatalf("Ask() err = %v", out.err)
+		}
+		if out.resp.Declined {
+			t.Fatal("Ask() declined = true, want false")
+		}
+		if got := len(out.resp.Answers); got != 1 {
+			t.Fatalf("answer count = %d, want 1", got)
+		}
+		if got := out.resp.Answers[0].Answer; got != "frontend" {
+			t.Fatalf("answer = %q, want %q", got, "frontend")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Ask() result")
+	}
+}
+
+func TestAskUserQuestionPromptUI_HandleMalformedPayloadDeclines(t *testing.T) {
+	eventCh := make(chan model.Event, 1)
+	ui := NewAskUserQuestionPromptUI(eventCh)
+
+	resultCh := make(chan askuserquestion.PromptResponse, 1)
+	go func() {
+		resp, _ := ui.Ask(context.Background(), askuserquestion.PromptRequest{
+			Questions: []askuserquestion.Question{{
+				Header:   "Tests",
+				Question: "Which tests should we add?",
+				Options: []askuserquestion.QuestionOption{
+					{Label: "unit", Description: "Add unit tests"},
+					{Label: "integration", Description: "Add integration tests"},
+				},
+			}},
+		})
+		resultCh <- resp
+	}()
+
+	<-eventCh
+	if handled := ui.HandleInput(askUserQuestionInputPrefix + "{bad json"); !handled {
+		t.Fatal("HandleInput() = false, want true for malformed prefixed payload")
+	}
+
+	select {
+	case resp := <-resultCh:
+		if !resp.Declined {
+			t.Fatal("resp.Declined = false, want true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for declined response")
+	}
+}
+
+func TestApplicationProcessInput_AskUserQuestionReplyPriority(t *testing.T) {
+	app := &Application{
+		EventCh: make(chan model.Event, 2),
+	}
+	app.questionUI = NewAskUserQuestionPromptUI(app.EventCh)
+
+	resultCh := make(chan askuserquestion.PromptResponse, 1)
+	go func() {
+		resp, _ := app.questionUI.Ask(context.Background(), askuserquestion.PromptRequest{
+			Questions: []askuserquestion.Question{{
+				Header:   "Scope",
+				Question: "Which scope should we optimize first?",
+				Options: []askuserquestion.QuestionOption{
+					{Label: "backend", Description: "Optimize backend first"},
+					{Label: "frontend", Description: "Optimize frontend first"},
+				},
+			}},
+		})
+		resultCh <- resp
+	}()
+
+	select {
+	case <-app.EventCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for question prompt")
+	}
+
+	app.processInput(askUserQuestionInputPrefix + `{"declined":true}`)
+
+	select {
+	case resp := <-resultCh:
+		if !resp.Declined {
+			t.Fatal("resp.Declined = false, want true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for processInput to resolve question prompt")
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -186,6 +186,9 @@ func (a *Application) processInput(input string) {
 	if a.permissionUI != nil && a.permissionUI.HandleInput(trimmed) {
 		return
 	}
+	if a.questionUI != nil && a.questionUI.HandleInput(trimmed) {
+		return
+	}
 
 	if strings.HasPrefix(trimmed, modelSetupToken+" ") {
 		parts := strings.Fields(trimmed)
@@ -692,6 +695,7 @@ var loopEventTypeMap = map[string]model.EventType{
 	"ToolEdit":            model.ToolEdit,
 	"ToolWrite":           model.ToolWrite,
 	"ToolSkill":           model.ToolSkill,
+	"ToolAskUserQuestion": model.ToolAskUserQuestion,
 	"ToolError":           model.ToolError,
 	"ToolInterrupted":     model.ToolInterrupted,
 	"CmdStarted":          model.CmdStarted,

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mindspore-lab/mindspore-cli/permission"
 	rshell "github.com/mindspore-lab/mindspore-cli/runtime/shell"
 	"github.com/mindspore-lab/mindspore-cli/tools"
+	askuserquestion "github.com/mindspore-lab/mindspore-cli/tools/ask_user_question"
 	"github.com/mindspore-lab/mindspore-cli/tools/fs"
 	"github.com/mindspore-lab/mindspore-cli/tools/shell"
 	skillstool "github.com/mindspore-lab/mindspore-cli/tools/skills"
@@ -53,6 +54,7 @@ type Application struct {
 	ctxManager              *agentctx.Manager
 	permService             permission.PermissionService
 	permissionUI            *PermissionPromptUI
+	questionUI              *AskUserQuestionPromptUI
 	permissionSettingsIssue *permissionSettingsIssue
 	session                 *session.Session
 	replayBacklog           []model.Event
@@ -287,7 +289,9 @@ func Wire(cfg BootstrapConfig) (*Application, error) {
 	engine.SetLLMDebugDumper(llmDebugDumper)
 	permService := permission.NewDefaultPermissionService(config.Permissions)
 	permissionUI := NewPermissionPromptUI(eventCh)
+	questionUI := NewAskUserQuestionPromptUI(eventCh)
 	permService.SetUI(permissionUI)
+	toolRegistry.MustRegister(askuserquestion.NewTool(questionUI))
 	var (
 		permSettingsIssue *permissionSettingsIssue
 		sessionStoreReady bool
@@ -324,6 +328,7 @@ func Wire(cfg BootstrapConfig) (*Application, error) {
 		ctxManager:              ctxManager,
 		permService:             permService,
 		permissionUI:            permissionUI,
+		questionUI:              questionUI,
 		permissionSettingsIssue: permSettingsIssue,
 		session:                 runtimeSession,
 		replayBacklog:           replayBacklog,

--- a/permission/service.go
+++ b/permission/service.go
@@ -312,6 +312,10 @@ func (s *DefaultPermissionService) Check(tool, action string) PermissionLevel {
 		return level
 	}
 
+	if strings.EqualFold(strings.TrimSpace(tool), "AskUserQuestion") {
+		return PermissionAllowAlways
+	}
+
 	// Check read/write patterns
 	if tool == "read" || tool == "glob" {
 		return PermissionAllowAlways

--- a/permission/service_test.go
+++ b/permission/service_test.go
@@ -150,6 +150,24 @@ func TestRuleConfig_BashOperatorAwareMatching(t *testing.T) {
 	}
 }
 
+func TestAskUserQuestion_DefaultAllowButExplicitRulesStillApply(t *testing.T) {
+	svc := NewDefaultPermissionService(configs.PermissionsConfig{
+		DefaultLevel: "ask",
+		Deny:         []string{"AskUserQuestion"},
+	})
+
+	if got := svc.Check("AskUserQuestion", ""); got != PermissionDeny {
+		t.Fatalf("Check(AskUserQuestion) = %v, want %v with explicit deny rule", got, PermissionDeny)
+	}
+
+	plain := NewDefaultPermissionService(configs.PermissionsConfig{
+		DefaultLevel: "ask",
+	})
+	if got := plain.Check("AskUserQuestion", ""); got != PermissionAllowAlways {
+		t.Fatalf("default Check(AskUserQuestion) = %v, want %v", got, PermissionAllowAlways)
+	}
+}
+
 func TestRuleConfig_BashFindPatternMatchesQuoteAndGroupingVariants(t *testing.T) {
 	svc := NewDefaultPermissionService(configs.PermissionsConfig{
 		DefaultLevel: "ask",

--- a/tools/ask_user_question/ask_user_question.go
+++ b/tools/ask_user_question/ask_user_question.go
@@ -64,7 +64,7 @@ func (t *Tool) Name() string {
 
 // Description returns the tool description for the model.
 func (t *Tool) Description() string {
-	return "Ask the user one to four multiple-choice questions to clarify requirements, gather preferences, or choose between implementation options. Users can always pick Other to provide custom text."
+	return "Ask the user one to four multiple-choice questions to clarify requirements, gather preferences, or choose between implementation options. Provide one to four concrete options per question and never add an explicit Other/manual-input option because the UI always provides Other for custom text."
 }
 
 // Schema returns the nested JSON schema used for tool calling.
@@ -97,7 +97,7 @@ func (t *Tool) Schema() llm.ToolSchema {
 			},
 			"options": {
 				Type:        "array",
-				Description: "Two to four options for the user to choose from.",
+				Description: "One to four concrete options for the user to choose from. Do not include an explicit Other or manual-input option because the UI adds Other automatically.",
 				Items:       &optionSchema,
 			},
 			"multiSelect": {
@@ -127,6 +127,7 @@ func (t *Tool) Execute(ctx context.Context, params json.RawMessage) (*tools.Resu
 	if err := tools.ParseParams(params, &req); err != nil {
 		return tools.ErrorResult(err), nil
 	}
+	req = normalizeRequest(req)
 	if err := validateRequest(req); err != nil {
 		return tools.ErrorResult(err), nil
 	}
@@ -167,6 +168,60 @@ func (t *Tool) Execute(ctx context.Context, params json.RawMessage) (*tools.Resu
 	return tools.StringResultWithSummary(strings.Join(lines, "\n"), summary), nil
 }
 
+func normalizeRequest(req PromptRequest) PromptRequest {
+	normalized := PromptRequest{
+		Questions: make([]Question, 0, len(req.Questions)),
+	}
+	for _, question := range req.Questions {
+		normalized = appendNormalizedQuestion(normalized, question)
+	}
+	return normalized
+}
+
+func appendNormalizedQuestion(req PromptRequest, question Question) PromptRequest {
+	req.Questions = append(req.Questions, Question{
+		Header:      strings.TrimSpace(question.Header),
+		Question:    strings.TrimSpace(question.Question),
+		Options:     normalizeQuestionOptions(question.Options),
+		MultiSelect: question.MultiSelect,
+	})
+	return req
+}
+
+func normalizeQuestionOptions(options []QuestionOption) []QuestionOption {
+	normalized := make([]QuestionOption, 0, len(options))
+	for _, option := range options {
+		label := strings.TrimSpace(option.Label)
+		description := strings.TrimSpace(option.Description)
+		if isBuiltInOtherOption(label, description) {
+			continue
+		}
+		normalized = append(normalized, QuestionOption{
+			Label:       label,
+			Description: description,
+		})
+	}
+	return normalized
+}
+
+func isBuiltInOtherOption(label, description string) bool {
+	normalizedLabel := normalizeOptionToken(label)
+	switch normalizedLabel {
+	case "other", "use manual input", "manual input", "manual entry", "enter a custom value manually", "custom input":
+		return true
+	}
+
+	normalizedDescription := normalizeOptionToken(description)
+	return strings.HasPrefix(normalizedLabel, "other") && (strings.Contains(normalizedDescription, "custom") || strings.Contains(normalizedDescription, "manual"))
+}
+
+func normalizeOptionToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	replacer := strings.NewReplacer("-", " ", "_", " ", "/", " ", "(", " ", ")", " ", ",", " ", ".", " ", ":", " ")
+	value = replacer.Replace(value)
+	return strings.Join(strings.Fields(value), " ")
+}
+
 func validateRequest(req PromptRequest) error {
 	if len(req.Questions) < 1 || len(req.Questions) > 4 {
 		return fmt.Errorf("questions must contain 1 to 4 entries")
@@ -186,8 +241,8 @@ func validateRequest(req PromptRequest) error {
 		}
 		seenQuestions[text] = struct{}{}
 
-		if len(question.Options) < 2 || len(question.Options) > 4 {
-			return fmt.Errorf("questions[%d].options must contain 2 to 4 entries", i)
+		if len(question.Options) < 1 || len(question.Options) > 4 {
+			return fmt.Errorf("questions[%d].options must contain 1 to 4 concrete entries", i)
 		}
 
 		seenLabels := make(map[string]struct{}, len(question.Options))

--- a/tools/ask_user_question/ask_user_question.go
+++ b/tools/ask_user_question/ask_user_question.go
@@ -1,0 +1,210 @@
+package askuserquestion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mindspore-lab/mindspore-cli/integrations/llm"
+	"github.com/mindspore-lab/mindspore-cli/tools"
+)
+
+// PromptUI collects answers from the user through the application UI.
+type PromptUI interface {
+	Ask(ctx context.Context, req PromptRequest) (PromptResponse, error)
+}
+
+// QuestionOption is a single option shown to the user.
+type QuestionOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// Question describes one question to ask the user.
+type Question struct {
+	Header      string           `json:"header"`
+	Question    string           `json:"question"`
+	Options     []QuestionOption `json:"options"`
+	MultiSelect bool             `json:"multiSelect"`
+}
+
+// PromptRequest is the tool input schema.
+type PromptRequest struct {
+	Questions []Question `json:"questions"`
+}
+
+// PromptAnswer is one final answer returned by the UI.
+type PromptAnswer struct {
+	Question string `json:"question"`
+	Answer   string `json:"answer"`
+}
+
+// PromptResponse is the final question result returned by the UI.
+type PromptResponse struct {
+	Answers  []PromptAnswer `json:"answers"`
+	Declined bool           `json:"declined"`
+}
+
+// Tool asks the user clarifying multiple-choice questions during execution.
+type Tool struct {
+	promptUI PromptUI
+}
+
+// NewTool creates a new AskUserQuestion tool.
+func NewTool(promptUI PromptUI) *Tool {
+	return &Tool{promptUI: promptUI}
+}
+
+// Name returns the tool name.
+func (t *Tool) Name() string {
+	return "AskUserQuestion"
+}
+
+// Description returns the tool description for the model.
+func (t *Tool) Description() string {
+	return "Ask the user one to four multiple-choice questions to clarify requirements, gather preferences, or choose between implementation options. Users can always pick Other to provide custom text."
+}
+
+// Schema returns the nested JSON schema used for tool calling.
+func (t *Tool) Schema() llm.ToolSchema {
+	optionSchema := llm.Property{
+		Type: "object",
+		Properties: map[string]llm.Property{
+			"label": {
+				Type:        "string",
+				Description: "Short label shown for this option. Keep it concise and distinct from the other options.",
+			},
+			"description": {
+				Type:        "string",
+				Description: "One sentence explaining what the option means or what tradeoff it implies.",
+			},
+		},
+		Required: []string{"label", "description"},
+	}
+
+	questionSchema := llm.Property{
+		Type: "object",
+		Properties: map[string]llm.Property{
+			"header": {
+				Type:        "string",
+				Description: "Very short label for this question, such as 'Scope' or 'Tests'.",
+			},
+			"question": {
+				Type:        "string",
+				Description: "The full question to ask the user.",
+			},
+			"options": {
+				Type:        "array",
+				Description: "Two to four options for the user to choose from.",
+				Items:       &optionSchema,
+			},
+			"multiSelect": {
+				Type:        "boolean",
+				Description: "Set true when the user may choose more than one option.",
+			},
+		},
+		Required: []string{"header", "question", "options"},
+	}
+
+	return llm.ToolSchema{
+		Type: "object",
+		Properties: map[string]llm.Property{
+			"questions": {
+				Type:        "array",
+				Description: "One to four questions to ask the user.",
+				Items:       &questionSchema,
+			},
+		},
+		Required: []string{"questions"},
+	}
+}
+
+// Execute asks the user the requested questions and returns the collected answers.
+func (t *Tool) Execute(ctx context.Context, params json.RawMessage) (*tools.Result, error) {
+	var req PromptRequest
+	if err := tools.ParseParams(params, &req); err != nil {
+		return tools.ErrorResult(err), nil
+	}
+	if err := validateRequest(req); err != nil {
+		return tools.ErrorResult(err), nil
+	}
+	if t.promptUI == nil {
+		return tools.ErrorResultf("ask user question ui is not configured"), nil
+	}
+
+	resp, err := t.promptUI.Ask(ctx, req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		return tools.ErrorResultf("ask user: %w", err), nil
+	}
+
+	if resp.Declined {
+		return tools.StringResultWithSummary(
+			"User declined to answer the questions. Continue by making reasonable assumptions based on the current conversation and code context.",
+			"declined",
+		), nil
+	}
+
+	if len(resp.Answers) == 0 {
+		return tools.ErrorResultf("ask user returned no answers"), nil
+	}
+
+	lines := make([]string, 0, len(resp.Answers)+2)
+	lines = append(lines, "User has answered your questions:")
+	for _, answer := range resp.Answers {
+		lines = append(lines, fmt.Sprintf("- %q = %q", answer.Question, answer.Answer))
+	}
+	lines = append(lines, "You can now continue with the user's answers in mind.")
+
+	summary := fmt.Sprintf("%d answers collected", len(resp.Answers))
+	if len(resp.Answers) == 1 {
+		summary = "1 answer collected"
+	}
+	return tools.StringResultWithSummary(strings.Join(lines, "\n"), summary), nil
+}
+
+func validateRequest(req PromptRequest) error {
+	if len(req.Questions) < 1 || len(req.Questions) > 4 {
+		return fmt.Errorf("questions must contain 1 to 4 entries")
+	}
+
+	seenQuestions := make(map[string]struct{}, len(req.Questions))
+	for i, question := range req.Questions {
+		if strings.TrimSpace(question.Header) == "" {
+			return fmt.Errorf("questions[%d].header is required", i)
+		}
+		text := strings.TrimSpace(question.Question)
+		if text == "" {
+			return fmt.Errorf("questions[%d].question is required", i)
+		}
+		if _, exists := seenQuestions[text]; exists {
+			return fmt.Errorf("question text must be unique: %q", text)
+		}
+		seenQuestions[text] = struct{}{}
+
+		if len(question.Options) < 2 || len(question.Options) > 4 {
+			return fmt.Errorf("questions[%d].options must contain 2 to 4 entries", i)
+		}
+
+		seenLabels := make(map[string]struct{}, len(question.Options))
+		for j, option := range question.Options {
+			label := strings.TrimSpace(option.Label)
+			if label == "" {
+				return fmt.Errorf("questions[%d].options[%d].label is required", i, j)
+			}
+			if strings.TrimSpace(option.Description) == "" {
+				return fmt.Errorf("questions[%d].options[%d].description is required", i, j)
+			}
+			if _, exists := seenLabels[label]; exists {
+				return fmt.Errorf("option labels must be unique within question %q", text)
+			}
+			seenLabels[label] = struct{}{}
+		}
+	}
+
+	return nil
+}

--- a/tools/ask_user_question/ask_user_question.go
+++ b/tools/ask_user_question/ask_user_question.go
@@ -64,7 +64,7 @@ func (t *Tool) Name() string {
 
 // Description returns the tool description for the model.
 func (t *Tool) Description() string {
-	return "Ask the user one to four multiple-choice questions to clarify requirements, gather preferences, or choose between implementation options. Provide one to four concrete options per question and never add an explicit Other/manual-input option because the UI always provides Other for custom text."
+	return "Ask the user one to four multiple-choice questions to clarify requirements, gather preferences, or choose between implementation options. Provide one to four concrete options per question and never add an explicit Other/manual-input option because the UI always provides a built-in custom-input path."
 }
 
 // Schema returns the nested JSON schema used for tool calling.
@@ -97,7 +97,7 @@ func (t *Tool) Schema() llm.ToolSchema {
 			},
 			"options": {
 				Type:        "array",
-				Description: "One to four concrete options for the user to choose from. Do not include an explicit Other or manual-input option because the UI adds Other automatically.",
+				Description: "One to four concrete options for the user to choose from. Do not include an explicit Other or manual-input option because the UI already adds a built-in custom-input path.",
 				Items:       &optionSchema,
 			},
 			"multiSelect": {
@@ -191,33 +191,87 @@ func appendNormalizedQuestion(req PromptRequest, question Question) PromptReques
 func normalizeQuestionOptions(options []QuestionOption) []QuestionOption {
 	normalized := make([]QuestionOption, 0, len(options))
 	for _, option := range options {
-		label := strings.TrimSpace(option.Label)
-		description := strings.TrimSpace(option.Description)
-		if isBuiltInOtherOption(label, description) {
+		option, keep := normalizeQuestionOption(option)
+		if !keep {
 			continue
 		}
-		normalized = append(normalized, QuestionOption{
-			Label:       label,
-			Description: description,
-		})
+		normalized = append(normalized, option)
 	}
 	return normalized
 }
 
+func normalizeQuestionOption(option QuestionOption) (QuestionOption, bool) {
+	label := strings.TrimSpace(option.Label)
+	description := strings.TrimSpace(option.Description)
+	if isBuiltInOtherOption(label, description) {
+		return QuestionOption{}, false
+	}
+	return QuestionOption{
+		Label:       label,
+		Description: description,
+	}, true
+}
+
 func isBuiltInOtherOption(label, description string) bool {
-	normalizedLabel := normalizeOptionToken(label)
-	switch normalizedLabel {
-	case "other", "use manual input", "manual input", "manual entry", "enter a custom value manually", "custom input":
-		return true
+	normalizedCombined := normalizeOptionToken(strings.TrimSpace(label + " " + description))
+	for _, phrase := range []string{
+		"other",
+		"chat about this",
+		"use manual input",
+		"manual input",
+		"manual entry",
+		"enter a custom value manually",
+		"custom input",
+		"custom value",
+		"custom path",
+	} {
+		if containsOptionPhrase(normalizedCombined, phrase) {
+			return true
+		}
 	}
 
-	normalizedDescription := normalizeOptionToken(description)
-	return strings.HasPrefix(normalizedLabel, "other") && (strings.Contains(normalizedDescription, "custom") || strings.Contains(normalizedDescription, "manual"))
+	rawCombined := strings.TrimSpace(label + " " + description)
+	for _, phrase := range []string{
+		"\u81ea\u5b9a\u4e49",
+		"\u81ea\u5b9a\u4e49\u8def\u5f84",
+		"\u624b\u52a8\u8f93\u5165",
+		"\u624b\u52a8\u586b\u5199",
+		"\u624b\u52a8\u6307\u5b9a",
+		"\u624b\u52a8\u63d0\u4f9b",
+		"\u5176\u4ed6",
+	} {
+		if strings.Contains(rawCombined, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsOptionPhrase(value, phrase string) bool {
+	if value == phrase {
+		return true
+	}
+	return strings.HasPrefix(value, phrase+" ") ||
+		strings.Contains(value, " "+phrase+" ") ||
+		strings.HasSuffix(value, " "+phrase)
 }
 
 func normalizeOptionToken(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
-	replacer := strings.NewReplacer("-", " ", "_", " ", "/", " ", "(", " ", ")", " ", ",", " ", ".", " ", ":", " ")
+	replacer := strings.NewReplacer(
+		"-", " ",
+		"_", " ",
+		"/", " ",
+		"(", " ",
+		")", " ",
+		"\uff08", " ",
+		"\uff09", " ",
+		",", " ",
+		"\uff0c", " ",
+		".", " ",
+		":", " ",
+		"\uff1a", " ",
+	)
 	value = replacer.Replace(value)
 	return strings.Join(strings.Fields(value), " ")
 }

--- a/tools/ask_user_question/ask_user_question_test.go
+++ b/tools/ask_user_question/ask_user_question_test.go
@@ -133,6 +133,44 @@ func TestToolExecute_ValidatesRequest(t *testing.T) {
 	}
 }
 
+func TestToolExecute_StripsExplicitOtherOptionAndKeepsCustomInputPath(t *testing.T) {
+	ui := &stubPromptUI{
+		resp: PromptResponse{
+			Answers: []PromptAnswer{
+				{Question: "Which CANN path should we use?", Answer: "/home/cann_custom_path/8.5.0/ascend-toolkit/set_env.sh"},
+			},
+		},
+	}
+	tool := NewTool(ui)
+	params := mustJSON(t, PromptRequest{
+		Questions: []Question{{
+			Header:   "CANN Path",
+			Question: "Which CANN path should we use?",
+			Options: []QuestionOption{
+				{Label: "/usr/local/Ascend/ascend-toolkit/latest", Description: "Typical CANN toolkit installation path."},
+				{Label: "Other", Description: "I will type a custom path."},
+			},
+		}},
+	})
+
+	result, err := tool.Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute() result.Error = %v", result.Error)
+	}
+	if got := len(ui.req.Questions[0].Options); got != 1 {
+		t.Fatalf("normalized option count = %d, want 1 concrete option after stripping explicit Other", got)
+	}
+	if got := ui.req.Questions[0].Options[0].Label; got != "/usr/local/Ascend/ascend-toolkit/latest" {
+		t.Fatalf("remaining option label = %q, want toolkit path", got)
+	}
+	if !strings.Contains(result.Content, `"/home/cann_custom_path/8.5.0/ascend-toolkit/set_env.sh"`) {
+		t.Fatalf("result.Content missing custom path answer:\n%s", result.Content)
+	}
+}
+
 func mustJSON(t *testing.T, v any) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(v)

--- a/tools/ask_user_question/ask_user_question_test.go
+++ b/tools/ask_user_question/ask_user_question_test.go
@@ -1,0 +1,143 @@
+package askuserquestion
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type stubPromptUI struct {
+	resp PromptResponse
+	err  error
+	req  PromptRequest
+}
+
+func (s *stubPromptUI) Ask(_ context.Context, req PromptRequest) (PromptResponse, error) {
+	s.req = req
+	return s.resp, s.err
+}
+
+func TestToolSchema_ContainsNestedQuestionShape(t *testing.T) {
+	tool := NewTool(nil)
+	schema := tool.Schema()
+
+	questions, ok := schema.Properties["questions"]
+	if !ok {
+		t.Fatal("questions property missing")
+	}
+	if questions.Type != "array" {
+		t.Fatalf("questions.Type = %q, want array", questions.Type)
+	}
+	if questions.Items == nil {
+		t.Fatal("questions.Items = nil, want nested question schema")
+	}
+	if got := questions.Items.Properties["options"].Items; got == nil {
+		t.Fatal("options.Items = nil, want nested option schema")
+	}
+}
+
+func TestToolExecute_ReturnsCollectedAnswers(t *testing.T) {
+	ui := &stubPromptUI{
+		resp: PromptResponse{
+			Answers: []PromptAnswer{
+				{Question: "Which scope should we optimize first?", Answer: "backend"},
+				{Question: "Which tests do you want?", Answer: "unit, integration"},
+			},
+		},
+	}
+	tool := NewTool(ui)
+	params := mustJSON(t, PromptRequest{
+		Questions: []Question{
+			{
+				Header:   "Scope",
+				Question: "Which scope should we optimize first?",
+				Options: []QuestionOption{
+					{Label: "backend", Description: "Optimize backend first"},
+					{Label: "frontend", Description: "Optimize frontend first"},
+				},
+			},
+			{
+				Header:      "Tests",
+				Question:    "Which tests do you want?",
+				MultiSelect: true,
+				Options: []QuestionOption{
+					{Label: "unit", Description: "Add unit tests"},
+					{Label: "integration", Description: "Add integration tests"},
+				},
+			},
+		},
+	})
+
+	result, err := tool.Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute() result.Error = %v", result.Error)
+	}
+	if got, want := result.Summary, "2 answers collected"; got != want {
+		t.Fatalf("result.Summary = %q, want %q", got, want)
+	}
+	if !strings.Contains(result.Content, `"Which scope should we optimize first?" = "backend"`) {
+		t.Fatalf("result.Content missing first answer:\n%s", result.Content)
+	}
+	if len(ui.req.Questions) != 2 {
+		t.Fatalf("prompt ui saw %d questions, want 2", len(ui.req.Questions))
+	}
+}
+
+func TestToolExecute_Declined(t *testing.T) {
+	tool := NewTool(&stubPromptUI{resp: PromptResponse{Declined: true}})
+	params := mustJSON(t, PromptRequest{
+		Questions: []Question{{
+			Header:   "Scope",
+			Question: "Which scope should we optimize first?",
+			Options: []QuestionOption{
+				{Label: "backend", Description: "Optimize backend first"},
+				{Label: "frontend", Description: "Optimize frontend first"},
+			},
+		}},
+	})
+
+	result, err := tool.Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute() result.Error = %v", result.Error)
+	}
+	if got, want := result.Summary, "declined"; got != want {
+		t.Fatalf("result.Summary = %q, want %q", got, want)
+	}
+}
+
+func TestToolExecute_ValidatesRequest(t *testing.T) {
+	tool := NewTool(&stubPromptUI{})
+	params := mustJSON(t, PromptRequest{
+		Questions: []Question{{
+			Header:   "",
+			Question: "",
+			Options: []QuestionOption{
+				{Label: "backend", Description: "Optimize backend first"},
+			},
+		}},
+	})
+
+	result, err := tool.Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if result.Error == nil {
+		t.Fatal("result.Error = nil, want validation error")
+	}
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal() err = %v", err)
+	}
+	return data
+}

--- a/tools/ask_user_question/ask_user_question_test.go
+++ b/tools/ask_user_question/ask_user_question_test.go
@@ -171,6 +171,42 @@ func TestToolExecute_StripsExplicitOtherOptionAndKeepsCustomInputPath(t *testing
 	}
 }
 
+func TestToolExecute_StripsLocalizedManualOption(t *testing.T) {
+	ui := &stubPromptUI{
+		resp: PromptResponse{
+			Answers: []PromptAnswer{
+				{Question: "\u68c0\u6d4b\u5230\u591a\u4e2a CANN \u73af\u5883\uff0c\u8bf7\u786e\u8ba4\u60a8\u8981\u4f7f\u7528\u7684 CANN \u7248\u672c\uff1a", Answer: "Unknown / not sure"},
+			},
+		},
+	}
+	tool := NewTool(ui)
+	params := mustJSON(t, PromptRequest{
+		Questions: []Question{{
+			Header:   "CANN Path",
+			Question: "\u68c0\u6d4b\u5230\u591a\u4e2a CANN \u73af\u5883\uff0c\u8bf7\u786e\u8ba4\u60a8\u8981\u4f7f\u7528\u7684 CANN \u7248\u672c\uff1a",
+			Options: []QuestionOption{
+				{Label: "/home/cann_custom_path/8.5.0/ascend-toolkit/set_env.sh", Description: "\u63a8\u8350\u7248\u672c\u3002"},
+				{Label: "\u81ea\u5b9a\u4e49\u8def\u5f84\uff08\u624b\u52a8\u8f93\u5165\uff09", Description: "\u6211\u60f3\u81ea\u5df1\u8f93\u5165\u3002"},
+				{Label: "Unknown / not sure", Description: "\u6682\u65f6\u5148\u8df3\u8fc7\u3002"},
+			},
+		}},
+	})
+
+	result, err := tool.Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("Execute() result.Error = %v", result.Error)
+	}
+	if got := len(ui.req.Questions[0].Options); got != 2 {
+		t.Fatalf("normalized option count = %d, want 2 after stripping localized manual option", got)
+	}
+	if got := ui.req.Questions[0].Options[1].Label; got != "Unknown / not sure" {
+		t.Fatalf("remaining skip label = %q, want %q", got, "Unknown / not sure")
+	}
+}
+
 func mustJSON(t *testing.T, v any) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(v)

--- a/ui/app.go
+++ b/ui/app.go
@@ -205,6 +205,7 @@ type App struct {
 	queuedInputs  []string
 
 	permissionPrompt *permissionPromptState
+	askUserQuestionPrompt *askUserQuestionPromptState
 	permissionsView  *permissionsViewState
 	toolsExpanded    *bool
 	modelPicker      *model.SelectionPopup
@@ -557,6 +558,10 @@ func (a App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		default:
 			return a, nil
 		}
+	}
+
+	if a.askUserQuestionPrompt != nil {
+		return a.handleAskUserQuestionKey(msg)
 	}
 
 	if a.permissionsView != nil {
@@ -1131,6 +1136,18 @@ func (a App) handleEvent(ev model.Event) (tea.Model, tea.Cmd) {
 		a.state = a.clearThinking()
 		a.permissionPrompt = toPermissionPromptState(ev)
 
+	case model.AskUserQuestionPrompt:
+		a.replayWait = nil
+		a.backgroundModelWork = false
+		a.state = a.clearThinking()
+		a.askUserQuestionPrompt = toAskUserQuestionPromptState(ev)
+
+	case model.AskUserQuestionClose:
+		a.replayWait = nil
+		a.backgroundModelWork = false
+		a.state = a.clearThinking()
+		a.askUserQuestionPrompt = nil
+
 	case model.PermissionsView:
 		a.replayWait = nil
 		a.backgroundModelWork = false
@@ -1248,6 +1265,16 @@ func (a App) handleEvent(ev model.Event) (tea.Model, tea.Cmd) {
 		} else {
 			a.state = a.state.WithMessage(msg)
 		}
+
+	case model.ToolAskUserQuestion:
+		a.replayWait = nil
+		a.backgroundModelWork = false
+		a.state = a.clearThinking()
+		a.askUserQuestionPrompt = nil
+		a.state = a.resolveToolEvent(ev, model.Message{
+			Kind: model.MsgTool, ToolName: displayToolName(ev.ToolName), ToolArgs: ev.Message,
+			Display: model.DisplayCollapsed, Content: ev.Message, Summary: ev.Summary,
+		})
 
 	case model.ToolWarning:
 		a.replayWait = nil
@@ -2416,6 +2443,8 @@ func (a App) pendingToolMessage(ev model.Event) model.Message {
 	case "load_skill":
 		toolName = "Skill"
 		summary = "loading skill..."
+	case "AskUserQuestion":
+		summary = "waiting for answers..."
 	}
 	content := ev.Message
 	if ev.ToolName == "shell" && !strings.HasPrefix(strings.TrimSpace(content), "$ ") {
@@ -2618,7 +2647,7 @@ func finalizeToolMessage(pending model.Message, ev model.Event) model.Message {
 			Summary:    firstNonEmpty(ev.Summary, pending.Summary),
 			Meta:       firstNonNilMeta(ev.Meta, pending.Meta),
 		}
-	case model.ToolGrep, model.ToolGlob, model.ToolSkill:
+	case model.ToolGrep, model.ToolGlob, model.ToolSkill, model.ToolAskUserQuestion:
 		return model.Message{
 			Kind:       model.MsgTool,
 			ToolName:   pending.ToolName,

--- a/ui/app_ask_user_question_test.go
+++ b/ui/app_ask_user_question_test.go
@@ -1,0 +1,272 @@
+package ui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+)
+
+func TestAskUserQuestionPrompt_SingleSelectEnterSubmits(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type: model.AskUserQuestionPrompt,
+		AskUserQuestion: &model.AskUserQuestionPromptData{
+			Title:        "Answer Questions",
+			SubmitPrefix: "ask:",
+			Questions: []model.AskUserQuestionView{{
+				Header:   "Scope",
+				Question: "Which scope should we optimize first?",
+				Options: []model.AskUserQuestionOption{
+					{Label: "backend", Description: "Optimize backend first"},
+					{Label: "frontend", Description: "Optimize frontend first"},
+				},
+			}},
+		},
+	})
+	app = next.(App)
+
+	if app.askUserQuestionPrompt == nil {
+		t.Fatal("askUserQuestionPrompt should be set after prompt event")
+	}
+	if view := app.renderMainView(); !strings.Contains(view, "Which scope should we optimize first?") {
+		t.Fatalf("rendered view missing question text:\n%s", view)
+	}
+
+	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = nextModel.(App)
+
+	token := readAskUserQuestionToken(t, userCh)
+	if !strings.HasPrefix(token, "ask:") {
+		t.Fatalf("submitted token = %q, want prefix %q", token, "ask:")
+	}
+
+	var payload struct {
+		Answers []struct {
+			Question string `json:"question"`
+			Answer   string `json:"answer"`
+		} `json:"answers"`
+		Declined bool `json:"declined"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(token, "ask:")), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() err = %v", err)
+	}
+	if payload.Declined {
+		t.Fatal("payload.Declined = true, want false")
+	}
+	if got := payload.Answers[0].Answer; got != "frontend" {
+		t.Fatalf("selected answer = %q, want %q", got, "frontend")
+	}
+	if app.askUserQuestionPrompt != nil {
+		t.Fatal("askUserQuestionPrompt should be cleared after submit")
+	}
+}
+
+func TestAskUserQuestionPrompt_EscDeclines(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type: model.AskUserQuestionPrompt,
+		AskUserQuestion: &model.AskUserQuestionPromptData{
+			Title:        "Answer Questions",
+			SubmitPrefix: "ask:",
+			Questions: []model.AskUserQuestionView{{
+				Header:   "Scope",
+				Question: "Which scope should we optimize first?",
+				Options: []model.AskUserQuestionOption{
+					{Label: "backend", Description: "Optimize backend first"},
+					{Label: "frontend", Description: "Optimize frontend first"},
+				},
+			}},
+		},
+	})
+	app = next.(App)
+
+	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	app = nextModel.(App)
+
+	token := readAskUserQuestionToken(t, userCh)
+	if !strings.Contains(token, `"declined":true`) {
+		t.Fatalf("submitted token = %q, want declined payload", token)
+	}
+	if app.askUserQuestionPrompt != nil {
+		t.Fatal("askUserQuestionPrompt should be cleared after esc")
+	}
+}
+
+func TestAskUserQuestionPrompt_MultiSelectSpaceThenEnterSubmits(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type: model.AskUserQuestionPrompt,
+		AskUserQuestion: &model.AskUserQuestionPromptData{
+			Title:        "Answer Questions",
+			SubmitPrefix: "ask:",
+			Questions: []model.AskUserQuestionView{{
+				Header:      "Tests",
+				Question:    "Which tests should we add?",
+				MultiSelect: true,
+				Options: []model.AskUserQuestionOption{
+					{Label: "unit", Description: "Add unit tests"},
+					{Label: "integration", Description: "Add integration tests"},
+				},
+			}},
+		},
+	})
+	app = next.(App)
+
+	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeySpace})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeySpace})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = nextModel.(App)
+
+	token := readAskUserQuestionToken(t, userCh)
+	if !strings.Contains(token, `"answer":"unit, integration"`) {
+		t.Fatalf("submitted token = %q, want joined multi-select answer", token)
+	}
+	if app.askUserQuestionPrompt != nil {
+		t.Fatal("askUserQuestionPrompt should be cleared after multi-select submit")
+	}
+}
+
+func TestAskUserQuestionPrompt_OtherAnswerSubmitsCustomText(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type: model.AskUserQuestionPrompt,
+		AskUserQuestion: &model.AskUserQuestionPromptData{
+			Title:        "Answer Questions",
+			SubmitPrefix: "ask:",
+			Questions: []model.AskUserQuestionView{{
+				Header:   "Scope",
+				Question: "Which scope should we optimize first?",
+				Options: []model.AskUserQuestionOption{
+					{Label: "backend", Description: "Optimize backend first"},
+					{Label: "frontend", Description: "Optimize frontend first"},
+				},
+			}},
+		},
+	})
+	app = next.(App)
+
+	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = nextModel.(App)
+	for _, r := range []rune("custom scope") {
+		keyType := tea.KeyRunes
+		if r == ' ' {
+			keyType = tea.KeySpace
+		}
+		nextModel, _ = app.handleKey(tea.KeyMsg{Type: keyType, Runes: []rune{r}})
+		app = nextModel.(App)
+	}
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = nextModel.(App)
+
+	token := readAskUserQuestionToken(t, userCh)
+	if !strings.Contains(token, `"answer":"custom scope"`) {
+		t.Fatalf("submitted token = %q, want custom answer", token)
+	}
+}
+
+func TestAskUserQuestionToolEvent_ResolvesPendingToolMessage(t *testing.T) {
+	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type:       model.ToolCallStart,
+		ToolName:   "AskUserQuestion",
+		ToolCallID: "tool-1",
+		Message:    "Scope",
+	})
+	app = next.(App)
+
+	if got := len(app.state.Messages); got != 1 {
+		t.Fatalf("message count = %d, want 1", got)
+	}
+	if !app.state.Messages[0].Pending {
+		t.Fatal("pending tool message should be pending after ToolCallStart")
+	}
+	if got := app.state.Messages[0].Summary; got != "waiting for answers..." {
+		t.Fatalf("pending summary = %q, want %q", got, "waiting for answers...")
+	}
+
+	next, _ = app.handleEvent(model.Event{
+		Type: model.AskUserQuestionPrompt,
+		AskUserQuestion: &model.AskUserQuestionPromptData{
+			Title:        "Answer Questions",
+			SubmitPrefix: "ask:",
+			Questions: []model.AskUserQuestionView{{
+				Header:   "Scope",
+				Question: "Which scope should we optimize first?",
+				Options: []model.AskUserQuestionOption{
+					{Label: "backend", Description: "Optimize backend first"},
+					{Label: "frontend", Description: "Optimize frontend first"},
+				},
+			}},
+		},
+	})
+	app = next.(App)
+	if app.askUserQuestionPrompt == nil {
+		t.Fatal("askUserQuestionPrompt should be active after prompt event")
+	}
+
+	next, _ = app.handleEvent(model.Event{
+		Type:       model.ToolAskUserQuestion,
+		ToolName:   "AskUserQuestion",
+		ToolCallID: "tool-1",
+		Message:    `User has answered your questions: - "Which scope should we optimize first?" = "frontend"`,
+		Summary:    "1 answer collected",
+	})
+	app = next.(App)
+
+	if app.askUserQuestionPrompt != nil {
+		t.Fatal("askUserQuestionPrompt should be cleared after resolved tool event")
+	}
+	if got := len(app.state.Messages); got != 1 {
+		t.Fatalf("message count after resolve = %d, want 1", got)
+	}
+	last := app.state.Messages[0]
+	if last.Pending {
+		t.Fatal("resolved tool message should not be pending")
+	}
+	if got := last.Summary; got != "1 answer collected" {
+		t.Fatalf("resolved summary = %q, want %q", got, "1 answer collected")
+	}
+	if !strings.Contains(last.Content, `"frontend"`) {
+		t.Fatalf("resolved content = %q, want collected answer", last.Content)
+	}
+}
+
+func readAskUserQuestionToken(t *testing.T, userCh <-chan string) string {
+	t.Helper()
+
+	select {
+	case token := <-userCh:
+		return token
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ask-user-question submission")
+		return ""
+	}
+}

--- a/ui/app_ask_user_question_test.go
+++ b/ui/app_ask_user_question_test.go
@@ -171,8 +171,6 @@ func TestAskUserQuestionPrompt_OtherAnswerSubmitsCustomText(t *testing.T) {
 	app = nextModel.(App)
 	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
 	app = nextModel.(App)
-	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	app = nextModel.(App)
 	for _, r := range []rune("custom scope") {
 		keyType := tea.KeyRunes
 		if r == ' ' {
@@ -190,7 +188,46 @@ func TestAskUserQuestionPrompt_OtherAnswerSubmitsCustomText(t *testing.T) {
 	}
 }
 
-func TestAskUserQuestionPrompt_TypingStartsChatInputImmediately(t *testing.T) {
+func TestAskUserQuestionPrompt_EmptyCustomAnswerDoesNotSubmit(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type: model.AskUserQuestionPrompt,
+		AskUserQuestion: &model.AskUserQuestionPromptData{
+			Title:        "Answer Questions",
+			SubmitPrefix: "ask:",
+			Questions: []model.AskUserQuestionView{{
+				Header:   "Scope",
+				Question: "Which scope should we optimize first?",
+				Options: []model.AskUserQuestionOption{
+					{Label: "backend", Description: "Optimize backend first"},
+					{Label: "frontend", Description: "Optimize frontend first"},
+				},
+			}},
+		},
+	})
+	app = next.(App)
+
+	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = nextModel.(App)
+
+	select {
+	case token := <-userCh:
+		t.Fatalf("unexpected submission for empty custom answer: %q", token)
+	default:
+	}
+	if app.askUserQuestionPrompt == nil {
+		t.Fatal("askUserQuestionPrompt should stay open when custom answer is empty")
+	}
+}
+
+func TestAskUserQuestionPrompt_CustomAnswerPersistsAcrossNavigation(t *testing.T) {
 	userCh := make(chan string, 1)
 	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
 	app.bootActive = false
@@ -214,10 +251,25 @@ func TestAskUserQuestionPrompt_TypingStartsChatInputImmediately(t *testing.T) {
 
 	if view := app.renderMainView(); !strings.Contains(view, askUserQuestionChatLabel) {
 		t.Fatalf("rendered view missing chat label:\n%s", view)
-	} else if !strings.Contains(view, "Type your custom answer and press Enter") {
-		t.Fatalf("rendered view missing custom-answer prompt:\n%s", view)
-	} else if !strings.Contains(view, "start typing here") {
-		t.Fatalf("rendered view missing always-visible chat placeholder:\n%s", view)
+	} else if !strings.Contains(view, "start typing") {
+		t.Fatalf("rendered view should show the inline chat placeholder from the start:\n%s", view)
+	}
+
+	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	app = nextModel.(App)
+	if got := app.askUserQuestionPrompt.answers[0].other; got != "" {
+		t.Fatalf("custom answer = %q, want empty while focus stays on normal option", got)
+	}
+
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+
+	if view := app.renderMainView(); !strings.Contains(view, "> "+askUserQuestionChatLabel) {
+		t.Fatalf("rendered view should place the cursor on chat input after navigation:\n%s", view)
+	} else if !strings.Contains(view, "   |") {
+		t.Fatalf("rendered view should show an active inline cursor after selecting chat:\n%s", view)
 	}
 
 	for _, r := range []rune("/custom/cann") {
@@ -225,10 +277,23 @@ func TestAskUserQuestionPrompt_TypingStartsChatInputImmediately(t *testing.T) {
 		if r == ' ' {
 			keyType = tea.KeySpace
 		}
-		nextModel, _ := app.handleKey(tea.KeyMsg{Type: keyType, Runes: []rune{r}})
+		nextModel, _ = app.handleKey(tea.KeyMsg{Type: keyType, Runes: []rune{r}})
 		app = nextModel.(App)
 	}
-	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	app = nextModel.(App)
+	if got := app.askUserQuestionPrompt.answers[0].other; got != "/custom/cann" {
+		t.Fatalf("custom answer after moving away = %q, want %q", got, "/custom/cann")
+	}
+
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyDown})
+	app = nextModel.(App)
+	if view := app.renderMainView(); !strings.Contains(view, "   /custom/cann|") {
+		t.Fatalf("rendered view should preserve custom text after moving away and back:\n%s", view)
+	}
+
+	nextModel, _ = app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 	app = nextModel.(App)
 
 	token := readAskUserQuestionToken(t, userCh)

--- a/ui/app_ask_user_question_test.go
+++ b/ui/app_ask_user_question_test.go
@@ -214,6 +214,10 @@ func TestAskUserQuestionPrompt_TypingStartsChatInputImmediately(t *testing.T) {
 
 	if view := app.renderMainView(); !strings.Contains(view, askUserQuestionChatLabel) {
 		t.Fatalf("rendered view missing chat label:\n%s", view)
+	} else if !strings.Contains(view, "Type your custom answer and press Enter") {
+		t.Fatalf("rendered view missing custom-answer prompt:\n%s", view)
+	} else if !strings.Contains(view, "start typing here") {
+		t.Fatalf("rendered view missing always-visible chat placeholder:\n%s", view)
 	}
 
 	for _, r := range []rune("/custom/cann") {

--- a/ui/app_ask_user_question_test.go
+++ b/ui/app_ask_user_question_test.go
@@ -190,6 +190,49 @@ func TestAskUserQuestionPrompt_OtherAnswerSubmitsCustomText(t *testing.T) {
 	}
 }
 
+func TestAskUserQuestionPrompt_TypingStartsChatInputImmediately(t *testing.T) {
+	userCh := make(chan string, 1)
+	app := New(nil, userCh, "test", ".", "", "demo-model", 4096)
+	app.bootActive = false
+
+	next, _ := app.handleEvent(model.Event{
+		Type: model.AskUserQuestionPrompt,
+		AskUserQuestion: &model.AskUserQuestionPromptData{
+			Title:        "Answer Questions",
+			SubmitPrefix: "ask:",
+			Questions: []model.AskUserQuestionView{{
+				Header:   "CANN Path",
+				Question: "Which CANN path should we use?",
+				Options: []model.AskUserQuestionOption{
+					{Label: "/usr/local/Ascend/ascend-toolkit/latest", Description: "Use the default toolkit path."},
+					{Label: "Skip for now", Description: "Continue without confirming this path."},
+				},
+			}},
+		},
+	})
+	app = next.(App)
+
+	if view := app.renderMainView(); !strings.Contains(view, askUserQuestionChatLabel) {
+		t.Fatalf("rendered view missing chat label:\n%s", view)
+	}
+
+	for _, r := range []rune("/custom/cann") {
+		keyType := tea.KeyRunes
+		if r == ' ' {
+			keyType = tea.KeySpace
+		}
+		nextModel, _ := app.handleKey(tea.KeyMsg{Type: keyType, Runes: []rune{r}})
+		app = nextModel.(App)
+	}
+	nextModel, _ := app.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	app = nextModel.(App)
+
+	token := readAskUserQuestionToken(t, userCh)
+	if !strings.Contains(token, `"answer":"/custom/cann"`) {
+		t.Fatalf("submitted token = %q, want direct typed custom answer", token)
+	}
+}
+
 func TestAskUserQuestionToolEvent_ResolvesPendingToolMessage(t *testing.T) {
 	app := New(nil, nil, "test", ".", "", "demo-model", 4096)
 	app.bootActive = false

--- a/ui/ask_user_question.go
+++ b/ui/ask_user_question.go
@@ -241,6 +241,16 @@ func (p *askUserQuestionPromptState) beginCustomAnswerInput(seed string) {
 	p.textValue += seed
 }
 
+func (p *askUserQuestionPromptState) customAnswerValue() string {
+	if p == nil || p.current < 0 || p.current >= len(p.answers) {
+		return ""
+	}
+	if p.textInput {
+		return p.textValue
+	}
+	return p.answers[p.current].other
+}
+
 func (p *askUserQuestionPromptState) hasAnswerForCurrentQuestion() bool {
 	if p == nil || p.current < 0 || p.current >= len(p.answers) {
 		return false
@@ -340,13 +350,8 @@ func renderAskUserQuestionPromptPopup(p *askUserQuestionPromptState) string {
 		lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.selectedOption == i, p.answers[p.current].selected[i], option.Label, option.Description, selectedStyle, normalStyle, descStyle)...)
 	}
 	lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.isOtherSelected(), strings.TrimSpace(p.answers[p.current].other) != "", askUserQuestionChatLabel, askUserQuestionChatDescription, selectedStyle, normalStyle, descStyle)...)
-
-	if p.textInput {
-		lines = append(lines, "", subtitleStyle.Render("Type your custom answer and press Enter"))
-		lines = append(lines, inputStyle.Render(renderAskUserQuestionInputValue(p.textValue)))
-	} else if other := strings.TrimSpace(p.answers[p.current].other); other != "" {
-		lines = append(lines, "", subtitleStyle.Render(askUserQuestionChatLabel+": "+other))
-	}
+	lines = append(lines, "", subtitleStyle.Render("Type your custom answer and press Enter"))
+	lines = append(lines, inputStyle.Render(renderAskUserQuestionInputValue(p.customAnswerValue(), p.textInput)))
 
 	lines = append(lines, "")
 	if question.MultiSelect {
@@ -388,11 +393,17 @@ func renderAskUserQuestionOptionLine(multiSelect, isCursor, isSelected bool, lab
 	return lines
 }
 
-func renderAskUserQuestionInputValue(value string) string {
+func renderAskUserQuestionInputValue(value string, active bool) string {
 	if strings.TrimSpace(value) == "" {
-		return " "
+		if active {
+			return "|"
+		}
+		return "start typing here"
 	}
-	return value + "|"
+	if active {
+		return value + "|"
+	}
+	return value
 }
 
 func askUserQuestionTextInputSeed(msg tea.KeyMsg, multiSelect bool) (string, bool) {

--- a/ui/ask_user_question.go
+++ b/ui/ask_user_question.go
@@ -18,8 +18,6 @@ type askUserQuestionPromptState struct {
 	current        int
 	selectedOption int
 	answers        []askUserQuestionAnswerState
-	textInput      bool
-	textValue      string
 }
 
 type askUserQuestionAnswerState struct {
@@ -38,8 +36,8 @@ type askUserQuestionAnswerPayload struct {
 }
 
 const (
-	askUserQuestionChatLabel       = "Chat about this"
-	askUserQuestionChatDescription = "Type your own answer directly."
+	askUserQuestionChatLabel       = "Type something here"
+	askUserQuestionChatDescription = ""
 )
 
 func toAskUserQuestionPromptState(ev model.Event) *askUserQuestionPromptState {
@@ -64,10 +62,11 @@ func toAskUserQuestionPromptState(ev model.Event) *askUserQuestionPromptState {
 	}
 
 	return &askUserQuestionPromptState{
-		title:        valueOrString(strings.TrimSpace(data.Title), "Answer Questions"),
-		submitPrefix: strings.TrimSpace(data.SubmitPrefix),
-		questions:    questions,
-		answers:      answers,
+		title:          valueOrString(strings.TrimSpace(data.Title), "Answer Questions"),
+		submitPrefix:   strings.TrimSpace(data.SubmitPrefix),
+		questions:      questions,
+		answers:        answers,
+		selectedOption: 0,
 	}
 }
 
@@ -80,46 +79,7 @@ func (a App) handleAskUserQuestionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
-	if p.textInput {
-		switch msg.String() {
-		case "enter":
-			text := strings.TrimSpace(p.textValue)
-			if text == "" {
-				return a, nil
-			}
-			answer := &p.answers[p.current]
-			if !p.currentQuestion().MultiSelect {
-				answer.selected = map[int]bool{}
-			}
-			answer.other = text
-			p.textInput = false
-			p.textValue = ""
-			if !p.currentQuestion().MultiSelect {
-				return a.finishCurrentAskUserQuestion()
-			}
-			return a, nil
-		case "backspace":
-			runes := []rune(p.textValue)
-			if len(runes) > 0 {
-				p.textValue = string(runes[:len(runes)-1])
-			}
-			return a, nil
-		case "esc":
-			p.textInput = false
-			p.textValue = ""
-			return a, nil
-		default:
-			if msg.Type == tea.KeyRunes {
-				p.textValue += string(msg.Runes)
-			} else if msg.Type == tea.KeySpace {
-				p.textValue += " "
-			}
-			return a, nil
-		}
-	}
-
-	if seed, ok := askUserQuestionTextInputSeed(msg, p.currentQuestion().MultiSelect); ok {
-		p.beginCustomAnswerInput(seed)
+	if p.handleInputOptionEdit(msg) {
 		return a, nil
 	}
 
@@ -134,12 +94,10 @@ func (a App) handleAskUserQuestionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		p.selectedOption = (p.selectedOption + 1) % p.optionCount()
 		return a, nil
 	case "space":
-		if !p.currentQuestion().MultiSelect {
+		if p.isInputFocused() {
 			return a, nil
 		}
-		if p.isOtherSelected() {
-			p.textInput = true
-			p.textValue = p.answers[p.current].other
+		if !p.currentQuestion().MultiSelect {
 			return a, nil
 		}
 		answer := &p.answers[p.current]
@@ -150,13 +108,14 @@ func (a App) handleAskUserQuestionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 	case "enter":
-		if p.isOtherSelected() {
-			if p.currentQuestion().MultiSelect && strings.TrimSpace(p.answers[p.current].other) != "" {
-				return a.finishCurrentAskUserQuestion()
+		if p.isInputFocused() {
+			if !p.canSubmitInputOption() {
+				return a, nil
 			}
-			p.textInput = true
-			p.textValue = p.answers[p.current].other
-			return a, nil
+			if !p.currentQuestion().MultiSelect {
+				p.currentAnswer().selected = map[int]bool{}
+			}
+			return a.finishCurrentAskUserQuestion()
 		}
 		answer := &p.answers[p.current]
 		if p.currentQuestion().MultiSelect {
@@ -190,8 +149,6 @@ func (a App) finishCurrentAskUserQuestion() (tea.Model, tea.Cmd) {
 	if p.current < len(p.questions)-1 {
 		p.current++
 		p.selectedOption = 0
-		p.textInput = false
-		p.textValue = ""
 		return a, nil
 	}
 
@@ -227,28 +184,65 @@ func (p *askUserQuestionPromptState) optionCount() int {
 	return len(p.currentQuestion().Options) + 1
 }
 
-func (p *askUserQuestionPromptState) isOtherSelected() bool {
+func (p *askUserQuestionPromptState) isInputFocused() bool {
 	return p != nil && p.selectedOption == len(p.currentQuestion().Options)
 }
 
-func (p *askUserQuestionPromptState) beginCustomAnswerInput(seed string) {
-	if p == nil {
-		return
+func (p *askUserQuestionPromptState) currentAnswer() *askUserQuestionAnswerState {
+	if p == nil || p.current < 0 || p.current >= len(p.answers) {
+		return nil
 	}
-	p.textInput = true
-	p.selectedOption = len(p.currentQuestion().Options)
-	p.textValue = p.answers[p.current].other
-	p.textValue += seed
+	return &p.answers[p.current]
 }
 
-func (p *askUserQuestionPromptState) customAnswerValue() string {
-	if p == nil || p.current < 0 || p.current >= len(p.answers) {
+func (p *askUserQuestionPromptState) customAnswer() string {
+	answer := p.currentAnswer()
+	if answer == nil {
 		return ""
 	}
-	if p.textInput {
-		return p.textValue
+	return answer.other
+}
+
+func (p *askUserQuestionPromptState) canSubmitInputOption() bool {
+	answer := p.currentAnswer()
+	if answer == nil {
+		return false
 	}
-	return p.answers[p.current].other
+	if strings.TrimSpace(answer.other) != "" {
+		return true
+	}
+	return p.currentQuestion().MultiSelect && len(answer.selected) > 0
+}
+
+func (p *askUserQuestionPromptState) handleInputOptionEdit(msg tea.KeyMsg) bool {
+	if p == nil || !p.isInputFocused() {
+		return false
+	}
+
+	answer := p.currentAnswer()
+	if answer == nil {
+		return false
+	}
+
+	switch {
+	case msg.Type == tea.KeyRunes && len(msg.Runes) > 0:
+		answer.other += string(msg.Runes)
+	case msg.Type == tea.KeySpace:
+		answer.other += " "
+	case msg.String() == "backspace":
+		runes := []rune(answer.other)
+		if len(runes) == 0 {
+			return true
+		}
+		answer.other = string(runes[:len(runes)-1])
+	default:
+		return false
+	}
+
+	if !p.currentQuestion().MultiSelect {
+		answer.selected = map[int]bool{}
+	}
+	return true
 }
 
 func (p *askUserQuestionPromptState) hasAnswerForCurrentQuestion() bool {
@@ -319,7 +313,8 @@ func renderAskUserQuestionPromptPopup(p *askUserQuestionPromptState) string {
 	selectedStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true)
 	normalStyle := lipgloss.NewStyle().Foreground(t.TextPrimary)
 	descStyle := lipgloss.NewStyle().Foreground(t.TextSecondary)
-	inputStyle := lipgloss.NewStyle().Foreground(t.TextPrimary).Border(lipgloss.RoundedBorder()).BorderForeground(t.Accent).Padding(0, 1)
+	inlineInputStyle := lipgloss.NewStyle().Foreground(t.TextPrimary)
+	inlineInputInactiveStyle := lipgloss.NewStyle().Foreground(t.TextMuted)
 	hintStyle := lipgloss.NewStyle().Foreground(t.TextMuted).Italic(true)
 
 	question := p.currentQuestion()
@@ -349,15 +344,19 @@ func renderAskUserQuestionPromptPopup(p *askUserQuestionPromptState) string {
 	for i, option := range question.Options {
 		lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.selectedOption == i, p.answers[p.current].selected[i], option.Label, option.Description, selectedStyle, normalStyle, descStyle)...)
 	}
-	lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.isOtherSelected(), strings.TrimSpace(p.answers[p.current].other) != "", askUserQuestionChatLabel, askUserQuestionChatDescription, selectedStyle, normalStyle, descStyle)...)
-	lines = append(lines, "", subtitleStyle.Render("Type your custom answer and press Enter"))
-	lines = append(lines, inputStyle.Render(renderAskUserQuestionInputValue(p.customAnswerValue(), p.textInput)))
+	lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.isInputFocused(), strings.TrimSpace(p.answers[p.current].other) != "", askUserQuestionChatLabel, askUserQuestionChatDescription, selectedStyle, normalStyle, descStyle)...)
+	lines = append(lines, renderAskUserQuestionInlineInputLine(
+		p.customAnswer(),
+		p.isInputFocused(),
+		inlineInputStyle,
+		inlineInputInactiveStyle,
+	))
 
 	lines = append(lines, "")
 	if question.MultiSelect {
-		lines = append(lines, hintStyle.Render("up/down move | space toggle | enter continue | type to chat | esc cancel"))
+		lines = append(lines, hintStyle.Render("up/down move | space toggle | enter continue | esc cancel"))
 	} else {
-		lines = append(lines, hintStyle.Render("up/down move | enter confirm | type to chat | esc cancel"))
+		lines = append(lines, hintStyle.Render("up/down move | enter confirm | esc cancel"))
 	}
 
 	content := strings.Join(lines, "\n")
@@ -376,21 +375,32 @@ func renderAskUserQuestionOptionLine(multiSelect, isCursor, isSelected bool, lab
 		style = selectedStyle
 	}
 
-	choice := "( )"
+	choice := ""
 	if multiSelect {
 		choice = "[ ]"
 		if isSelected {
 			choice = "[x]"
 		}
-	} else if isSelected {
-		choice = "(*)"
 	}
 
-	lines := []string{cursor + style.Render(choice+" "+label)}
+	prefix := ""
+	if choice != "" {
+		prefix = choice + " "
+	}
+
+	lines := []string{cursor + style.Render(prefix+label)}
 	if strings.TrimSpace(description) != "" {
 		lines = append(lines, "   "+descStyle.Render(description))
 	}
 	return lines
+}
+
+func renderAskUserQuestionInlineInputLine(value string, active bool, activeStyle, inactiveStyle lipgloss.Style) string {
+	rendered := renderAskUserQuestionInputValue(value, active)
+	if active {
+		return "   " + activeStyle.Render(rendered)
+	}
+	return "   " + inactiveStyle.Render(rendered)
 }
 
 func renderAskUserQuestionInputValue(value string, active bool) string {
@@ -398,22 +408,12 @@ func renderAskUserQuestionInputValue(value string, active bool) string {
 		if active {
 			return "|"
 		}
-		return "start typing here"
+		return "start typing"
 	}
 	if active {
 		return value + "|"
 	}
 	return value
-}
-
-func askUserQuestionTextInputSeed(msg tea.KeyMsg, multiSelect bool) (string, bool) {
-	if msg.Type == tea.KeyRunes && len(msg.Runes) > 0 {
-		return string(msg.Runes), true
-	}
-	if !multiSelect && msg.Type == tea.KeySpace {
-		return " ", true
-	}
-	return "", false
 }
 
 func itoa(v int) string {

--- a/ui/ask_user_question.go
+++ b/ui/ask_user_question.go
@@ -1,0 +1,380 @@
+package ui
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mindspore-lab/mindspore-cli/ui/model"
+	"github.com/mindspore-lab/mindspore-cli/ui/theme"
+)
+
+type askUserQuestionPromptState struct {
+	title          string
+	submitPrefix   string
+	questions      []model.AskUserQuestionView
+	current        int
+	selectedOption int
+	answers        []askUserQuestionAnswerState
+	textInput      bool
+	textValue      string
+}
+
+type askUserQuestionAnswerState struct {
+	selected map[int]bool
+	other    string
+}
+
+type askUserQuestionResponsePayload struct {
+	Answers  []askUserQuestionAnswerPayload `json:"answers"`
+	Declined bool                           `json:"declined"`
+}
+
+type askUserQuestionAnswerPayload struct {
+	Question string `json:"question"`
+	Answer   string `json:"answer"`
+}
+
+func toAskUserQuestionPromptState(ev model.Event) *askUserQuestionPromptState {
+	data := ev.AskUserQuestion
+	if data == nil {
+		return nil
+	}
+
+	questions := make([]model.AskUserQuestionView, 0, len(data.Questions))
+	answers := make([]askUserQuestionAnswerState, 0, len(data.Questions))
+	for _, question := range data.Questions {
+		options := append([]model.AskUserQuestionOption(nil), question.Options...)
+		questions = append(questions, model.AskUserQuestionView{
+			Header:      question.Header,
+			Question:    question.Question,
+			Options:     options,
+			MultiSelect: question.MultiSelect,
+		})
+		answers = append(answers, askUserQuestionAnswerState{
+			selected: make(map[int]bool),
+		})
+	}
+
+	return &askUserQuestionPromptState{
+		title:        valueOrString(strings.TrimSpace(data.Title), "Answer Questions"),
+		submitPrefix: strings.TrimSpace(data.SubmitPrefix),
+		questions:    questions,
+		answers:      answers,
+	}
+}
+
+func (a App) handleAskUserQuestionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	p := a.askUserQuestionPrompt
+	if p == nil {
+		return a, nil
+	}
+	if p.optionCount() == 0 {
+		return a, nil
+	}
+
+	if p.textInput {
+		switch msg.String() {
+		case "enter":
+			text := strings.TrimSpace(p.textValue)
+			if text == "" {
+				return a, nil
+			}
+			answer := &p.answers[p.current]
+			if !p.currentQuestion().MultiSelect {
+				answer.selected = map[int]bool{}
+			}
+			answer.other = text
+			p.textInput = false
+			p.textValue = ""
+			if !p.currentQuestion().MultiSelect {
+				return a.finishCurrentAskUserQuestion()
+			}
+			return a, nil
+		case "backspace":
+			runes := []rune(p.textValue)
+			if len(runes) > 0 {
+				p.textValue = string(runes[:len(runes)-1])
+			}
+			return a, nil
+		case "esc":
+			p.textInput = false
+			p.textValue = ""
+			return a, nil
+		default:
+			if msg.Type == tea.KeyRunes {
+				p.textValue += string(msg.Runes)
+			} else if msg.Type == tea.KeySpace {
+				p.textValue += " "
+			}
+			return a, nil
+		}
+	}
+
+	switch msg.String() {
+	case "up", "left":
+		p.selectedOption--
+		if p.selectedOption < 0 {
+			p.selectedOption = p.optionCount() - 1
+		}
+		return a, nil
+	case "down", "right", "tab":
+		p.selectedOption = (p.selectedOption + 1) % p.optionCount()
+		return a, nil
+	case "space":
+		if !p.currentQuestion().MultiSelect {
+			return a, nil
+		}
+		if p.isOtherSelected() {
+			p.textInput = true
+			p.textValue = p.answers[p.current].other
+			return a, nil
+		}
+		answer := &p.answers[p.current]
+		if answer.selected[p.selectedOption] {
+			delete(answer.selected, p.selectedOption)
+		} else {
+			answer.selected[p.selectedOption] = true
+		}
+		return a, nil
+	case "enter":
+		if p.isOtherSelected() {
+			if p.currentQuestion().MultiSelect && strings.TrimSpace(p.answers[p.current].other) != "" {
+				return a.finishCurrentAskUserQuestion()
+			}
+			p.textInput = true
+			p.textValue = p.answers[p.current].other
+			return a, nil
+		}
+		answer := &p.answers[p.current]
+		if p.currentQuestion().MultiSelect {
+			if !p.hasAnswerForCurrentQuestion() {
+				return a, nil
+			}
+			return a.finishCurrentAskUserQuestion()
+		}
+		answer.selected = map[int]bool{p.selectedOption: true}
+		answer.other = ""
+		return a.finishCurrentAskUserQuestion()
+	case "esc":
+		a.submitAskUserQuestionResponse(askUserQuestionResponsePayload{Declined: true})
+		a.askUserQuestionPrompt = nil
+		return a, nil
+	default:
+		return a, nil
+	}
+}
+
+func (a App) finishCurrentAskUserQuestion() (tea.Model, tea.Cmd) {
+	p := a.askUserQuestionPrompt
+	if p == nil {
+		return a, nil
+	}
+
+	if !p.hasAnswerForCurrentQuestion() {
+		return a, nil
+	}
+
+	if p.current < len(p.questions)-1 {
+		p.current++
+		p.selectedOption = 0
+		p.textInput = false
+		p.textValue = ""
+		return a, nil
+	}
+
+	a.submitAskUserQuestionResponse(p.responsePayload())
+	a.askUserQuestionPrompt = nil
+	return a, nil
+}
+
+func (a App) submitAskUserQuestionResponse(payload askUserQuestionResponsePayload) {
+	if a.askUserQuestionPrompt == nil || a.userCh == nil {
+		return
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		data = []byte(`{"declined":true}`)
+	}
+	token := a.askUserQuestionPrompt.submitPrefix + string(data)
+	select {
+	case a.userCh <- token:
+	default:
+	}
+}
+
+func (p *askUserQuestionPromptState) currentQuestion() model.AskUserQuestionView {
+	if p == nil || p.current < 0 || p.current >= len(p.questions) {
+		return model.AskUserQuestionView{}
+	}
+	return p.questions[p.current]
+}
+
+func (p *askUserQuestionPromptState) optionCount() int {
+	return len(p.currentQuestion().Options) + 1
+}
+
+func (p *askUserQuestionPromptState) isOtherSelected() bool {
+	return p != nil && p.selectedOption == len(p.currentQuestion().Options)
+}
+
+func (p *askUserQuestionPromptState) hasAnswerForCurrentQuestion() bool {
+	if p == nil || p.current < 0 || p.current >= len(p.answers) {
+		return false
+	}
+	answer := p.answers[p.current]
+	return len(answer.selected) > 0 || strings.TrimSpace(answer.other) != ""
+}
+
+func (p *askUserQuestionPromptState) responsePayload() askUserQuestionResponsePayload {
+	payload := askUserQuestionResponsePayload{
+		Answers: make([]askUserQuestionAnswerPayload, 0, len(p.questions)),
+	}
+	for i, question := range p.questions {
+		answerText := p.answerTextForQuestion(i)
+		if strings.TrimSpace(answerText) == "" {
+			continue
+		}
+		payload.Answers = append(payload.Answers, askUserQuestionAnswerPayload{
+			Question: question.Question,
+			Answer:   answerText,
+		})
+	}
+	return payload
+}
+
+func (p *askUserQuestionPromptState) answerTextForQuestion(index int) string {
+	if p == nil || index < 0 || index >= len(p.questions) || index >= len(p.answers) {
+		return ""
+	}
+	question := p.questions[index]
+	answer := p.answers[index]
+
+	if !question.MultiSelect {
+		if strings.TrimSpace(answer.other) != "" {
+			return strings.TrimSpace(answer.other)
+		}
+		for optionIndex := range question.Options {
+			if answer.selected[optionIndex] {
+				return question.Options[optionIndex].Label
+			}
+		}
+		return ""
+	}
+
+	parts := make([]string, 0, len(answer.selected)+1)
+	for optionIndex, option := range question.Options {
+		if answer.selected[optionIndex] {
+			parts = append(parts, option.Label)
+		}
+	}
+	if strings.TrimSpace(answer.other) != "" {
+		parts = append(parts, strings.TrimSpace(answer.other))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func renderAskUserQuestionPromptPopup(p *askUserQuestionPromptState) string {
+	if p == nil || len(p.questions) == 0 {
+		return ""
+	}
+
+	t := theme.Current
+	titleStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true)
+	subtitleStyle := lipgloss.NewStyle().Foreground(t.TextMuted)
+	questionStyle := lipgloss.NewStyle().Foreground(t.TextPrimary).Bold(true)
+	selectedStyle := lipgloss.NewStyle().Foreground(t.Accent).Bold(true)
+	normalStyle := lipgloss.NewStyle().Foreground(t.TextPrimary)
+	descStyle := lipgloss.NewStyle().Foreground(t.TextSecondary)
+	inputStyle := lipgloss.NewStyle().Foreground(t.TextPrimary).Border(lipgloss.RoundedBorder()).BorderForeground(t.Accent).Padding(0, 1)
+	hintStyle := lipgloss.NewStyle().Foreground(t.TextMuted).Italic(true)
+
+	question := p.currentQuestion()
+	progress := ""
+	if len(p.questions) > 1 {
+		progress = lipgloss.NewStyle().Foreground(t.TextMuted).Render(
+			strings.TrimSpace(
+				lipgloss.JoinHorizontal(lipgloss.Left,
+					"Question ",
+					itoa(p.current+1),
+					"/",
+					itoa(len(p.questions)),
+				),
+			),
+		)
+	}
+
+	lines := []string{titleStyle.Render(p.title)}
+	if progress != "" {
+		lines = append(lines, progress)
+	}
+	if header := strings.TrimSpace(question.Header); header != "" {
+		lines = append(lines, subtitleStyle.Render("["+header+"]"))
+	}
+	lines = append(lines, questionStyle.Render(question.Question), "")
+
+	for i, option := range question.Options {
+		lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.selectedOption == i, p.answers[p.current].selected[i], option.Label, option.Description, selectedStyle, normalStyle, descStyle)...)
+	}
+	lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.isOtherSelected(), strings.TrimSpace(p.answers[p.current].other) != "", "Other", "Type a custom answer.", selectedStyle, normalStyle, descStyle)...)
+
+	if p.textInput {
+		lines = append(lines, "", subtitleStyle.Render("Type your custom answer and press Enter"))
+		lines = append(lines, inputStyle.Render(renderAskUserQuestionInputValue(p.textValue)))
+	} else if other := strings.TrimSpace(p.answers[p.current].other); other != "" {
+		lines = append(lines, "", subtitleStyle.Render("Other: "+other))
+	}
+
+	lines = append(lines, "")
+	if question.MultiSelect {
+		lines = append(lines, hintStyle.Render("up/down move | space toggle | enter continue | esc cancel"))
+	} else {
+		lines = append(lines, hintStyle.Render("up/down move | enter confirm | esc cancel"))
+	}
+
+	content := strings.Join(lines, "\n")
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(t.Accent).
+		Padding(0, 1).
+		Render(content)
+}
+
+func renderAskUserQuestionOptionLine(multiSelect, isCursor, isSelected bool, label, description string, selectedStyle, normalStyle, descStyle lipgloss.Style) []string {
+	cursor := "  "
+	style := normalStyle
+	if isCursor {
+		cursor = "> "
+		style = selectedStyle
+	}
+
+	choice := "( )"
+	if multiSelect {
+		choice = "[ ]"
+		if isSelected {
+			choice = "[x]"
+		}
+	} else if isSelected {
+		choice = "(*)"
+	}
+
+	lines := []string{cursor + style.Render(choice+" "+label)}
+	if strings.TrimSpace(description) != "" {
+		lines = append(lines, "   "+descStyle.Render(description))
+	}
+	return lines
+}
+
+func renderAskUserQuestionInputValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return " "
+	}
+	return value + "|"
+}
+
+func itoa(v int) string {
+	return strconv.Itoa(v)
+}

--- a/ui/ask_user_question.go
+++ b/ui/ask_user_question.go
@@ -37,6 +37,11 @@ type askUserQuestionAnswerPayload struct {
 	Answer   string `json:"answer"`
 }
 
+const (
+	askUserQuestionChatLabel       = "Chat about this"
+	askUserQuestionChatDescription = "Type your own answer directly."
+)
+
 func toAskUserQuestionPromptState(ev model.Event) *askUserQuestionPromptState {
 	data := ev.AskUserQuestion
 	if data == nil {
@@ -111,6 +116,11 @@ func (a App) handleAskUserQuestionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		}
+	}
+
+	if seed, ok := askUserQuestionTextInputSeed(msg, p.currentQuestion().MultiSelect); ok {
+		p.beginCustomAnswerInput(seed)
+		return a, nil
 	}
 
 	switch msg.String() {
@@ -221,6 +231,16 @@ func (p *askUserQuestionPromptState) isOtherSelected() bool {
 	return p != nil && p.selectedOption == len(p.currentQuestion().Options)
 }
 
+func (p *askUserQuestionPromptState) beginCustomAnswerInput(seed string) {
+	if p == nil {
+		return
+	}
+	p.textInput = true
+	p.selectedOption = len(p.currentQuestion().Options)
+	p.textValue = p.answers[p.current].other
+	p.textValue += seed
+}
+
 func (p *askUserQuestionPromptState) hasAnswerForCurrentQuestion() bool {
 	if p == nil || p.current < 0 || p.current >= len(p.answers) {
 		return false
@@ -319,20 +339,20 @@ func renderAskUserQuestionPromptPopup(p *askUserQuestionPromptState) string {
 	for i, option := range question.Options {
 		lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.selectedOption == i, p.answers[p.current].selected[i], option.Label, option.Description, selectedStyle, normalStyle, descStyle)...)
 	}
-	lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.isOtherSelected(), strings.TrimSpace(p.answers[p.current].other) != "", "Other", "Type a custom answer.", selectedStyle, normalStyle, descStyle)...)
+	lines = append(lines, renderAskUserQuestionOptionLine(question.MultiSelect, p.isOtherSelected(), strings.TrimSpace(p.answers[p.current].other) != "", askUserQuestionChatLabel, askUserQuestionChatDescription, selectedStyle, normalStyle, descStyle)...)
 
 	if p.textInput {
 		lines = append(lines, "", subtitleStyle.Render("Type your custom answer and press Enter"))
 		lines = append(lines, inputStyle.Render(renderAskUserQuestionInputValue(p.textValue)))
 	} else if other := strings.TrimSpace(p.answers[p.current].other); other != "" {
-		lines = append(lines, "", subtitleStyle.Render("Other: "+other))
+		lines = append(lines, "", subtitleStyle.Render(askUserQuestionChatLabel+": "+other))
 	}
 
 	lines = append(lines, "")
 	if question.MultiSelect {
-		lines = append(lines, hintStyle.Render("up/down move | space toggle | enter continue | esc cancel"))
+		lines = append(lines, hintStyle.Render("up/down move | space toggle | enter continue | type to chat | esc cancel"))
 	} else {
-		lines = append(lines, hintStyle.Render("up/down move | enter confirm | esc cancel"))
+		lines = append(lines, hintStyle.Render("up/down move | enter confirm | type to chat | esc cancel"))
 	}
 
 	content := strings.Join(lines, "\n")
@@ -373,6 +393,16 @@ func renderAskUserQuestionInputValue(value string) string {
 		return " "
 	}
 	return value + "|"
+}
+
+func askUserQuestionTextInputSeed(msg tea.KeyMsg, multiSelect bool) (string, bool) {
+	if msg.Type == tea.KeyRunes && len(msg.Runes) > 0 {
+		return string(msg.Runes), true
+	}
+	if !multiSelect && msg.Type == tea.KeySpace {
+		return " ", true
+	}
+	return "", false
 }
 
 func itoa(v int) string {

--- a/ui/inline.go
+++ b/ui/inline.go
@@ -133,6 +133,8 @@ func (a App) renderMainView() string {
 	}
 	if a.permissionPrompt != nil {
 		parts = append(parts, renderPermissionPromptPopup(a.permissionPrompt))
+	} else if a.askUserQuestionPrompt != nil {
+		parts = append(parts, renderAskUserQuestionPromptPopup(a.askUserQuestionPrompt))
 	} else {
 		reservedParts := append([]string{}, parts...)
 		if queueBanner != "" {
@@ -495,7 +497,7 @@ func (a App) eventPrintCmd(ev model.Event, prevMessages []model.Message) tea.Cmd
 		return a.printMessage(model.Message{Kind: model.MsgAgent, Content: ev.Message, RawANSI: ev.RawANSI})
 	case model.AgentReplyDelta:
 		return a.printAgentDelta(ev.Message)
-	case model.AgentBackgroundWork, model.AgentThinking, model.TaskDone, model.TokenUpdate:
+	case model.AgentBackgroundWork, model.AgentThinking, model.TaskDone, model.TokenUpdate, model.AskUserQuestionPrompt, model.AskUserQuestionClose:
 		return nil
 	case model.ToolCallStart:
 		// Don't print pending tools to scrollback — they show in the live
@@ -514,7 +516,7 @@ func (a App) eventPrintCmd(ev model.Event, prevMessages []model.Message) tea.Cmd
 		return nil
 	case model.CmdFinished:
 		return a.printResolvedTool(ev)
-	case model.ToolRead, model.ToolGrep, model.ToolGlob, model.ToolEdit, model.ToolWrite, model.ToolSkill, model.ToolInterrupted, model.ToolWarning, model.ToolError, model.ToolReplay:
+	case model.ToolRead, model.ToolGrep, model.ToolGlob, model.ToolEdit, model.ToolWrite, model.ToolSkill, model.ToolAskUserQuestion, model.ToolInterrupted, model.ToolWarning, model.ToolError, model.ToolReplay:
 		return a.printResolvedTool(ev)
 	case model.ClearScreen:
 		return clearMessage()

--- a/ui/model/model.go
+++ b/ui/model/model.go
@@ -69,67 +69,71 @@ type Message struct {
 type EventType string
 
 const (
-	TaskUpdated          EventType = "TaskUpdated"
-	ToolCallStart        EventType = "ToolCallStart"
-	CmdStarted           EventType = "CmdStarted"
-	CmdOutput            EventType = "CmdOutput"
-	CmdFinished          EventType = "CmdFinished"
-	AnalysisReady        EventType = "AnalysisReady"
-	AgentReply           EventType = "AgentReply"
-	AgentReplyDelta      EventType = "AgentReplyDelta"
-	AgentBackgroundWork  EventType = "AgentBackgroundWork"
-	PermissionPrompt     EventType = "PermissionPrompt"
-	PermissionsView      EventType = "PermissionsView"
-	AgentThinking        EventType = "AgentThinking"
-	ContextNotice        EventType = "ContextNotice"
-	UserInput            EventType = "UserInput"
-	ToolReplay           EventType = "ToolReplay"
-	TokenUpdate          EventType = "TokenUpdate"
-	ToolRead             EventType = "ToolRead"
-	ToolGrep             EventType = "ToolGrep"
-	ToolGlob             EventType = "ToolGlob"
-	ToolEdit             EventType = "ToolEdit"
-	ToolWrite            EventType = "ToolWrite"
-	ToolSkill            EventType = "ToolSkill"
-	ToolInterrupted      EventType = "ToolInterrupted"
-	ToolWarning          EventType = "ToolWarning"
-	ToolError            EventType = "ToolError"
-	ClearScreen          EventType = "ClearScreen"
-	ModelUpdate          EventType = "ModelUpdate"
-	ModelPickerOpen      EventType = "ModelPickerOpen"
-	ModelSetupOpen       EventType = "ModelSetupOpen"
-	ModelSetupClose      EventType = "ModelSetupClose"
+	TaskUpdated           EventType = "TaskUpdated"
+	ToolCallStart         EventType = "ToolCallStart"
+	CmdStarted            EventType = "CmdStarted"
+	CmdOutput             EventType = "CmdOutput"
+	CmdFinished           EventType = "CmdFinished"
+	AnalysisReady         EventType = "AnalysisReady"
+	AgentReply            EventType = "AgentReply"
+	AgentReplyDelta       EventType = "AgentReplyDelta"
+	AgentBackgroundWork   EventType = "AgentBackgroundWork"
+	PermissionPrompt      EventType = "PermissionPrompt"
+	AskUserQuestionPrompt EventType = "AskUserQuestionPrompt"
+	AskUserQuestionClose  EventType = "AskUserQuestionClose"
+	PermissionsView       EventType = "PermissionsView"
+	AgentThinking         EventType = "AgentThinking"
+	ContextNotice         EventType = "ContextNotice"
+	UserInput             EventType = "UserInput"
+	ToolReplay            EventType = "ToolReplay"
+	TokenUpdate           EventType = "TokenUpdate"
+	ToolRead              EventType = "ToolRead"
+	ToolGrep              EventType = "ToolGrep"
+	ToolGlob              EventType = "ToolGlob"
+	ToolEdit              EventType = "ToolEdit"
+	ToolWrite             EventType = "ToolWrite"
+	ToolSkill             EventType = "ToolSkill"
+	ToolAskUserQuestion   EventType = "ToolAskUserQuestion"
+	ToolInterrupted       EventType = "ToolInterrupted"
+	ToolWarning           EventType = "ToolWarning"
+	ToolError             EventType = "ToolError"
+	ClearScreen           EventType = "ClearScreen"
+	ModelUpdate           EventType = "ModelUpdate"
+	ModelPickerOpen       EventType = "ModelPickerOpen"
+	ModelSetupOpen        EventType = "ModelSetupOpen"
+	ModelSetupClose       EventType = "ModelSetupClose"
 	ModelSetupTokenError EventType = "ModelSetupTokenError"
-	MouseModeToggle      EventType = "MouseModeToggle"
-	IssueUserUpdate      EventType = "IssueUserUpdate"
-	SkillsNoteUpdate     EventType = "SkillsNoteUpdate"
-	TaskDone             EventType = "TaskDone"
-	Done                 EventType = "Done"
+	MouseModeToggle       EventType = "MouseModeToggle"
+	IssueUserUpdate       EventType = "IssueUserUpdate"
+	SkillsNoteUpdate      EventType = "SkillsNoteUpdate"
+	TaskDone              EventType = "TaskDone"
+	Done                  EventType = "Done"
 )
 
 // Event is sent from the agent loop to the TUI.
 // Implements tea.Msg so Bubble Tea can route it.
 type Event struct {
-	Type        EventType
-	Task        string
-	Message     string
-	RawANSI     bool
-	ToolName    string
-	ToolCallID  string
-	Summary     string
-	Meta        map[string]any
-	ReplayWait  *ReplayWaitData
-	CtxUsed     int
-	CtxMax      int
-	TokensUsed  int
-	Train       *TrainEventData // non-nil for train events only
-	Project     *ProjectStatusView
-	Permission  *PermissionPromptData
-	Permissions *PermissionsViewData
-	Popup       *SelectionPopup // non-nil for popup events only
-	SetupPopup  *SetupPopup     // non-nil for model setup popup events
-	IssueView   *IssueEventData // non-nil for issue view events only
-	Issue       *issuepkg.Issue // reserved for lightweight issue payloads
+	Type            EventType
+	Task            string
+	Message         string
+	RawANSI         bool
+	ToolName        string
+	ToolCallID      string
+	Summary         string
+	Meta            map[string]any
+	ReplayWait      *ReplayWaitData
+	CtxUsed         int
+	CtxMax          int
+	TokensUsed      int
+	Train           *TrainEventData // non-nil for train events only
+	Project         *ProjectStatusView
+	Permission      *PermissionPromptData
+	AskUserQuestion *AskUserQuestionPromptData
+	Permissions     *PermissionsViewData
+	Popup           *SelectionPopup // non-nil for popup events only
+	SetupPopup      *SetupPopup     // non-nil for model setup popup events
+	IssueView       *IssueEventData // non-nil for issue view events only
+	Issue           *issuepkg.Issue // reserved for lightweight issue payloads
 }
 
 // ReplayWaitData lets replay fast-forward the UI timer while using shorter real delays.
@@ -150,6 +154,27 @@ type PermissionOption struct {
 	// Input is the token sent back to backend permission handler, e.g. "1", "2", "3", "esc".
 	Input string
 	Label string
+}
+
+// AskUserQuestionPromptData describes a structured question prompt rendered by the UI.
+type AskUserQuestionPromptData struct {
+	Title        string
+	SubmitPrefix string
+	Questions    []AskUserQuestionView
+}
+
+// AskUserQuestionView is one question shown in the interactive prompt.
+type AskUserQuestionView struct {
+	Header      string
+	Question    string
+	Options     []AskUserQuestionOption
+	MultiSelect bool
+}
+
+// AskUserQuestionOption is one selectable answer option.
+type AskUserQuestionOption struct {
+	Label       string
+	Description string
 }
 
 // PermissionsViewData is the payload for interactive /permissions view.


### PR DESCRIPTION
﻿## Summary
This PR adds a new interactive tool, `AskUserQuestion`, to `mindspore-cli`.

It gives the agent a Claude-Code-style way to pause execution, ask the user structured multiple-choice questions inside the TUI, collect the answer, and continue with the answer recorded as a normal tool result.

The implementation includes both the initial tool flow and a follow-up fix for custom/manual answers:
- add the full `AskUserQuestion` tool path to the runtime
- add a dedicated TUI question prompt instead of reusing the permission prompt UI
- support built-in `Other` custom text entry
- normalize explicit `Other` / `manual input` options so hosts and skills can still pass custom-path scenarios safely

## What This Adds
### New tool
`AskUserQuestion` is now a first-class tool in `mindspore-cli`.

It supports:
- `1-4` questions per call
- single-select and multi-select questions
- structured option labels and descriptions
- built-in `Other` custom text entry in the TUI
- normal tool-result return semantics, so the answer goes back to the model as part of the conversation/tool history

### Runtime integration
This PR wires the tool into the full runtime path:
- tool schema registration and provider-side nested schema support
- app wiring and prompt bridge
- TUI rendering and key handling
- tool lifecycle events and pending-tool resolution
- default permission behavior for `AskUserQuestion`

### Follow-up normalization fix
During readiness-skill testing, we hit a real host/skill interoperability issue:
- some flows already rely on the host to provide `Other`
- some model outputs still tried to pass an explicit `Other` / `manual input` option
- that produced duplicate `Other` entries and could fail option-count validation

This PR now strips explicit manual-input/`Other` options before rendering, while preserving the host-native `Other` path for custom answers such as CANN paths.

## Why This Change Is Needed
Before this PR, `mindspore-cli` did not have a native structured question tool.

That meant the model had only two bad choices when it needed user input:
- guess and keep going
- ask in plain text and lose the benefits of structured tool interaction

For workflows like environment selection, launcher choice, scope confirmation, or readiness checks, that is not enough. We need a native tool that can:
- pause at a decision point
- collect a structured user choice inside the TUI
- feed that answer back into the agent loop in a standard tool-call/tool-result form

This is especially important for skill-driven workflows such as `new-readiness-agent`, where the agent may need to confirm runtime choices like a Python environment, CANN path, or asset source before it should continue.

## Design Approach
The design intentionally follows the existing `mindspore-cli` architecture instead of introducing a new interactive runtime model.

Key design choices:
- keep `AskUserQuestion` as a normal tool, not a special-case loop primitive
- add a dedicated question UI instead of reusing the permission prompt UI
- keep answers flowing back as normal tool results so replay/session history stay aligned with the rest of the tool model
- extend the LLM tool schema just enough to support nested arrays/objects needed by `questions[].options[]`
- let the host own `Other`, so skills and prompts do not need to reinvent custom-text handling

This keeps the diff local and compatible with the current `internal/app -> agent/loop -> tools -> ui` execution path.

## How It Works
At a high level, the flow is:
1. the model emits an `AskUserQuestion` tool call
2. the runtime validates and normalizes the request
3. `internal/app` bridges the request into a dedicated TUI prompt
4. the user selects an option or chooses `Other` and types a custom answer
5. the UI serializes the response back to the app
6. the tool returns a normal tool result like `User has answered your questions: ...`
7. the agent continues with the collected answer in context

The lifecycle is intentionally visible in the UI, including a pending state while the tool is waiting for answers.

## Trigger Conditions
`AskUserQuestion` is still a model-invoked tool rather than a manual slash command.

The tool is intended to be used when the agent is blocked on:
- user preferences
- ambiguous requirements
- implementation choices
- runtime/environment choices that should not be guessed

This PR also tightens the system guidance so the model is explicitly told:
- use `AskUserQuestion` instead of guessing when blocked on user choices
- pass `1-4` concrete options
- never add an explicit `Other` / `manual-input` option because the host UI already provides it

In practice, trigger quality becomes much better for prompts like:
- "If you need me to choose scope, compatibility policy, or test level, use AskUserQuestion instead of guessing."
- "Do not make assumptions. When a runtime choice needs confirmation, call AskUserQuestion."

## Example Usage
### Example 1: implementation clarification
The model can ask:

```json
{
  "questions": [
    {
      "header": "Tests",
      "question": "Which tests should I add?",
      "options": [
        {"label": "unit", "description": "Add focused unit coverage."},
        {"label": "integration", "description": "Add end-to-end integration coverage."}
      ],
      "multiSelect": true
    }
  ]
}
```

The user can then:
- choose one or more options
- or select `Other` and type a custom answer

### Example 2: readiness confirmation
For readiness-style flows, the model can ask a single-field question such as:
- header: `CANN Path`
- question: `Which CANN path should we use?`
- options:
  - `/usr/local/Ascend/ascend-toolkit/latest`
  - `skip check for now`

If the user needs a custom path that is not listed, they can choose the built-in `Other` entry and type something like:
- `/home/cann_custom_path/8.5.0/ascend-toolkit/set_env.sh`

## Notable Behavior
- The host always provides a built-in `Other` path for custom text.
- Explicit `Other` / `manual input` options are normalized away before rendering.
- This prevents duplicate `Other` entries and makes host-side custom input reliable.
- `AskUserQuestion` is allowed by default, while explicit permission rules can still override that behavior.

## Scope of This PR
Included:
- `AskUserQuestion` tool implementation
- nested tool schema support needed for question/options payloads
- dedicated TUI prompt and input handling
- tool lifecycle/event integration
- design documentation
- normalization fix for explicit manual-input options

Not included:
- Claude Code's richer `preview` / `annotations` features
- a manual slash command that forces `AskUserQuestion`
- a generic runtime gate that automatically converts all skill confirmation states into tool calls

## Testing
Verified in this environment:
- `git diff --check`

Not run in this environment:
- `go test`
- `gofmt`

Reason:
- the current environment does not have a working Go toolchain available
