### PR TITLE
[factory] add issue-sourced known issue cards

### DIFF
--- a/incubating/factory/cards/known_issues/accuracy-compile-fusion-controlflow-drift.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-compile-fusion-controlflow-drift.yaml
@@ -1,0 +1,135 @@
+schema_version: "known_issue/v0.6"
+kind: known_issue
+id: accuracy-compile-fusion-controlflow-drift
+title: DVM CV fusion control-flow same-input drift
+tags:
+  - accuracy
+  - compile
+  - fusion
+  - controlflow
+  - dvm
+  - cv-fusion
+  - same-input
+  - gradient-drift
+
+case:
+  problem_type: accuracy
+  stage: compile
+  domain: mindspore
+  hardware: ascend
+  severity: high
+  occurrence_count: 1
+
+  environment:
+    frameworks:
+      - name: mindspore
+        version: "2.9.0"
+        branch: "master"
+        commit: "c899f34d"
+
+    runtime:
+      cann_version: "unknown"
+      python_version: "unknown"
+
+    model:
+      pattern: "control-flow while loop with Add + MatMul/BatchMatMulExt fusion"
+      execution_mode: "PyNative"
+      optimization: "DVM on/off comparison"
+      input_reuse: "same input reused across fused cube/load paths"
+      dtype: "float16"
+      input_shapes:
+        original_report: "(1024, 1024)"
+        regression_note: "(1, 1024, 1024)"
+
+    affected:
+      - "DVM-enabled control-flow CV fusion scenes"
+      - "same-input fused cube/load ownership path"
+
+match:
+  metadata:
+    problem_type: accuracy
+    stage: compile
+    domain: mindspore
+    hardware: ascend
+
+  keywords:
+    - "DVM"
+    - "CV融合"
+    - "控制流"
+    - "same input"
+    - "output and gradient mismatch"
+
+  regex:
+    - "(?i)dvm.*control"
+    - "(?i)cv.*fusion"
+    - "(?i)allclose\\(output1, output2"
+    - "(?i)开启DVM.*不开启DVM"
+
+guidance:
+  symptom: >
+    In a control-flow network, enabling DVM makes output and gradient compare
+    fail, while disabling DVM makes the same case pass.
+
+  trigger_signals:
+    - "开启 DVM 与不开启 DVM 对比时，output 不一致"
+    - "开启 DVM 与不开启 DVM 对比时，grad_output 不一致"
+    - "控制流 while 场景下的 CV 融合精度报错"
+
+  representative_errors:
+    - "assert np.allclose(output1, output2, 1e-03, 1e-03, equal_nan=True)"
+
+  diagnosis: >
+    DVM CV fusion mishandles same-input cube/load ownership in control-flow
+    scenes, and graph-split recovery does not fully preserve the relocated GM
+    tracking state needed by later cloned loads.
+
+  diagnosis_details:
+    - "cube 自有输入和后续融合共用 load，导致 load 状态被后续处理污染"
+    - "splitgraphd 场景首次重定位后，loadb 残留状态影响后续 clone/load 处理"
+    - "recover tracker 没把 relocation 后仍需要的 GM 节点完整纳入，导致恢复链不完整"
+
+  actions:
+    - "给 cube 自有输入重新创建独立 load，不再复用会参与后续融合的 load"
+    - "在 splitgraphd 场景处理首次重定位后残留的 loadb，并把相关 GM 节点加入 recover tracker，保证后续 clone loadb 还能被 cube_gen 正确处理"
+
+  fix: >
+    recreate dedicated loads for cube-owned inputs and add GM nodes to the
+    recover tracker after split-graph relocation
+
+  why_it_works:
+    - "独立 load 让 cube 输入生命周期与后续融合解耦，避免共享 load 状态被错误复用"
+    - "补齐 GM 恢复跟踪后，重定位后的 clone/load 仍能走到正确恢复链，不会读到脏状态"
+
+  verification: >
+    After the fix, enabling DVM no longer changes output or gradient in this
+    control-flow CV-fusion pattern.
+
+  non_causes:
+    - "不是普通 matmul 数值波动"
+    - "不是单纯 while 控制流语义错误"
+    - "不是仅梯度路径问题，forward 和 grad 都会漂"
+
+provenance:
+  references:
+    - "issue:org-issues#42220"
+    - "introduced_by:pr#91899"
+    - "fixed_by:pr#91960"
+
+  notes: >
+    Derived from org-issues#42220 root-cause discussion and linked fix landing.
+
+  expected_behavior:
+    - "关闭 DVM 作为 baseline，开启 DVM 后 output 对齐"
+    - "关闭 DVM 作为 baseline，开启 DVM 后 grad_output 对齐"
+    - "same-input matmul/elementwise 控制流 ST 用例通过"
+
+  regression_tests:
+    - "_run_matmul_same_input_elemwise"
+    - "_run_matmul_elemwise_same_input"
+
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: "initial revision aligned to KnownIssueCard source schema"
+  updated_at: "2026-05-09"

--- a/incubating/factory/cards/known_issues/accuracy-lite-int8-conv1x1-input-pack-batch-missing.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-lite-int8-conv1x1-input-pack-batch-missing.yaml
@@ -1,0 +1,120 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-lite-int8-conv1x1-input-pack-batch-missing
+title: Lite int8 Conv1x1 batch packing drift
+tags:
+- accuracy
+- lite
+- int8
+- conv1x1
+- batch-pack
+- android
+- cpp-infer
+case:
+  problem_type: accuracy
+  stage: infer
+  domain: mindspore-lite
+  hardware: cpu
+  severity: high
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindspore-lite
+      version: master
+      commit: dcd0eebbc7fbbb34e8173cbdce720019dd10b983
+    runtime:
+      python_version: '3.10'
+      runtime_target: android_aarch64_cpu_mate40
+      model_format: tflite
+      accelerator_version: Ascend 310
+    model:
+      runtime: Android aarch64 CPU
+      execution_mode: Lite C++ inference
+      quantization: int8
+      model: Q_language_model_hrmini_Q4_b4_17w.tflite
+      lite_build:
+        enable_train: 'ON'
+        enable_tools: 'ON'
+        enable_controlflow: 'ON'
+        enable_auto_parallel: 'ON'
+        enable_weight_decode: 'ON'
+        enable_custom_kernel: 'ON'
+        enable_mindrt: 'ON'
+        enable_delegate: 'ON'
+        enable_fp16: 'ON'
+        enable_int8: 'ON'
+    affected:
+    - mindspore-lite int8 inference
+    - Conv1x1
+    - batch dimension > 1
+    - Android aarch64 CPU Mate40
+match:
+  metadata:
+    problem_type: accuracy
+    stage: infer
+    domain: mindspore-lite
+    hardware: cpu
+  keywords:
+  - Conv1x1InputPack
+  - Conv1x1InputPackBatch
+  - android_aarch64_cpu_mate40
+  - int8
+  - 端侧C++推理精度失败
+  - Q_language_model_hrmini_Q4_b4_17w.tflite
+  regex:
+  - "(?i)conv1x1.*pack"
+  - "(?i)android.*cpu.*accuracy"
+guidance:
+  symptom: |
+    Android-side int8 C++ inference shows large output drift on a Lite model
+    when the Conv1x1 path sees batched input.
+  trigger_signals:
+  - 端侧 C++ 推理精度失败
+  - 同模型单 batch 正常，多 batch 漂移明显
+  - "[Check][Result][failed][base/backbone_out/Relu]: accepted=0.99, actual=0.766398"
+  - "[Check][Result][failed][base/class_out/BiasAdd]: accepted=0.99, actual=0.405105"
+  representative_errors:
+  - "[Check][Result][failed][base/backbone_out/Relu]: accepted=0.99, actual=0.766398"
+  - "[Check][Result][failed][base/class_out/BiasAdd]: accepted=0.99, actual=0.405105"
+  diagnosis: 'The source issue and root-cause comment both point to the same bug:
+    the low-level Conv1x1InputPack path only handled single-batch data and ignored
+    the batch dimension, so batched int8 inputs were packed into the wrong memory
+    layout before Conv1x1 execution.'
+  diagnosis_details:
+  - 底层 Conv1x1InputPack 函数只处理单 batch 数据
+  - batch 维度没有被正确打包进输入布局
+  - 在 int8 卷积调用点继续走旧 packing 路径，导致 batch>1 时输入读入错位
+  actions:
+  - 新增 Conv1x1InputPackBatch，显式支持多 batch 输入打包。
+  - 把 int8 Conv1x1 调用点切到新的 batch-aware packing 路径，而不是继续复用单 batch 的 Conv1x1InputPack。
+  - 按 issue 里的 Android 端转换 + C++ 推理流程回归，并执行 UT `TestConv1x1Int8.Conv1x1InputPackBatch_GoldenTest`。
+  fix: 新增 `Conv1x1InputPackBatch` 支持多 batch 打包，并把 int8 Conv1x1 调用点改到这个新路径。
+  why_it_works:
+  - batch 维度进入 packing 逻辑后，Conv1x1 读取的输入布局重新与真实 batched 数据对齐。
+  - 同一模型在端侧 C++ 推理路径上不再因为 batch>1 的 packing 错位而出现精度漂移。
+  verification: |
+    After the fix, batched int8 Conv1x1 inference no longer drifts from the
+    baseline on Android CPU.
+  non_causes:
+  - 不是模型权重本身损坏
+  - 不是 Android 端随机数值波动
+provenance:
+  references:
+  - issue:org-issues#42339
+  - fixed_by:mindspore-lite#738
+  notes: Rewritten from org-issues#42339 issue body and root-cause comments. The source
+    issue describes Android-side conversion and C++ inference steps, and the root-cause
+    comment pins the problem to single-batch-only Conv1x1InputPack handling.
+  expected_behavior:
+  - 原始 Android 端 C++ 推理 case 输出重新与 baseline 对齐
+  - 本地 UT TestConv1x1Int8.Conv1x1InputPackBatch_GoldenTest 通过
+  - 端侧精度回归通过
+  regression_tests:
+  - TestConv1x1Int8.Conv1x1InputPackBatch_GoldenTest
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42339 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-model-diffusers-scheduler-regression.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-model-diffusers-scheduler-regression.yaml
@@ -1,0 +1,113 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-model-diffusers-scheduler-regression
+title: Diffusers scheduler scalar-tensor eq demotion drift
+tags:
+- accuracy
+- model
+- diffusers
+- scheduler
+- eq
+- scalar-tensor
+- fp64
+- demotion
+case:
+  problem_type: accuracy
+  stage: infer
+  domain: mindone
+  hardware: ascend
+  severity: high
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindone
+      version: v0.3.0-dev
+    - name: mindspore
+      version: master
+      commit: ae2c0a77a
+    - name: torch
+      version: 2.4.0
+    - name: transformers
+      version: 4.46.3
+    - name: tokenizers
+      version: 0.20.4
+    runtime:
+      cann_version: 9.0.0 / 20260323
+    model:
+      model_area: diffusers scheduler
+      execution_mode: PyNative
+      testcase: tests/diffusers_tests/test_schedulers.py
+      dtype: comparison path involves float64 operands
+    affected:
+    - mindone diffusers scheduler regression test
+    - 两个输入进入 eq/==，其中右侧是标量 Tensor
+    - 重载特性把标量 Tensor 自动降成标量
+match:
+  metadata:
+    problem_type: accuracy
+    stage: infer
+    domain: mindone
+    hardware: ascend
+  keywords:
+  - DPMSolverSDEScheduler
+  - eq
+  - scalar Tensor
+  - disable_scalar_tensor
+  - float64
+  regex:
+  - "(?i)dpmsolversdescheduler"
+  - "(?i)eq.*scalar"
+guidance:
+  symptom: |
+    DPMSolverSDEScheduler fails its alignment test even though the scheduler
+    formula itself is not wrong; the drift comes from an `eq` comparison path
+    that silently changes scalar-tensor precision.
+  trigger_signals:
+  - DPMSolverSDEScheduler 精度不达标
+  - test_schedulers[float32-scheduler_name4] 断言失败
+  - 问题最终落在 compare/eq 分支，不在 scheduler 方程本身
+  representative_errors: []
+  diagnosis: 'The root-cause comment states that `==/eq` changed behavior after a
+    recent overload feature: when both operands should stay in float64 and the right-hand
+    side is a scalar Tensor, the scalar Tensor is silently converted to a scalar and
+    precision is demoted from fp64 to fp32, which corrupts the compare result used
+    by DPMSolverSDEScheduler.'
+  diagnosis_details:
+  - 问题不在 scheduler 公式，而在 compare 语义被重载特性改坏
+  - 右侧标量 Tensor 被默认转标量时丢失 fp64 精度
+  - 比较结果变错后，scheduler 分支判断随之漂移
+  actions:
+  - '在 `eq.yaml` 中增加 `disable_scalar_tensor: other`，禁用右侧标量 Tensor 自动转标量。'
+  - 回归 `tests/diffusers_tests/test_schedulers.py` 中的 DPMSolverSDEScheduler 场景，并保留这个
+    compare 形态的看护用例。
+  fix: 修复 `eq` 的标量 Tensor 自动降级路径，在右侧为标量 Tensor 时保持 Tensor compare 语义。
+  why_it_works:
+  - 右侧操作数不再被偷偷降成标量后，float64 compare 保持在 Tensor 路径上，不会误降到 fp32。
+  - scheduler 分支判断重新建立在正确的 compare 结果上，因此不需要修改 scheduler 公式本身。
+  verification: |
+    After the fix, DPMSolverSDEScheduler aligns with the reference without any
+    scheduler-equation workaround, because the underlying eq compare semantics
+    are corrected.
+  non_causes:
+  - 不是单纯 scheduler 推导错误
+provenance:
+  references:
+  - issue:org-issues#42290
+  - introduced_by:mindspore#91746
+  - fixed_by:mindspore#92163
+  notes: Rewritten from org-issues#42290 issue body and root-cause comments. The source
+    issue reports DPMSolverSDEScheduler test failure, and the root-cause comment ties
+    it to eq overload behavior rather than scheduler math.
+  expected_behavior:
+  - 原始 test_schedulers 中 DPMSolverSDEScheduler case 通过
+  - daily 包回归通过
+  - 新增 ST 看护当前 scalar-tensor eq 场景
+  regression_tests:
+  - tests/diffusers_tests/test_schedulers.py
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42290 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-model-qwen3vl-resize-interpolate-mismatch.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-model-qwen3vl-resize-interpolate-mismatch.yaml
@@ -1,0 +1,120 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-model-qwen3vl-resize-interpolate-mismatch
+title: Qwen3VL resize interpolate semantic mismatch
+tags:
+- accuracy
+- qwen3vl
+- interpolate
+- resize
+- image-preprocess
+- training
+- torch-parity
+case:
+  problem_type: accuracy
+  stage: train
+  domain: mindspore
+  hardware: ascend
+  severity: high
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindspore
+      version: master
+      commit: 4b99047cefc86fa0af9b5c0be7f0b8c4aee9b644
+    - name: torch
+      version: 2.7.1
+    - name: torch-npu
+      version: 2.7.1.post4.dev20260226
+    - name: transformers
+      version: 4.57.0
+    - name: sqlalchemy
+      version: 2.0.36
+    - name: megatron-lm
+      version: a845aa7e12b3a117e24c2352b9e3e60bad2e3a17
+    - name: mindspeed
+      version: 932fc7906f49d6e8d4bf0860ecf11c2a89dc2922
+    - name: mindspeed-mm
+      version: 7b8e497efcbfb1a44a77a03a7755de88f1a0424a
+    - name: msadapter
+      version: 81032fd5bb226a0f679994dfbc1f86adde335d33
+    runtime:
+      cann_version: 9.0.0.B073_20260317
+      python_version: '3.12'
+    model:
+      model_area: vision preprocessing
+      topology: tp1 / pp2 / cp1 / GBS8
+      dataset: COCO
+      training_mode: fine-tuning, non-frozen, deterministic enabled
+      resize_path: torchvision/transforms/v2/functional/_geometry.py::resize_image
+        -> interpolate
+    affected:
+    - Qwen3VL image preprocessing in training
+    - resize_image 调到 interpolate
+    - MindSpore vs torch 行为不一致
+match:
+  metadata:
+    problem_type: accuracy
+    stage: train
+    domain: mindspore
+    hardware: ascend
+  keywords:
+  - qwen3vl
+  - resize_image
+  - interpolate
+  - 8B
+  - 30B
+  regex:
+  - "(?i)qwen3vl"
+  - "(?i)resize.*interpolate"
+guidance:
+  symptom: |
+    Qwen3VL 8B/30B fine-tuning drifts even with deterministic mode enabled,
+    and the first stable divergence is traced back to the image resize path.
+  trigger_signals:
+  - qwen3vl 8B/30B 网络训练精度异常
+  - 和 PTA 对比时 loss 逐 step 漂移
+  - 问题集中在 resize_image / interpolate 路径
+  representative_errors: []
+  diagnosis: 'The source issue comments identify the first stable divergence in the
+    Qwen3VL training pipeline at `resize_image -> interpolate`: `ms.ops.interpolate`
+    does not match the torch path for this scene, so preprocessing drifts before the
+    model proper, and the training loss drift is downstream of that mismatch.'
+  diagnosis_details:
+  - 精度对齐时定位到 torchvision resize_image 中的 interpolate 调用
+  - mode / align_corners / antialias 三个参数组合触发与 torch 不一致的行为
+  - 前处理输出先漂移，随后带着漂移进入主网络训练
+  actions:
+  - 在精度对齐阶段，先对比 `resize_image` 输出，确认漂移发生在前处理而不是主网络。
+  - 按 root-cause comment 的临时规避方式，在 `torchvision/transforms/v2/functional/_geometry.py`
+    的 `resize_image` 里注释 `interpolate` 的 `mode`、`align_corners`、`antialias` 三个参数。
+  - 在规避后重新对齐 Qwen3VL 8B 和 30B 的训练场景，并继续推进长期的 op-plugin/mint 语义对齐。
+  fix: 短期按 issue 评论中的方案规避 `resize_image` 调用里的 `interpolate` 参数组合；长期需要把该路径切到与 torch
+    对齐的实现语义。
+  why_it_works:
+  - 先把 resize 路径的语义偏差压住后，loss 漂移不会再从图像前处理一路传进训练主干。
+  - 把问题锁定在 `interpolate` 语义层，可以避免把它误判成大模型训练链路本身的精度问题。
+  verification: |
+    After the fix, Qwen3VL image preprocessing matches the reference path and
+    the observed training loss drift disappears in both 8B and 30B scenes.
+  non_causes:
+  - 不是 Qwen3VL 主网络结构本身错误
+  - 不是随机性或数据集不稳定导致
+provenance:
+  references:
+  - issue:org-issues#42408
+  notes: Rewritten from org-issues#42408 issue body and root-cause comments. The source
+    issue tracks Qwen3VL 8B/30B training loss drift, and the root-cause comment attributes
+    it to interpolate semantic mismatch in the resize path.
+  expected_behavior:
+  - Qwen3VL 8B 精度恢复
+  - Qwen3VL 30B 精度恢复
+  - resize path 输出与 reference 对齐
+  - loss 绝对误差回到 0.0
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42408 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-operator-atan-precision-drift.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-operator-atan-precision-drift.yaml
@@ -1,0 +1,89 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-operator-atan-precision-drift
+title: Atan complex tolerance false positive
+tags:
+- accuracy
+- operator
+- atan
+- complex
+- tolerance
+- testcase
+case:
+  problem_type: accuracy
+  stage: infer
+  domain: mindspore
+  hardware: cpu
+  severity: medium
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindspore
+      version: master
+      commit: 20fd6e9d
+    runtime:
+      cann_version: none
+      python_version: unknown
+    model:
+      execution_mode: GRAPH_MODE
+      testcase: test_p_atan_input_20x7x8x2x3_complex64
+      overflow_flag: MS_ASCEND_CHECK_OVERFLOW_MODE=INFNAN_MODE
+match:
+  metadata:
+    problem_type: accuracy
+    stage: infer
+    domain: mindspore
+    hardware: cpu
+  keywords:
+  - atan
+  - complex64
+  - complex128
+  - tolerance
+  regex:
+  - "(?i)atan.*complex"
+guidance:
+  symptom: |
+    CPU `atan` appears to fail complex precision checks, but the mismatch comes
+    from an overly strict testcase tolerance rather than the operator kernel.
+  trigger_signals:
+  - CPU 后端 atan 算子精度异常
+  - complex64/complex128 场景误报不一致
+  - 把 complex64 loss 设成 1e-6 时失败，放宽后通过
+  representative_errors:
+  - complex64/complex128 场景误报不一致
+  diagnosis: 'The root-cause comment says this is not a kernel defect: the test repository
+    set the complex64 and complex128 loss thresholds too strictly, so normal floating-point
+    variation on complex atan was misclassified as an operator precision bug.'
+  diagnosis_details:
+  - complex64 原用例把 fact.loss 设成 1e-6，阈值过严
+  - 回归结论是 complex64 调到 1e-4、complex128 调到 1e-5 后即可通过
+  actions:
+  - 按 issue 评论调整测试阈值：`complex64` 场景把 `fact.loss` 调到 `1e-4`。
+  - 按 issue 评论调整测试阈值：`complex128` 场景把 `fact.loss` 调到 `1e-5`。
+  - 排查同类复数测试用例是否也沿用了过严的 loss 阈值。
+  fix: 放宽复数 `atan` 测试用例的 loss 阈值，而不是修改 CPU atan 算子实现。
+  why_it_works:
+  - 阈值回到合理区间后，正常复数浮点波动不会再被误报成精度缺陷。
+  verification: |
+    After the fix, complex `atan` no longer reports false precision failures
+    caused only by an over-strict testcase threshold.
+  non_causes:
+  - 不是 atan kernel 算法实现错误
+provenance:
+  references:
+  - issue:org-issues#42194
+  notes: Rewritten from org-issues#42194 issue body and root-cause comments. The source
+    issue reports CPU atan precision failure on complex inputs, and the root-cause
+    comment identifies it as an over-strict testcase threshold.
+  expected_behavior:
+  - complex64/complex128 case 在新容差下稳定通过
+  - 实数场景容差不被放宽过度
+  regression_tests:
+  - test_p_atan_input_20x7x8x2x3_complex64
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42194 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-operator-atan2-precision-drift.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-operator-atan2-precision-drift.yaml
@@ -1,0 +1,96 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-operator-atan2-precision-drift
+title: Atan2 910A boundary-value hardware limitation
+tags:
+- accuracy
+- operator
+- atan2
+- 910a
+- 910b
+- boundary-value
+- hardware-limitation
+case:
+  problem_type: accuracy
+  stage: infer
+  domain: mindspore
+  hardware: ascend
+  severity: medium
+  occurrence_count: 2
+  environment:
+    frameworks:
+    - name: mindspore
+      version: master
+      commit: c899f34dbd6ab49886b6970c72d432e0e6c0556e
+    runtime:
+      hardware_detail: 910A / 910B
+    model:
+      affected_scenes:
+      - mint.atan2(Tensor(False), Tensor(False))
+      - mint.atan2(0, 0)
+      hardware_scope: 910A only
+    affected:
+    - 910A boundary-value scene
+    - mint.atan2(False, False)
+    - mint.atan2(0, 0)
+match:
+  metadata:
+    problem_type: accuracy
+    stage: infer
+    domain: mindspore
+    hardware: ascend
+  keywords:
+  - atan2
+  - 910A
+  - 910B
+  - bool
+  - '0,0'
+  - boundary
+  regex:
+  - "(?i)atan2.*910a"
+guidance:
+  symptom: |
+    `atan2` appears inconsistent between 910A, 910B, and torch on a boundary
+    scene, but the mismatch is tied to a 910A hardware limitation rather than
+    a generic operator regression.
+  trigger_signals:
+  - mint.atan2 910A 对 Bool 类型支持与 torch 及 910B 不符
+  - 910A / 910B 输出不一致
+  - mint.atan2(False, False) 在 910A 返回 1.5708，而 torch 返回 0
+  representative_errors:
+  - 910A / 910B 输出不一致
+  diagnosis: 'Both root-cause comments say the same thing: this is a 910A hardware
+    limitation. 910A lacks part of the TBE instruction support for these boundary-value
+    scenes, so the `(False, False)` and `(0, 0)` cases cannot be made to match torch/910B
+    through a normal atan2 operator fix.'
+  diagnosis_details: []
+  actions:
+  - 确认问题只在 910A 边界值场景触发，而不是通用的 `atan2` 功能回退。
+  - 按 issue 评论修改看护策略：该边界场景不再对 910A 做精度看护。
+  - 保留 910B 和其他正常场景的持续看护，并在能力说明里标记 910A 的这个限制。
+  fix: 把该场景按 910A 硬件限制处理，调整测试看护范围，而不是尝试修补 `atan2` 数学实现。
+  why_it_works:
+  - 把硬件不支持的边界值从通用精度判定里剥离后，问题定位不会继续被误导成算子回归。
+  verification: |
+    After the fix, unsupported 910A boundary-value behavior is treated as a
+    documented hardware limitation instead of an operator regression.
+  non_causes:
+  - 不是通用 atan2 算法错误
+  - 不是所有 dtype 都存在该问题
+provenance:
+  references:
+  - issue:org-issues#42217
+  - issue:org-issues#42218
+  notes: Rewritten from org-issues#42217 and org-issues#42218 issue bodies and root-cause
+    comments. Both source issues describe the same 910A-only boundary-value limitation
+    for mint.atan2.
+  expected_behavior:
+  - 910A 边界值场景不再被当作通用精度缺陷
+  - 910B 与其他正常场景继续保持看护
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42217/#42218 source bodies and root-cause
+    comments on 2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-operator-baddbmm-dtype-drift.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-operator-baddbmm-dtype-drift.yaml
@@ -1,0 +1,109 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-operator-baddbmm-dtype-drift
+title: Mint baddbmm benchmark input mutation drift
+tags:
+- accuracy
+- operator
+- baddbmm
+- mint
+- cann
+- input-mutation
+- benchmark-pollution
+- dynamic-shape
+case:
+  problem_type: accuracy
+  stage: infer
+  domain: mindspore
+  hardware: ascend
+  severity: high
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindspore
+      version: master
+      commit: 6f53027e
+    runtime:
+      cann_version: '20260330'
+      python_version: '3.12'
+    model:
+      execution_mode:
+      - PYNATIVE_MODE
+      - GRAPH_MODE + O0 + ME_DYNAMIC_SHAPE=1
+      testcase_family:
+      - dynamic_shape_mint_f_baddbmm_dyn_rank_*
+      - dynamic_shape_mint_f_baddbmm_dyn_shape_*
+      - mint_f_baddbmm_bfloat16_3d_3x3x7_random
+    affected:
+    - mint.baddbmm
+    - beta 路径参与计算
+    - benchmark 直接复用 MindSpore 输入
+match:
+  metadata:
+    problem_type: accuracy
+    stage: infer
+    domain: mindspore
+    hardware: ascend
+  keywords:
+  - baddbmm
+  - fp16
+  - fp32
+  - dynamic shape
+  - beta
+  - input0
+  - 原地乘beta
+  regex:
+  - "(?i)baddbmm.*ascend"
+guidance:
+  symptom: |
+    Ascend `mint.baddbmm` looks inaccurate in both regular and dynamic-shape
+    scenes, but the visible mismatch is caused by polluted benchmark input.
+  trigger_signals:
+  - mint.baddbmm fp16/fp32 ascend 结果与标杆不一致
+  - dynamic shape 场景也会报
+  - 同类问题在 bfloat16 图模式动态 shape 场景也可复现
+  representative_errors:
+  - mint.baddbmm fp16/fp32 ascend 结果与标杆不一致
+  diagnosis: 'The root-cause discussion says the visible mismatch is not from baddbmm
+    math itself: a CANN-side optimization bug multiplies `input0` by `beta` in place,
+    so after MindSpore runs, the benchmark side reuses already-mutated input data
+    and reports a false mismatch. The same mutated-input family also shows up in dynamic-shape
+    and bfloat16 scenes.'
+  diagnosis_details:
+  - 海思算子优化引入问题，input0 会被原地乘 beta
+  - MindSpore 执行完后输入被改写，torch/benchmark 继续使用这份输入，导致参考值错误
+  - 动态 shape 与 bfloat16 场景复现的是同一类根因
+  actions:
+  - 不要直接复用 `ms_input` 做 benchmark/reference，先 clone/copy 输入。
+  - 确认运行环境使用了已修复这个原地改写问题的 CANN 版本。
+  - 按 issue 评论回归普通场景、dynamic-shape 场景和 bfloat16 图模式场景。
+  fix: 隔离 benchmark 输入，避免复用被原地改写的 `input0`，并在已修复该问题的 CANN 版本上回归。
+  why_it_works:
+  - 参考路径输入不再被污染后，误差来源会从“假阳性 benchmark 漂移”恢复成真实数值比较。
+  - 同一类 mutated-input 根因在静态、动态和 bfloat16 场景里会一起消失。
+  verification: |
+    After the fix, `mint.baddbmm` no longer shows false drift caused by a
+    mutated benchmark input across static and dynamic scenes.
+  non_causes:
+  - 不是 mint.baddbmm 主输出本身数值公式错误
+provenance:
+  references:
+  - issue:org-issues#42253
+  notes: Rewritten from org-issues#42253 issue body and root-cause comments. The source
+    issue covers mint.baddbmm drift in regular, dynamic-shape, and bfloat16 scenes,
+    and the comments trace them back to the same mutated-input bug.
+  expected_behavior:
+  - clone 后 benchmark 与框架结果恢复一致
+  - 动态 shape case 重新通过
+  - bfloat16 动态 shape case 重新通过
+  regression_tests:
+  - dynamic_shape_mint_f_baddbmm_dyn_rank_*
+  - dynamic_shape_mint_f_baddbmm_dyn_shape_*
+  - mint_f_baddbmm_bfloat16_3d_3x3x7_random
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42253 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-operator-baddbmm-precision-drift.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-operator-baddbmm-precision-drift.yaml
@@ -1,0 +1,94 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-operator-baddbmm-precision-drift
+title: Baddbmm false precision drift from mutated reference input
+tags:
+- accuracy
+- operator
+- baddbmm
+- cann
+- reference-pollution
+- beta-path
+case:
+  problem_type: accuracy
+  stage: infer
+  domain: mindspore
+  hardware: ascend
+  severity: high
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindspore
+      version: master
+      commit: 6f53027e
+    runtime:
+      cann_version: '20260330'
+      python_version: '3.12'
+    model:
+      execution_mode: PYNATIVE_MODE
+      testcase: tensor_baddbmm_input_dtype_float32_3d
+      runtime_observation: torch_npu shows the same wrong value as MindSpore after
+        input mutation
+match:
+  metadata:
+    problem_type: accuracy
+    stage: infer
+    domain: mindspore
+    hardware: ascend
+  keywords:
+  - baddbmm
+  - beta
+  - input tensor mutated
+  - reference polluted
+  - torch_npu
+  regex:
+  - "(?i)baddbmm.*precision"
+guidance:
+  symptom: |
+    `ops.baddbmm` is reported as a precision issue on Ascend, but the mismatch
+    comes from a polluted reference path after the input tensor is mutated.
+  trigger_signals:
+  - ops.baddbmm 存在精度问题
+  - 执行后参考值越来越偏
+  - torch_npu 复现出与 MindSpore 相同的错误值
+  representative_errors: []
+  diagnosis: The source comments explicitly say `input0` is multiplied by `beta` in
+    place during execution. The benchmark then reuses that polluted input to compute
+    the torch/numpy reference, so the reported mismatch is a false positive. The same
+    wrong value also reproduces in torch_npu, which further points to a lower-level
+    CANN issue rather than baddbmm operator math.
+  diagnosis_details:
+  - 问题由 CANN 升级引入
+  - input0 原地乘 beta 后，reference 继续复用被污染输入
+  - torch_npu 同样出现相同错误值，进一步指向底层 runtime 问题
+  actions:
+  - benchmark/reference 侧先复制输入，避免复用被 MindSpore 执行后污染的 `input0`。
+  - 升级到已修复该输入原地改写问题的 CANN 版本。
+  - 用 torch_npu / torch 交叉验证同一输入是否也会被底层原地改写。
+  fix: 先解耦 benchmark 输入，再在已修复该原地改写问题的 CANN 版本上验证 `baddbmm`。
+  why_it_works:
+  - 输入与 reference 解耦后，测试不再把“参考值被污染”误报成算子精度问题。
+  verification: |
+    After the fix, `baddbmm` no longer shows false precision drift caused by
+    mutated benchmark input.
+  non_causes:
+  - 不是 baddbmm 数学定义实现错误
+provenance:
+  references:
+  - issue:org-issues#42228
+  notes: Rewritten from org-issues#42228 issue body and root-cause comments. The source
+    issue reports baddbmm precision drift, while the root-cause comments identify
+    it as a CANN-side input-mutation problem that also reproduces in torch_npu.
+  expected_behavior:
+  - 复制输入后 reference 稳定
+  - 修复版 runtime 上 baddbmm case 通过
+  - MindSpore 结果正确而 reference 不再被输入污染
+  regression_tests:
+  - tensor_baddbmm_input_dtype_float32_3d
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42228 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-operator-clamp-precision-drift.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-operator-clamp-precision-drift.yaml
@@ -1,0 +1,91 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-operator-clamp-precision-drift
+title: Clamp O1 Cmp fusion drift
+tags:
+- accuracy
+- operator
+- clamp
+- o1
+- dvm
+- cmp-fusion
+- compile
+case:
+  problem_type: accuracy
+  stage: compile
+  domain: mindspore
+  hardware: ascend
+  severity: high
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindspore
+      version: master
+      commit: 20fd6e9d
+    runtime:
+      cann_version: '20260317'
+      python_version: '3.12'
+    model:
+      execution_mode: GRAPH_MODE
+      optimization_switch: CONTEXT_JIT_LEVEL=O1
+      testcase: t_clamp_bfloat16_6d_4x4x8x9x4x4_random_broadcast
+      dtype: bfloat16
+match:
+  metadata:
+    problem_type: accuracy
+    stage: compile
+    domain: mindspore
+    hardware: ascend
+  keywords:
+  - Tensor.clamp
+  - O1
+  - Cmp融合
+  regex:
+  - "(?i)clamp.*o1"
+guidance:
+  symptom: |
+    `Tensor.clamp` only drifts in O1 mode, indicating the error comes from the
+    fused compile path rather than clamp arithmetic itself.
+  trigger_signals:
+  - Tensor.clamp O1 模式下结果与标杆不一致
+  - 非 O1 场景不报
+  - 同一场景下 forward/grad compare 在 O1 模式漂移
+  representative_errors:
+  - Tensor.clamp O1 模式下结果与标杆不一致
+  diagnosis: 'The root-cause comment is direct: O1 mode `Cmp` fusion on the DVM side
+    is wrong. The issue is not in clamp arithmetic itself, but in the compare-fusion
+    path used when clamp is lowered in O1 mode.'
+  diagnosis_details:
+  - 问题在 O1 模式下复现，说明偏差来自编译融合路径
+  - Cmp 融合语义出错后，clamp 依赖的比较结果被带偏
+  actions:
+  - 修复 DVM 侧 O1 `Cmp` 融合算子问题。
+  - 复用 issue 中的 `t_clamp_bfloat16_6d_4x4x8x9x4x4_random_broadcast` 场景回归 forward 和
+    grad compare。
+  fix: 修复 O1 模式下的 DVM `Cmp` 融合路径，而不是改单独的 clamp 逻辑。
+  why_it_works:
+  - clamp 依赖的 compare 语义恢复正确后，O1 模式下的结果和梯度会一起回到基线。
+  verification: |
+    After the fix, clamp matches the baseline in O1 mode because the fused
+    compare path no longer drifts.
+  non_causes:
+  - 不是 clamp 本身数学公式错误
+provenance:
+  references:
+  - issue:org-issues#42271
+  - introduced_by:mindspore#91899
+  notes: Rewritten from org-issues#42271 issue body and root-cause comments. The source
+    issue reports clamp mismatch only in O1 mode, and the root-cause comment attributes
+    it to the O1-mode Cmp fusion path.
+  expected_behavior:
+  - O1 模式 clamp 结果恢复对齐
+  - 非 O1 场景保持不回退
+  regression_tests:
+  - t_clamp_bfloat16_6d_4x4x8x9x4x4_random_broadcast
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42271 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/accuracy-operator-cos-precision-drift.yaml
+++ b/incubating/factory/cards/known_issues/accuracy-operator-cos-precision-drift.yaml
@@ -1,0 +1,95 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: accuracy-operator-cos-precision-drift
+title: Cos complex benchmark conjugate false positive
+tags:
+- accuracy
+- operator
+- cos
+- complex
+- benchmark
+- conjugate
+- testcase
+case:
+  problem_type: accuracy
+  stage: infer
+  domain: mindspore
+  hardware: cpu
+  severity: medium
+  occurrence_count: 1
+  environment:
+    frameworks:
+    - name: mindspore
+      version: master
+      commit: 0b12b4a1
+    runtime:
+      cann_version: none
+    model:
+      execution_mode: GRAPH_MODE
+      testcase_family:
+      - test_p_cos_input_2d_complex64
+      - test_p_cos_input_4d_complex64
+      - test_p_cos_input_5d_complex128
+      - test_p_cos_input_6d_complex64
+      - test_p_cos_input_7d_complex128
+match:
+  metadata:
+    problem_type: accuracy
+    stage: infer
+    domain: mindspore
+    hardware: cpu
+  keywords:
+  - cos
+  - complex64
+  - complex128
+  - conjugate
+  regex:
+  - "(?i)cos.*complex"
+guidance:
+  symptom: |
+    Complex `cos` on CPU appears inaccurate, but the mismatch is caused by an
+    extra conjugate inserted in the benchmark path.
+  trigger_signals:
+  - cos 算子复数类型 complex64/complex128 精度异常
+  - 框架输出和参考值方向相反或被额外处理
+  representative_errors: []
+  diagnosis: 'The root-cause comment explicitly says this is not an operator problem:
+    the testcase wrote the benchmark path incorrectly by applying an extra conjugate,
+    so the comparison target itself was wrong.'
+  diagnosis_details:
+  - 与开发确认后结论是测试用例写错
+  - 多做的共轭导致 reference 被改坏，不是算子输出错误
+  actions:
+  - 检查 complex benchmark/reference 是否多做了 conjugate。
+  - 删除测试用例中的额外共轭处理。
+  - 回归 complex64/complex128 的各个 shape 场景。
+  fix: 修改测试用例，去掉 benchmark 路径里多余的 conjugate。
+  why_it_works:
+  - 参考路径恢复正确后，CPU complex `cos` 的输出会自然与基准对齐。
+  verification: |
+    After the fix, complex `cos` no longer shows a false mismatch caused by the
+    benchmark path.
+  non_causes:
+  - 不是 cos kernel 的复数实现错误
+provenance:
+  references:
+  - issue:org-issues#42131
+  notes: Rewritten from org-issues#42131 issue body and root-cause comments. The source
+    issue reports complex cos precision failure, and the root-cause comment says the
+    testcase inserted an extra conjugate.
+  expected_behavior:
+  - complex64/complex128 场景对齐
+  - CPU 端参考值一致
+  regression_tests:
+  - test_p_cos_input_2d_complex64
+  - test_p_cos_input_4d_complex64
+  - test_p_cos_input_5d_complex128
+  - test_p_cos_input_6d_complex64
+  - test_p_cos_input_7d_complex128
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from org-issues#42131 source body and root-cause comments on
+    2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/cards/known_issues/function-runtime-module-import-missing.yaml
+++ b/incubating/factory/cards/known_issues/function-runtime-module-import-missing.yaml
@@ -1,0 +1,121 @@
+schema_version: known_issue/v0.6
+kind: known_issue
+id: function-runtime-module-import-missing
+title: MindFormers experimental module import breakage
+tags:
+- b-componenttest
+- mindspore-org-issues
+- runtime
+- import
+- module-missing
+- b-sig-mindformers-infer
+- mindspore-mindformers
+- golden-stick
+- pangu-deploy
+case:
+  problem_type: failure
+  stage: runtime
+  domain: mindformers
+  hardware: ascend
+  severity: high
+  occurrence_count: 5
+  environment:
+    frameworks:
+    - name: mindformers
+      version: dev
+    - name: golden-stick
+    - name: mindrlhf
+    - name: pangu-deploy
+    runtime:
+      cann_version: unknown
+      python_version: unknown
+    model:
+      error_family: downstream imports still reference removed or relocated mindformers.experimental
+        modules
+      affected_projects:
+      - ms_custom_ops
+      - golden-stick
+      - mindrlhf
+      - pangu_deploy
+      execution_modes:
+      - inference
+      - quantization
+      - parallel runtime
+    affected:
+    - MindFormers dev-branch refactors that remove or relocate mindformers.experimental
+      APIs
+    - Downstream projects that still import removed experimental parallel_core helpers
+match:
+  metadata:
+    problem_type: failure
+    stage: runtime
+    domain: mindformers
+    hardware: ascend
+  keywords:
+  - mindformers.experimental
+  - ModuleNotFoundError
+  - ImportError
+  - parallel_core
+  - get_tensor_model_parallel_rank
+  regex:
+  - "(ModuleNotFoundError|No module named|ImportError)"
+guidance:
+  symptom: |
+    Multiple downstream projects broke after MindFormers dev-branch refactors
+    removed or relocated `mindformers.experimental.*` modules. The failures show
+    up as `No module named ...` import errors in inference and quantization
+    scenarios. The real repair is not a generic environment workaround: callers
+    must update imports to the new MindFormers locations, and any helper that was
+    dropped from dev must be carried or reimplemented in the downstream project.
+  trigger_signals:
+  - No module named mindformers.experimental
+  - Failed to import get_tensor_model_parallel_rank from both possible locations
+  - MindFormers dev refactor后，下游推理或量化任务在 import 阶段直接失败
+  representative_errors:
+  - "(ModuleNotFoundError|No module named|ImportError)"
+  - No module named 'mindformers.experimental'
+  - Failed to import get_tensor_model_parallel_rank from both possible locations
+  diagnosis: 'The source issues converge on the same family: MindFormers dev-branch
+    refactors moved or removed `mindformers.experimental.*` APIs, but downstream projects
+    still import the old paths. In some cases the API still exists and only the import
+    path changed; in other cases helpers such as experimental parallel-core utilities
+    or `ReduceScatterToSequenceParallelRegion` were removed from dev and must be carried
+    or reimplemented downstream.'
+  diagnosis_details:
+  - 仍保留在 dev 分支里的接口需要改到新 import 路径
+  - dev 分支已经删除的 helper 不能继续从 mindformers.experimental 引用，需要在下游仓继承或重实现
+  - 这类报错不是通用环境问题，而是下游代码仍绑定旧 API 面
+  actions:
+  - 对仍保留在 MindFormers dev 分支里的接口，改到新的 import 路径。
+  - 对 dev 已删除的 helper，在下游仓继承、补定义或重实现兼容层。
+  - 同步更新依赖这些 helper 的调用点，而不是只修单个 import 语句。
+  - 回归盘古推理、Golden Stick 深度量化、MindRLHF 并行场景，确认 import 阶段不再失败。
+  fix: 把保留接口切到新的 MindFormers import 路径，并对 dev 已删除的 experimental helper 在下游仓补齐兼容实现。
+  why_it_works:
+  - 仍存在的 API 走到正确新路径后，模块解析会重新命中当前 MindFormers dev API 面。
+  - 对已删除 helper 做下游继承或补定义后，运行不再依赖 `mindformers.experimental` 的历史实现。
+  verification: After the fix, downstream inference, quantization, and parallel tasks
+    no longer fail during module import when running against the refactored MindFormers
+    dev branch.
+  non_causes:
+  - 不是单纯 PYTHONPATH 没配好
+  - 不是随机安装缺包，而是 API 路径迁移后的兼容性断裂
+provenance:
+  references:
+  - issue:mindformers#2220
+  - issue:org-issues#ICK1SO
+  - issue:org-issues#ICK2HD
+  - issue:org-issues#ICKL7B
+  - issue:org-issues#ICLEY2
+  notes: Rewritten from mindformers#2220 plus org-issues ICK1SO / ICK2HD / ICKL7B
+    / ICLEY2 source details and root-cause notes. These source issues all describe
+    downstream breakage after MindFormers dev-branch API moves or removals under `mindformers.experimental`.
+  expected_behavior:
+  - 下游项目在 import 阶段不再抛出 ModuleNotFoundError 或 ImportError
+  - 推理、量化和并行相关任务能够继续进入后续执行阶段
+governance:
+  confidence: verified
+  lifecycle: stable
+  review_status: pending
+  rationale: rewritten from multiple source issues and root-cause notes on 2026-05-12
+  updated_at: '2026-05-12'

--- a/incubating/factory/manifests/pack.yaml
+++ b/incubating/factory/manifests/pack.yaml
@@ -3,7 +3,7 @@ channel: stable
 created_at: "2026-03-19"
 card_count:
   operators: 6
-  known_issues: 3
+  known_issues: 14
   perf_features: 9
   algo_features: 9
   models: 1
@@ -17,6 +17,17 @@ cards:
   - { id: dsa-torch27-ascend, kind: known_issue, path: known_issues/dsa-torch27-ascend.yaml }
   - { id: fp16-softmax-drift, kind: known_issue, path: known_issues/fp16-softmax-drift.yaml }
   - { id: cann-flash-attn-version, kind: known_issue, path: known_issues/cann-flash-attn-version.yaml }
+  - { id: accuracy-compile-fusion-controlflow-drift, kind: known_issue, path: known_issues/accuracy-compile-fusion-controlflow-drift.yaml }
+  - { id: accuracy-lite-int8-conv1x1-input-pack-batch-missing, kind: known_issue, path: known_issues/accuracy-lite-int8-conv1x1-input-pack-batch-missing.yaml }
+  - { id: accuracy-model-diffusers-scheduler-regression, kind: known_issue, path: known_issues/accuracy-model-diffusers-scheduler-regression.yaml }
+  - { id: accuracy-model-qwen3vl-resize-interpolate-mismatch, kind: known_issue, path: known_issues/accuracy-model-qwen3vl-resize-interpolate-mismatch.yaml }
+  - { id: accuracy-operator-atan-precision-drift, kind: known_issue, path: known_issues/accuracy-operator-atan-precision-drift.yaml }
+  - { id: accuracy-operator-atan2-precision-drift, kind: known_issue, path: known_issues/accuracy-operator-atan2-precision-drift.yaml }
+  - { id: accuracy-operator-baddbmm-dtype-drift, kind: known_issue, path: known_issues/accuracy-operator-baddbmm-dtype-drift.yaml }
+  - { id: accuracy-operator-baddbmm-precision-drift, kind: known_issue, path: known_issues/accuracy-operator-baddbmm-precision-drift.yaml }
+  - { id: accuracy-operator-clamp-precision-drift, kind: known_issue, path: known_issues/accuracy-operator-clamp-precision-drift.yaml }
+  - { id: accuracy-operator-cos-precision-drift, kind: known_issue, path: known_issues/accuracy-operator-cos-precision-drift.yaml }
+  - { id: function-runtime-module-import-missing, kind: known_issue, path: known_issues/function-runtime-module-import-missing.yaml }
   - { id: fused-adam, kind: perf_feature, path: perf_features/fused-adam.yaml }
   - { id: flash-attn-v2, kind: perf_feature, path: perf_features/flash-attn-v2.yaml }
   - { id: gradient-ckpt, kind: perf_feature, path: perf_features/gradient-ckpt.yaml }


### PR DESCRIPTION
 ## 背景

  补充了一批基于 issue 原文和根因评论整理的 known issue 卡，并统一到 `known_issue/v0.6` 结构。

  ## 本次修改

  - 在 `incubating/factory/cards/known_issues/` 新增 11 张 known issue 卡
  - 将 `accuracy-compile-fusion-controlflow-drift` 整理为正式卡并接入 pack
  - 更新 `incubating/factory/manifests/pack.yaml`
  - 将 `known_issues` 数量从 `3` 更新为 `14`

  新增卡片如下：

  - `accuracy-compile-fusion-controlflow-drift`
  - `accuracy-lite-int8-conv1x1-input-pack-batch-missing`
  - `accuracy-model-diffusers-scheduler-regression`
  - `accuracy-model-qwen3vl-resize-interpolate-mismatch`
  - `accuracy-operator-atan-precision-drift`
  - `accuracy-operator-atan2-precision-drift`
  - `accuracy-operator-baddbmm-dtype-drift`
  - `accuracy-operator-baddbmm-precision-drift`
  - `accuracy-operator-clamp-precision-drift`
  - `accuracy-operator-cos-precision-drift`
  - `function-runtime-module-import-missing`

  ## 整理原则

  - 卡片结构统一到 `known_issue/v0.6`
  - `provenance / diagnosis / actions / fix / why_it_works` 以 issue 原文和根因评论为主要依据
  - 尽量区分“真实算子/框架问题”和“benchmark/reference 污染、环境兼容性、下游 import 断裂”等问题类
  型，避免泛化描述

  ## 影响范围

  - 仅涉及 factory 卡片与 manifest
  - 不涉及运行时代码、算子实现或测试逻辑修改

  ## 验证

  - YAML 解析校验通过
  - `pack.yaml` 已能正确枚举新增 known issue 卡